### PR TITLE
Fixed domino dependency to 0.8.2

### DIFF
--- a/packages/jaspr/pubspec.yaml
+++ b/packages/jaspr/pubspec.yaml
@@ -13,7 +13,7 @@ executables:
 dependencies:
   args: ^2.3.0
   binary_codec: ^2.0.3
-  domino: ^0.8.1
+  domino: ^0.8.2
   hotreloader: ^3.0.4
   html: ^0.15.0
   http: ^0.13.4


### PR DESCRIPTION
The jaspr code requires the close method to return a value which was brought in on domino 0.8.2 so builds currently fail.

See: https://pub.dev/packages/domino/changelog

@schultek let me know if you need anything else.