### PR TITLE
Fix the runApp() usage during `jaspr create my_web_app`

### DIFF
--- a/packages/jaspr/bin/jaspr.dart
+++ b/packages/jaspr/bin/jaspr.dart
@@ -328,7 +328,7 @@ String mainFileContent(package) => ""
     "import '$package/app.dart';\n"
     "\n"
     "void main() {\n"
-    "  runApp(() => App(), id: 'output');\n"
+    "  runApp(App());\n"
     "}";
 String appFileContent() => ""
     "import 'package:jaspr/jaspr.dart';\n"


### PR DESCRIPTION
Creating a new `jaspr` web app with the pub executable creates an application with initial errors.

The following line does not properly build or compile.

```dart
runApp(() => App(), id: 'output');
```

But works properly when changed to 

```dart
runApp(App());
```

P.S. Thank you for making this package.