### PR TITLE
Add html components for common elements

### DIFF
--- a/packages/jaspr/lib/html.dart
+++ b/packages/jaspr/lib/html.dart
@@ -1,0 +1,4 @@
+export 'src/html/content.dart';
+export 'src/html/forms.dart';
+export 'src/html/media.dart';
+export 'src/html/text.dart';

--- a/packages/jaspr/lib/html.dart
+++ b/packages/jaspr/lib/html.dart
@@ -1,4 +1,9 @@
-export 'src/html/content.dart';
-export 'src/html/forms.dart';
-export 'src/html/media.dart';
-export 'src/html/text.dart';
+library jaspr_html;
+
+import 'src/framework/framework.dart';
+
+part 'src/html/content.dart';
+part 'src/html/forms.dart';
+part 'src/html/media.dart';
+part 'src/html/other.dart';
+part 'src/html/text.dart';

--- a/packages/jaspr/lib/html.dart
+++ b/packages/jaspr/lib/html.dart
@@ -7,3 +7,8 @@ part 'src/html/forms.dart';
 part 'src/html/media.dart';
 part 'src/html/other.dart';
 part 'src/html/text.dart';
+
+/// Utility method to create a text component when using jaspr html methods
+Component text(String text, {bool rawHtml = false}) {
+  return Text(text, rawHtml: rawHtml);
+}

--- a/packages/jaspr/lib/src/html/content.dart
+++ b/packages/jaspr/lib/src/html/content.dart
@@ -1,7 +1,7 @@
 part of jaspr_html;
 
 /// The &lt;article&gt; HTML element represents a self-contained composition in a document, page, application, or site, which is intended to be independently distributable or reusable (e.g., in syndication). Examples include: a forum post, a magazine or newspaper article, or a blog entry, a product card, a user-submitted comment, an interactive widget or gadget, or any other independent item of content.
-Component article({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+Component article(List<Component> children, {Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events}) {
   return DomComponent(
     tag: 'article',
     key: key,
@@ -10,13 +10,12 @@ Component article({Key? key, String? id, Iterable<String>? classes, Map<String, 
     styles: styles,
     attributes: attributes,
     events: events,
-    child: child,
     children: children,
   );
 }
 
 /// The &lt;aside&gt; HTML element represents a portion of a document whose content is only indirectly related to the document's main content. Asides are frequently presented as sidebars or call-out boxes.
-Component aside({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+Component aside(List<Component> children, {Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events}) {
   return DomComponent(
     tag: 'aside',
     key: key,
@@ -25,13 +24,12 @@ Component aside({Key? key, String? id, Iterable<String>? classes, Map<String, St
     styles: styles,
     attributes: attributes,
     events: events,
-    child: child,
     children: children,
   );
 }
 
 /// The &lt;footer&gt; HTML element represents a footer for its nearest ancestor sectioning content or sectioning root element. A &lt;footer&gt; typically contains information about the author of the section, copyright data or links to related documents.
-Component footer({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+Component footer(List<Component> children, {Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events}) {
   return DomComponent(
     tag: 'footer',
     key: key,
@@ -40,13 +38,12 @@ Component footer({Key? key, String? id, Iterable<String>? classes, Map<String, S
     styles: styles,
     attributes: attributes,
     events: events,
-    child: child,
     children: children,
   );
 }
 
 /// The &lt;header&gt; HTML element represents introductory content, typically a group of introductory or navigational aids. It may contain some heading elements but also a logo, a search form, an author name, and other elements.
-Component header({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+Component header(List<Component> children, {Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events}) {
   return DomComponent(
     tag: 'header',
     key: key,
@@ -55,13 +52,12 @@ Component header({Key? key, String? id, Iterable<String>? classes, Map<String, S
     styles: styles,
     attributes: attributes,
     events: events,
-    child: child,
     children: children,
   );
 }
 
 /// The &lt;h1&gt; to &lt;h6&gt; HTML elements represent six levels of section headings. &lt;h1&gt; is the highest section level and &lt;h6&gt; is the lowest.
-Component h1({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+Component h1(List<Component> children, {Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events}) {
   return DomComponent(
     tag: 'h1',
     key: key,
@@ -70,13 +66,12 @@ Component h1({Key? key, String? id, Iterable<String>? classes, Map<String, Strin
     styles: styles,
     attributes: attributes,
     events: events,
-    child: child,
     children: children,
   );
 }
 
 /// The &lt;h1&gt; to &lt;h6&gt; HTML elements represent six levels of section headings. &lt;h1&gt; is the highest section level and &lt;h6&gt; is the lowest.
-Component h2({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+Component h2(List<Component> children, {Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events}) {
   return DomComponent(
     tag: 'h2',
     key: key,
@@ -85,13 +80,12 @@ Component h2({Key? key, String? id, Iterable<String>? classes, Map<String, Strin
     styles: styles,
     attributes: attributes,
     events: events,
-    child: child,
     children: children,
   );
 }
 
 /// The &lt;h1&gt; to &lt;h6&gt; HTML elements represent six levels of section headings. &lt;h1&gt; is the highest section level and &lt;h6&gt; is the lowest.
-Component h3({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+Component h3(List<Component> children, {Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events}) {
   return DomComponent(
     tag: 'h3',
     key: key,
@@ -100,13 +94,12 @@ Component h3({Key? key, String? id, Iterable<String>? classes, Map<String, Strin
     styles: styles,
     attributes: attributes,
     events: events,
-    child: child,
     children: children,
   );
 }
 
 /// The &lt;h1&gt; to &lt;h6&gt; HTML elements represent six levels of section headings. &lt;h1&gt; is the highest section level and &lt;h6&gt; is the lowest.
-Component h4({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+Component h4(List<Component> children, {Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events}) {
   return DomComponent(
     tag: 'h4',
     key: key,
@@ -115,13 +108,12 @@ Component h4({Key? key, String? id, Iterable<String>? classes, Map<String, Strin
     styles: styles,
     attributes: attributes,
     events: events,
-    child: child,
     children: children,
   );
 }
 
 /// The &lt;h1&gt; to &lt;h6&gt; HTML elements represent six levels of section headings. &lt;h1&gt; is the highest section level and &lt;h6&gt; is the lowest.
-Component h5({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+Component h5(List<Component> children, {Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events}) {
   return DomComponent(
     tag: 'h5',
     key: key,
@@ -130,13 +122,12 @@ Component h5({Key? key, String? id, Iterable<String>? classes, Map<String, Strin
     styles: styles,
     attributes: attributes,
     events: events,
-    child: child,
     children: children,
   );
 }
 
 /// The &lt;h1&gt; to &lt;h6&gt; HTML elements represent six levels of section headings. &lt;h1&gt; is the highest section level and &lt;h6&gt; is the lowest.
-Component h6({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+Component h6(List<Component> children, {Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events}) {
   return DomComponent(
     tag: 'h6',
     key: key,
@@ -145,28 +136,12 @@ Component h6({Key? key, String? id, Iterable<String>? classes, Map<String, Strin
     styles: styles,
     attributes: attributes,
     events: events,
-    child: child,
-    children: children,
-  );
-}
-
-/// The &lt;main&gt; HTML element represents the dominant content of the &lt;body&gt; of a document. The main content area consists of content that is directly related to or expands upon the central topic of a document, or the central functionality of an application.
-Component main({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
-  return DomComponent(
-    tag: 'main',
-    key: key,
-    id: id,
-    classes: classes,
-    styles: styles,
-    attributes: attributes,
-    events: events,
-    child: child,
     children: children,
   );
 }
 
 /// The &lt;nav&gt; HTML element represents a section of a page whose purpose is to provide navigation links, either within the current document or to other documents. Common examples of navigation sections are menus, tables of contents, and indexes.
-Component nav({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+Component nav(List<Component> children, {Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events}) {
   return DomComponent(
     tag: 'nav',
     key: key,
@@ -175,13 +150,12 @@ Component nav({Key? key, String? id, Iterable<String>? classes, Map<String, Stri
     styles: styles,
     attributes: attributes,
     events: events,
-    child: child,
     children: children,
   );
 }
 
 /// The &lt;section&gt; HTML element represents a generic standalone section of a document, which doesn't have a more specific semantic element to represent it. Sections should always have a heading, with very few exceptions.
-Component section({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+Component section(List<Component> children, {Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events}) {
   return DomComponent(
     tag: 'section',
     key: key,
@@ -190,7 +164,6 @@ Component section({Key? key, String? id, Iterable<String>? classes, Map<String, 
     styles: styles,
     attributes: attributes,
     events: events,
-    child: child,
     children: children,
   );
 }
@@ -198,7 +171,7 @@ Component section({Key? key, String? id, Iterable<String>? classes, Map<String, 
 /// The &lt;blockquote&gt; HTML element indicates that the enclosed text is an extended quotation. Usually, this is rendered visually by indentation. A URL for the source of the quotation may be given using the cite attribute, while a text representation of the source can be given using the &lt;cite&gt; element.
 ///
 /// - [cite]: A URL that designates a source document or message for the information quoted. This attribute is intended to point to information explaining the context or the reference for the quote.
-Component blockquote({String? cite, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+Component blockquote(List<Component> children, {String? cite, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events}) {
   return DomComponent(
     tag: 'blockquote',
     key: key,
@@ -210,13 +183,12 @@ Component blockquote({String? cite, Key? key, String? id, Iterable<String>? clas
       if (cite != null) 'cite': cite,
     },
     events: events,
-    child: child,
     children: children,
   );
 }
 
 /// The &lt;div&gt; HTML element is the generic container for flow content. It has no effect on the content or layout until styled in some way using CSS (e.g. styling is directly applied to it, or some kind of layout model like Flexbox is applied to its parent element).
-Component div({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+Component div(List<Component> children, {Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events}) {
   return DomComponent(
     tag: 'div',
     key: key,
@@ -225,13 +197,12 @@ Component div({Key? key, String? id, Iterable<String>? classes, Map<String, Stri
     styles: styles,
     attributes: attributes,
     events: events,
-    child: child,
     children: children,
   );
 }
 
 /// The &lt;ul&gt; HTML element represents an unordered list of items, typically rendered as a bulleted list.
-Component ul({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+Component ul(List<Component> children, {Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events}) {
   return DomComponent(
     tag: 'ul',
     key: key,
@@ -240,7 +211,6 @@ Component ul({Key? key, String? id, Iterable<String>? classes, Map<String, Strin
     styles: styles,
     attributes: attributes,
     events: events,
-    child: child,
     children: children,
   );
 }
@@ -251,7 +221,7 @@ Component ul({Key? key, String? id, Iterable<String>? classes, Map<String, Strin
 /// - [start]: An integer to start counting from for the list items. Always an Arabic numeral (1, 2, 3, etc.), even when the numbering type is letters or Roman numerals. For example, to start numbering elements from the letter "d" or the Roman numeral "iv," use start="4".
 /// - [type]: Sets the numbering type
 ///   The specified type is used for the entire list unless a different type attribute is used on an enclosed &lt;li&gt; element.
-Component ol({bool? reversed, int? start, ListType? type, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+Component ol(List<Component> children, {bool? reversed, int? start, ListType? type, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events}) {
   return DomComponent(
     tag: 'ol',
     key: key,
@@ -265,7 +235,6 @@ Component ol({bool? reversed, int? start, ListType? type, Key? key, String? id, 
       if (type != null) 'type': type.value,
     },
     events: events,
-    child: child,
     children: children,
   );
 }
@@ -290,7 +259,7 @@ enum ListType {
 /// The &lt;li&gt; HTML element is used to represent an item in a list. It must be contained in a parent element: an ordered list (&lt;ol&gt;), an unordered list (&lt;ul&gt;), or a menu (&lt;menu&gt;). In menus and unordered lists, list items are usually displayed using bullet points. In ordered lists, they are usually displayed with an ascending counter on the left, such as a number or letter.
 ///
 /// - [value]: This integer attribute indicates the current ordinal value of the list item as defined by the &lt;ol&gt; element. The only allowed value for this attribute is a number, even if the list is displayed with Roman numerals or letters. List items that follow this one continue numbering from the value set. The value attribute has no meaning for unordered lists (&lt;ul&gt;) or for menus (&lt;menu&gt;).
-Component li({int? value, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+Component li(List<Component> children, {int? value, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events}) {
   return DomComponent(
     tag: 'li',
     key: key,
@@ -302,13 +271,12 @@ Component li({int? value, Key? key, String? id, Iterable<String>? classes, Map<S
       if (value != null) 'value': '$value',
     },
     events: events,
-    child: child,
     children: children,
   );
 }
 
 /// The &lt;hr&gt; HTML element represents a thematic break between paragraph-level elements: for example, a change of scene in a story, or a shift of topic within a section.
-Component hr({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+Component hr({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events}) {
   return DomComponent(
     tag: 'hr',
     key: key,
@@ -317,13 +285,11 @@ Component hr({Key? key, String? id, Iterable<String>? classes, Map<String, Strin
     styles: styles,
     attributes: attributes,
     events: events,
-    child: child,
-    children: children,
   );
 }
 
 /// The &lt;p&gt; HTML element represents a paragraph. Paragraphs are usually represented in visual media as blocks of text separated from adjacent blocks by blank lines and/or first-line indentation, but HTML paragraphs can be any structural grouping of related content, such as images or form fields.
-Component p({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+Component p(List<Component> children, {Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events}) {
   return DomComponent(
     tag: 'p',
     key: key,
@@ -332,13 +298,12 @@ Component p({Key? key, String? id, Iterable<String>? classes, Map<String, String
     styles: styles,
     attributes: attributes,
     events: events,
-    child: child,
     children: children,
   );
 }
 
 /// The &lt;pre&gt; HTML element represents preformatted text which is to be presented exactly as written in the HTML file. The text is typically rendered using a non-proportional, or monospaced, font. Whitespace inside this element is displayed as written.
-Component pre({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+Component pre(List<Component> children, {Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events}) {
   return DomComponent(
     tag: 'pre',
     key: key,
@@ -347,7 +312,6 @@ Component pre({Key? key, String? id, Iterable<String>? classes, Map<String, Stri
     styles: styles,
     attributes: attributes,
     events: events,
-    child: child,
     children: children,
   );
 }

--- a/packages/jaspr/lib/src/html/content.dart
+++ b/packages/jaspr/lib/src/html/content.dart
@@ -1,0 +1,320 @@
+import '../../jaspr.dart';
+
+/// The &lt;article&gt; HTML element represents a self-contained composition in a document, page, application, or site, which is intended to be independently distributable or reusable (e.g., in syndication). Examples include: a forum post, a magazine or newspaper article, or a blog entry, a product card, a user-submitted comment, an interactive widget or gadget, or any other independent item of content.
+Component article({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+  return DomComponent(
+    tag: 'article',
+    key: key,
+    id: id,
+    classes: classes,
+    styles: styles,
+    attributes: attributes,
+    events: events,
+    child: child,
+    children: children,
+  );
+}
+
+/// The &lt;aside&gt; HTML element represents a portion of a document whose content is only indirectly related to the document's main content. Asides are frequently presented as sidebars or call-out boxes.
+Component aside({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+  return DomComponent(
+    tag: 'aside',
+    key: key,
+    id: id,
+    classes: classes,
+    styles: styles,
+    attributes: attributes,
+    events: events,
+    child: child,
+    children: children,
+  );
+}
+
+/// The &lt;footer&gt; HTML element represents a footer for its nearest ancestor sectioning content or sectioning root element. A &lt;footer&gt; typically contains information about the author of the section, copyright data or links to related documents.
+Component footer({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+  return DomComponent(
+    tag: 'footer',
+    key: key,
+    id: id,
+    classes: classes,
+    styles: styles,
+    attributes: attributes,
+    events: events,
+    child: child,
+    children: children,
+  );
+}
+
+/// The &lt;header&gt; HTML element represents introductory content, typically a group of introductory or navigational aids. It may contain some heading elements but also a logo, a search form, an author name, and other elements.
+Component header({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+  return DomComponent(
+    tag: 'header',
+    key: key,
+    id: id,
+    classes: classes,
+    styles: styles,
+    attributes: attributes,
+    events: events,
+    child: child,
+    children: children,
+  );
+}
+
+/// The &lt;h1&gt; to &lt;h6&gt; HTML elements represent six levels of section headings. &lt;h1&gt; is the highest section level and &lt;h6&gt; is the lowest.
+Component h1({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+  return DomComponent(
+    tag: 'h1',
+    key: key,
+    id: id,
+    classes: classes,
+    styles: styles,
+    attributes: attributes,
+    events: events,
+    child: child,
+    children: children,
+  );
+}
+
+/// The &lt;h1&gt; to &lt;h6&gt; HTML elements represent six levels of section headings. &lt;h1&gt; is the highest section level and &lt;h6&gt; is the lowest.
+Component h2({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+  return DomComponent(
+    tag: 'h2',
+    key: key,
+    id: id,
+    classes: classes,
+    styles: styles,
+    attributes: attributes,
+    events: events,
+    child: child,
+    children: children,
+  );
+}
+
+/// The &lt;h1&gt; to &lt;h6&gt; HTML elements represent six levels of section headings. &lt;h1&gt; is the highest section level and &lt;h6&gt; is the lowest.
+Component h3({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+  return DomComponent(
+    tag: 'h3',
+    key: key,
+    id: id,
+    classes: classes,
+    styles: styles,
+    attributes: attributes,
+    events: events,
+    child: child,
+    children: children,
+  );
+}
+
+/// The &lt;h1&gt; to &lt;h6&gt; HTML elements represent six levels of section headings. &lt;h1&gt; is the highest section level and &lt;h6&gt; is the lowest.
+Component h4({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+  return DomComponent(
+    tag: 'h4',
+    key: key,
+    id: id,
+    classes: classes,
+    styles: styles,
+    attributes: attributes,
+    events: events,
+    child: child,
+    children: children,
+  );
+}
+
+/// The &lt;h1&gt; to &lt;h6&gt; HTML elements represent six levels of section headings. &lt;h1&gt; is the highest section level and &lt;h6&gt; is the lowest.
+Component h5({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+  return DomComponent(
+    tag: 'h5',
+    key: key,
+    id: id,
+    classes: classes,
+    styles: styles,
+    attributes: attributes,
+    events: events,
+    child: child,
+    children: children,
+  );
+}
+
+/// The &lt;h1&gt; to &lt;h6&gt; HTML elements represent six levels of section headings. &lt;h1&gt; is the highest section level and &lt;h6&gt; is the lowest.
+Component h6({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+  return DomComponent(
+    tag: 'h6',
+    key: key,
+    id: id,
+    classes: classes,
+    styles: styles,
+    attributes: attributes,
+    events: events,
+    child: child,
+    children: children,
+  );
+}
+
+/// The &lt;main&gt; HTML element represents the dominant content of the &lt;body&gt; of a document. The main content area consists of content that is directly related to or expands upon the central topic of a document, or the central functionality of an application.
+Component main({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+  return DomComponent(
+    tag: 'main',
+    key: key,
+    id: id,
+    classes: classes,
+    styles: styles,
+    attributes: attributes,
+    events: events,
+    child: child,
+    children: children,
+  );
+}
+
+/// The &lt;nav&gt; HTML element represents a section of a page whose purpose is to provide navigation links, either within the current document or to other documents. Common examples of navigation sections are menus, tables of contents, and indexes.
+Component nav({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+  return DomComponent(
+    tag: 'nav',
+    key: key,
+    id: id,
+    classes: classes,
+    styles: styles,
+    attributes: attributes,
+    events: events,
+    child: child,
+    children: children,
+  );
+}
+
+/// The &lt;section&gt; HTML element represents a generic standalone section of a document, which doesn't have a more specific semantic element to represent it. Sections should always have a heading, with very few exceptions.
+Component section({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+  return DomComponent(
+    tag: 'section',
+    key: key,
+    id: id,
+    classes: classes,
+    styles: styles,
+    attributes: attributes,
+    events: events,
+    child: child,
+    children: children,
+  );
+}
+
+/// The &lt;div&gt; HTML element is the generic container for flow content. It has no effect on the content or layout until styled in some way using CSS (e.g. styling is directly applied to it, or some kind of layout model like Flexbox is applied to its parent element).
+Component div({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+  return DomComponent(
+    tag: 'div',
+    key: key,
+    id: id,
+    classes: classes,
+    styles: styles,
+    attributes: attributes,
+    events: events,
+    child: child,
+    children: children,
+  );
+}
+
+/// The &lt;ul&gt; HTML element represents an unordered list of items, typically rendered as a bulleted list.
+Component ul({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+  return DomComponent(
+    tag: 'ul',
+    key: key,
+    id: id,
+    classes: classes,
+    styles: styles,
+    attributes: attributes,
+    events: events,
+    child: child,
+    children: children,
+  );
+}
+
+/// The &lt;ol&gt; HTML element represents an ordered list of items — typically rendered as a numbered list.
+///
+/// - [reversed]: This Boolean attribute specifies that the list's items are in reverse order. Items will be numbered from high to low.
+/// - [start]: An integer to start counting from for the list items. Always an Arabic numeral (1, 2, 3, etc.), even when the numbering type is letters or Roman numerals. For example, to start numbering elements from the letter "d" or the Roman numeral "iv," use start="4".
+/// - [type]: Sets the numbering type
+///   The specified type is used for the entire list unless a different type attribute is used on an enclosed &lt;li&gt; element.
+Component ol({bool? reversed, int? start, ListType? type, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+  return DomComponent(
+    tag: 'ol',
+    key: key,
+    id: id,
+    classes: classes,
+    styles: styles,
+    attributes: {
+      ...attributes ?? {},
+      if (reversed == true) 'reversed': '',
+      if (start != null) 'start': '$start',
+      if (type != null) 'type': type.value,
+    },
+    events: events,
+    child: child,
+    children: children,
+  );
+}
+
+enum ListType {
+  lowercaseLetters('a'), uppercaseLetters('A'), lowercaseRomanNumerals('i'), uppercaseRomanNumerals('I'), numbers('1')
+}
+
+/// The &lt;li&gt; HTML element is used to represent an item in a list. It must be contained in a parent element: an ordered list (&lt;ol&gt;), an unordered list (&lt;ul&gt;), or a menu (&lt;menu&gt;). In menus and unordered lists, list items are usually displayed using bullet points. In ordered lists, they are usually displayed with an ascending counter on the left, such as a number or letter.
+///
+/// - [value]: This integer attribute indicates the current ordinal value of the list item as defined by the &lt;ol&gt; element. The only allowed value for this attribute is a number, even if the list is displayed with Roman numerals or letters. List items that follow this one continue numbering from the value set. The value attribute has no meaning for unordered lists (&lt;ul&gt;) or for menus (&lt;menu&gt;).
+Component li({int? value, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+  return DomComponent(
+    tag: 'li',
+    key: key,
+    id: id,
+    classes: classes,
+    styles: styles,
+    attributes: {
+      ...attributes ?? {},
+      if (value != null) 'value': '$value',
+    },
+    events: events,
+    child: child,
+    children: children,
+  );
+}
+
+/// The &lt;hr&gt; HTML element represents a thematic break between paragraph-level elements: for example, a change of scene in a story, or a shift of topic within a section.
+Component hr({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+  return DomComponent(
+    tag: 'hr',
+    key: key,
+    id: id,
+    classes: classes,
+    styles: styles,
+    attributes: attributes,
+    events: events,
+    child: child,
+    children: children,
+  );
+}
+
+/// The &lt;p&gt; HTML element represents a paragraph. Paragraphs are usually represented in visual media as blocks of text separated from adjacent blocks by blank lines and/or first-line indentation, but HTML paragraphs can be any structural grouping of related content, such as images or form fields.
+Component p({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+  return DomComponent(
+    tag: 'p',
+    key: key,
+    id: id,
+    classes: classes,
+    styles: styles,
+    attributes: attributes,
+    events: events,
+    child: child,
+    children: children,
+  );
+}
+
+/// The &lt;pre&gt; HTML element represents preformatted text which is to be presented exactly as written in the HTML file. The text is typically rendered using a non-proportional, or monospaced, font. Whitespace inside this element is displayed as written.
+Component pre({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+  return DomComponent(
+    tag: 'pre',
+    key: key,
+    id: id,
+    classes: classes,
+    styles: styles,
+    attributes: attributes,
+    events: events,
+    child: child,
+    children: children,
+  );
+}

--- a/packages/jaspr/lib/src/html/content.dart
+++ b/packages/jaspr/lib/src/html/content.dart
@@ -1,4 +1,4 @@
-import '../../jaspr.dart';
+part of jaspr_html;
 
 /// The &lt;article&gt; HTML element represents a self-contained composition in a document, page, application, or site, which is intended to be independently distributable or reusable (e.g., in syndication). Examples include: a forum post, a magazine or newspaper article, or a blog entry, a product card, a user-submitted comment, an interactive widget or gadget, or any other independent item of content.
 Component article({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
@@ -195,6 +195,26 @@ Component section({Key? key, String? id, Iterable<String>? classes, Map<String, 
   );
 }
 
+/// The &lt;blockquote&gt; HTML element indicates that the enclosed text is an extended quotation. Usually, this is rendered visually by indentation. A URL for the source of the quotation may be given using the cite attribute, while a text representation of the source can be given using the &lt;cite&gt; element.
+///
+/// - [cite]: A URL that designates a source document or message for the information quoted. This attribute is intended to point to information explaining the context or the reference for the quote.
+Component blockquote({String? cite, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+  return DomComponent(
+    tag: 'blockquote',
+    key: key,
+    id: id,
+    classes: classes,
+    styles: styles,
+    attributes: {
+      ...attributes ?? {},
+      if (cite != null) 'cite': cite,
+    },
+    events: events,
+    child: child,
+    children: children,
+  );
+}
+
 /// The &lt;div&gt; HTML element is the generic container for flow content. It has no effect on the content or layout until styled in some way using CSS (e.g. styling is directly applied to it, or some kind of layout model like Flexbox is applied to its parent element).
 Component div({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
   return DomComponent(
@@ -249,7 +269,6 @@ Component ol({bool? reversed, int? start, ListType? type, Key? key, String? id, 
     children: children,
   );
 }
-
 
 /// Them numbering type for a list element.
 enum ListType {

--- a/packages/jaspr/lib/src/html/content.dart
+++ b/packages/jaspr/lib/src/html/content.dart
@@ -250,8 +250,22 @@ Component ol({bool? reversed, int? start, ListType? type, Key? key, String? id, 
   );
 }
 
+
+/// Them numbering type for a list element.
 enum ListType {
-  lowercaseLetters('a'), uppercaseLetters('A'), lowercaseRomanNumerals('i'), uppercaseRomanNumerals('I'), numbers('1')
+  /// For lowercase letters
+  lowercaseLetters('a'),
+  /// For uppercase letters
+  uppercaseLetters('A'),
+  /// For lowercase Roman numerals
+  lowercaseRomanNumerals('i'),
+  /// For uppercase Roman numerals
+  uppercaseRomanNumerals('I'),
+  /// For numbers (default)
+  numbers('1');
+
+  final String value;
+  const ListType(this.value);
 }
 
 /// The &lt;li&gt; HTML element is used to represent an item in a list. It must be contained in a parent element: an ordered list (&lt;ol&gt;), an unordered list (&lt;ul&gt;), or a menu (&lt;menu&gt;). In menus and unordered lists, list items are usually displayed using bullet points. In ordered lists, they are usually displayed with an ascending counter on the left, such as a number or letter.

--- a/packages/jaspr/lib/src/html/forms.dart
+++ b/packages/jaspr/lib/src/html/forms.dart
@@ -24,6 +24,16 @@ Component button({bool? autofocus, bool? disabled, ButtonType? type, Key? key, S
   );
 }
 
+
+/// Defines the default behavior of a button.
 enum ButtonType {
-  submit('submit'), reset('reset'), button('button')
+  /// The button submits the form data to the server. This is the default if the attribute is not specified for buttons associated with a &lt;form&gt;, or if the attribute is an empty or invalid value.
+  submit('submit'),
+  /// The button resets all the controls to their initial values, like &lt;input type="reset"&gt;. (This behavior tends to annoy users.)
+  reset('reset'),
+  /// The button has no default behavior, and does nothing when pressed by default. It can have client-side scripts listen to the element's events, which are triggered when the events occur.
+  button('button');
+
+  final String value;
+  const ButtonType(this.value);
 }

--- a/packages/jaspr/lib/src/html/forms.dart
+++ b/packages/jaspr/lib/src/html/forms.dart
@@ -1,0 +1,29 @@
+import '../../jaspr.dart';
+
+/// The &lt;button&gt; HTML element is an interactive element activated by a user with a mouse, keyboard, finger, voice command, or other assistive technology. Once activated, it then performs a programmable action, such as submitting a form or opening a dialog.
+///
+/// - [autofocus]: Specifies that the button should have input focus when the page loads. Only one element in a document can have this attribute.
+/// - [disabled]: Prevents the user from interacting with the button: it cannot be pressed or focused.
+/// - [type]: The default behavior of the button.
+Component button({bool? autofocus, bool? disabled, ButtonType? type, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+  return DomComponent(
+    tag: 'button',
+    key: key,
+    id: id,
+    classes: classes,
+    styles: styles,
+    attributes: {
+      ...attributes ?? {},
+      if (autofocus == true) 'autofocus': '',
+      if (disabled == true) 'disabled': '',
+      if (type != null) 'type': type.value,
+    },
+    events: events,
+    child: child,
+    children: children,
+  );
+}
+
+enum ButtonType {
+  submit('submit'), reset('reset'), button('button')
+}

--- a/packages/jaspr/lib/src/html/forms.dart
+++ b/packages/jaspr/lib/src/html/forms.dart
@@ -5,7 +5,7 @@ part of jaspr_html;
 /// - [autofocus]: Specifies that the button should have input focus when the page loads. Only one element in a document can have this attribute.
 /// - [disabled]: Prevents the user from interacting with the button: it cannot be pressed or focused.
 /// - [type]: The default behavior of the button.
-Component button({bool? autofocus, bool? disabled, ButtonType? type, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+Component button(List<Component> children, {bool? autofocus, bool? disabled, ButtonType? type, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events}) {
   return DomComponent(
     tag: 'button',
     key: key,
@@ -19,7 +19,6 @@ Component button({bool? autofocus, bool? disabled, ButtonType? type, Key? key, S
       if (type != null) 'type': type.value,
     },
     events: events,
-    child: child,
     children: children,
   );
 }
@@ -48,7 +47,7 @@ enum ButtonType {
 /// - [name]: The name of the form. The value must not be the empty string, and must be unique among the form elements in the forms collection that it is in, if any.
 /// - [noValidate]: Indicates that the form shouldn't be validated when submitted. If this attribute is not set (and therefore the form is validated), it can be overridden by a formnovalidate attribute on a &lt;button&gt;, &lt;input type="submit"&gt;, or &lt;input type="image"&gt; element belonging to the form.
 /// - [target]: Indicates where to display the response after submitting the form. In HTML 4, this is the name/keyword for a frame. In HTML5, it is a name/keyword for a browsing context (for example, tab, window, or iframe).
-Component form({String? action, FormMethod? method, FormEncType? encType, AutoComplete? autoComplete, String? name, bool? noValidate, Target? target, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+Component form(List<Component> children, {String? action, FormMethod? method, FormEncType? encType, AutoComplete? autoComplete, String? name, bool? noValidate, Target? target, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events}) {
   return DomComponent(
     tag: 'form',
     key: key,
@@ -66,7 +65,6 @@ Component form({String? action, FormMethod? method, FormEncType? encType, AutoCo
       if (target != null) 'target': target.value,
     },
     events: events,
-    child: child,
     children: children,
   );
 }
@@ -114,7 +112,7 @@ enum AutoComplete {
 /// - [name]: Name of the form control. Submitted with the form as part of a name/value pair
 /// - [value]: The initial value of the control
 /// - [disabled]: Indicates that the user should not be able to interact with the input. Disabled inputs are typically rendered with a dimmer color or using some other form of indication that the field is not available for use.
-Component input({InputType? type, String? name, String? value, bool? disabled, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+Component input(List<Component> children, {InputType? type, String? name, String? value, bool? disabled, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events}) {
   return DomComponent(
     tag: 'input',
     key: key,
@@ -129,7 +127,6 @@ Component input({InputType? type, String? name, String? value, bool? disabled, K
       if (disabled == true) 'disabled': '',
     },
     events: events,
-    child: child,
     children: children,
   );
 }
@@ -188,7 +185,7 @@ enum InputType {
 /// The &lt;label&gt; HTML element represents a caption for an item in a user interface.
 ///
 /// - [htmlFor]: The value of the for attribute must be a single id for a labelable form-related element in the same document as the &lt;label&gt; element. So, any given label element can be associated with only one form control.
-Component label({String? htmlFor, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+Component label(List<Component> children, {String? htmlFor, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events}) {
   return DomComponent(
     tag: 'label',
     key: key,
@@ -200,13 +197,12 @@ Component label({String? htmlFor, Key? key, String? id, Iterable<String>? classe
       if (htmlFor != null) 'for': htmlFor,
     },
     events: events,
-    child: child,
     children: children,
   );
 }
 
 /// The &lt;datalist&gt; HTML element contains a set of &lt;option&gt; elements that represent the permissible or recommended options available to choose from within other controls.
-Component datalist({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+Component datalist(List<Component> children, {Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events}) {
   return DomComponent(
     tag: 'datalist',
     key: key,
@@ -215,13 +211,12 @@ Component datalist({Key? key, String? id, Iterable<String>? classes, Map<String,
     styles: styles,
     attributes: attributes,
     events: events,
-    child: child,
     children: children,
   );
 }
 
 /// The &lt;legend&gt; HTML element represents a caption for the content of its parent &lt;fieldset&gt;.
-Component legend({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+Component legend(List<Component> children, {Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events}) {
   return DomComponent(
     tag: 'legend',
     key: key,
@@ -230,7 +225,6 @@ Component legend({Key? key, String? id, Iterable<String>? classes, Map<String, S
     styles: styles,
     attributes: attributes,
     events: events,
-    child: child,
     children: children,
   );
 }
@@ -243,7 +237,7 @@ Component legend({Key? key, String? id, Iterable<String>? classes, Map<String, S
 /// - [low]: The upper numeric bound of the low end of the measured range. This must be greater than the minimum value (min attribute), and it also must be less than the high value and maximum value (high attribute and max attribute, respectively), if any are specified. If unspecified, or if less than the minimum value, the low value is equal to the minimum value.
 /// - [high]: The lower numeric bound of the high end of the measured range. This must be less than the maximum value (max attribute), and it also must be greater than the low value and minimum value (low attribute and min attribute, respectively), if any are specified. If unspecified, or if greater than the maximum value, the high value is equal to the maximum value.
 /// - [optimum]: Indicates the optimal numeric value. It must be within the range (as defined by the min attribute and max attribute). When used with the low attribute and high attribute, it gives an indication where along the range is considered preferable. For example, if it is between the min attribute and the low attribute, then the lower range is considered preferred. The browser may color the meter's bar differently depending on whether the value is less than or equal to the optimum value.
-Component meter({double? value, double? min, double? max, double? low, double? high, double? optimum, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+Component meter(List<Component> children, {double? value, double? min, double? max, double? low, double? high, double? optimum, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events}) {
   return DomComponent(
     tag: 'meter',
     key: key,
@@ -260,7 +254,6 @@ Component meter({double? value, double? min, double? max, double? low, double? h
       if (optimum != null) 'optimum': '$optimum',
     },
     events: events,
-    child: child,
     children: children,
   );
 }
@@ -269,7 +262,7 @@ Component meter({double? value, double? min, double? max, double? low, double? h
 ///
 /// - [value]: This attribute specifies how much of the task that has been completed. It must be a valid floating point number between 0 and max, or between 0 and 1 if max is omitted. If there is no value attribute, the progress bar is indeterminate; this indicates that an activity is ongoing with no indication of how long it is expected to take.
 /// - [max]: This attribute describes how much work the task indicated by the progress element requires. The max attribute, if present, must have a value greater than 0 and be a valid floating point number. The default value is 1.
-Component progress({double? value, double? max, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+Component progress(List<Component> children, {double? value, double? max, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events}) {
   return DomComponent(
     tag: 'progress',
     key: key,
@@ -282,7 +275,6 @@ Component progress({double? value, double? max, Key? key, String? id, Iterable<S
       if (max != null) 'max': '$max',
     },
     events: events,
-    child: child,
     children: children,
   );
 }
@@ -291,7 +283,7 @@ Component progress({double? value, double? max, Key? key, String? id, Iterable<S
 ///
 /// - [label]: The name of the group of options, which the browser can use when labeling the options in the user interface.
 /// - [disabled]: If this attribute is set, none of the items in this option group is selectable. Often browsers grey out such control and it won't receive any browsing events, like mouse clicks or focus-related ones.
-Component optgroup({required String label, bool? disabled, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+Component optgroup(List<Component> children, {required String label, bool? disabled, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events}) {
   return DomComponent(
     tag: 'optgroup',
     key: key,
@@ -304,7 +296,6 @@ Component optgroup({required String label, bool? disabled, Key? key, String? id,
       if (disabled == true) 'disabled': '',
     },
     events: events,
-    child: child,
     children: children,
   );
 }
@@ -315,7 +306,7 @@ Component optgroup({required String label, bool? disabled, Key? key, String? id,
 /// - [value]: The content of this attribute represents the value to be submitted with the form, should this option be selected. If this attribute is omitted, the value is taken from the text content of the option element.
 /// - [selected]: Indicates that the option is initially selected. If the &lt;option&gt; element is the descendant of a &lt;select&gt; element whose multiple attribute is not set, only one single &lt;option&gt; of this &lt;select&gt; element may have the selected attribute.
 /// - [disabled]: If this attribute is set, this option is not checkable. Often browsers grey out such control and it won't receive any browsing event, like mouse clicks or focus-related ones. If this attribute is not set, the element can still be disabled if one of its ancestors is a disabled &lt;optgroup&gt; element.
-Component option({String? label, String? value, bool? selected, bool? disabled, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+Component option(List<Component> children, {String? label, String? value, bool? selected, bool? disabled, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events}) {
   return DomComponent(
     tag: 'option',
     key: key,
@@ -330,7 +321,6 @@ Component option({String? label, String? value, bool? selected, bool? disabled, 
       if (disabled == true) 'disabled': '',
     },
     events: events,
-    child: child,
     children: children,
   );
 }
@@ -344,7 +334,7 @@ Component option({String? label, String? value, bool? selected, bool? disabled, 
 /// - [autofocus]: This attribute lets you specify that a form control should have input focus when the page loads. Only one form element in a document can have the autofocus attribute.
 /// - [autocomplete]: A string providing a hint for a user agent's autocomplete feature.
 /// - [size]: If the control is presented as a scrolling list box (e.g. when multiple is specified), this attribute represents the number of rows in the list that should be visible at one time. Browsers are not required to present a select element as a scrolled list box. The default value is 0.
-Component select({String? name, bool? multiple, bool? required, bool? disabled, bool? autofocus, String? autocomplete, int? size, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+Component select(List<Component> children, {String? name, bool? multiple, bool? required, bool? disabled, bool? autofocus, String? autocomplete, int? size, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events}) {
   return DomComponent(
     tag: 'select',
     key: key,
@@ -362,7 +352,6 @@ Component select({String? name, bool? multiple, bool? required, bool? disabled, 
       if (size != null) 'size': '$size',
     },
     events: events,
-    child: child,
     children: children,
   );
 }
@@ -381,7 +370,7 @@ Component select({String? name, bool? multiple, bool? required, bool? disabled, 
 /// - [rows]: The number of visible text lines for the control. If it is specified, it must be a positive integer. If it is not specified, the default value is 2.
 /// - [spellCheck]: Specifies whether the &lt;textarea&gt; is subject to spell checking by the underlying browser/OS.
 /// - [wrap]: Indicates how the control wraps text. If this attribute is not specified, soft is its default value.
-Component textarea({AutoComplete? autoComplete, bool? autofocus, int? cols, bool? disabled, int? minLength, String? name, String? placeholder, bool? readonly, bool? required, int? rows, SpellCheck? spellCheck, TextWrap? wrap, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+Component textarea(List<Component> children, {AutoComplete? autoComplete, bool? autofocus, int? cols, bool? disabled, int? minLength, String? name, String? placeholder, bool? readonly, bool? required, int? rows, SpellCheck? spellCheck, TextWrap? wrap, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events}) {
   return DomComponent(
     tag: 'textarea',
     key: key,
@@ -404,7 +393,6 @@ Component textarea({AutoComplete? autoComplete, bool? autofocus, int? cols, bool
       if (wrap != null) 'wrap': wrap.value,
     },
     events: events,
-    child: child,
     children: children,
   );
 }

--- a/packages/jaspr/lib/src/html/forms.dart
+++ b/packages/jaspr/lib/src/html/forms.dart
@@ -1,4 +1,4 @@
-import '../../jaspr.dart';
+part of jaspr_html;
 
 /// The &lt;button&gt; HTML element is an interactive element activated by a user with a mouse, keyboard, finger, voice command, or other assistive technology. Once activated, it then performs a programmable action, such as submitting a form or opening a dialog.
 ///
@@ -24,7 +24,6 @@ Component button({bool? autofocus, bool? disabled, ButtonType? type, Key? key, S
   );
 }
 
-
 /// Defines the default behavior of a button.
 enum ButtonType {
   /// The button submits the form data to the server. This is the default if the attribute is not specified for buttons associated with a &lt;form&gt;, or if the attribute is an empty or invalid value.
@@ -36,4 +35,400 @@ enum ButtonType {
 
   final String value;
   const ButtonType(this.value);
+}
+
+/// The &lt;form&gt; HTML element represents a document section containing interactive controls for submitting information.
+///
+/// - [action]: The URL that processes the form submission. This value can be overridden by a formaction attribute on a &lt;button&gt;, &lt;input type="submit"&gt;, or &lt;input type="image"&gt; element. This attribute is ignored when method="dialog" is set.
+/// - [method]: The HTTP method to submit the form with.
+///   
+///   This value is overridden by formmethod attributes on &lt;button&gt;, &lt;input type="submit"&gt;, or &lt;input type="image"&gt; elements.
+/// - [encType]: If the value of the method attribute is post, enctype is the MIME type of the form submission.
+/// - [autoComplete]: Indicates whether input elements can by default have their values automatically completed by the browser. autocomplete attributes on form elements override it on &lt;form&gt;.
+/// - [name]: The name of the form. The value must not be the empty string, and must be unique among the form elements in the forms collection that it is in, if any.
+/// - [noValidate]: Indicates that the form shouldn't be validated when submitted. If this attribute is not set (and therefore the form is validated), it can be overridden by a formnovalidate attribute on a &lt;button&gt;, &lt;input type="submit"&gt;, or &lt;input type="image"&gt; element belonging to the form.
+/// - [target]: Indicates where to display the response after submitting the form. In HTML 4, this is the name/keyword for a frame. In HTML5, it is a name/keyword for a browsing context (for example, tab, window, or iframe).
+Component form({String? action, FormMethod? method, FormEncType? encType, AutoComplete? autoComplete, String? name, bool? noValidate, Target? target, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+  return DomComponent(
+    tag: 'form',
+    key: key,
+    id: id,
+    classes: classes,
+    styles: styles,
+    attributes: {
+      ...attributes ?? {},
+      if (action != null) 'action': action,
+      if (method != null) 'method': method.value,
+      if (encType != null) 'enctype': encType.value,
+      if (autoComplete != null) 'autocomplete': autoComplete.value,
+      if (name != null) 'name': name,
+      if (noValidate == true) 'novalidate': '',
+      if (target != null) 'target': target.value,
+    },
+    events: events,
+    child: child,
+    children: children,
+  );
+}
+
+/// The HTTP method to submit a form with.
+enum FormMethod {
+  /// The POST method; form data sent as the request body.
+  post('post'),
+  /// The GET method; form data appended to the action URL with a ? separator. Use this method when the form has no side-effects.
+  get('get'),
+  /// When the form is inside a &lt;dialog&gt;, closes the dialog and throws a submit event on submission without submitting data or clearing the form.
+  dialog('dialog');
+
+  final String value;
+  const FormMethod(this.value);
+}
+
+/// The MIME type of a form submission.
+enum FormEncType {
+  /// The default value
+  formUrlEncoded('application/x-www-form-urlencoded'),
+  /// Use this if the form contains &lt;input&gt; elements with type=file.
+  multiPart('multipart/form-data'),
+  /// Introduced by HTML5 for debugging purposes.
+  text('text/plain');
+
+  final String value;
+  const FormEncType(this.value);
+}
+
+/// Indicates whether input elements can by default have their values automatically completed by the browser. autocomplete attributes on form elements override it on &lt;form&gt;.
+enum AutoComplete {
+  /// The browser may not automatically complete entries.
+  off('off'),
+  /// The browser may automatically complete entries.
+  on('on');
+
+  final String value;
+  const AutoComplete(this.value);
+}
+
+/// The &lt;input&gt; HTML element is used to create interactive controls for web-based forms in order to accept data from the user; a wide variety of types of input data and control widgets are available, depending on the device and user agent. The &lt;input&gt; element is one of the most powerful and complex in all of HTML due to the sheer number of combinations of input types and attributes.
+///
+/// - [type]: Defines how an &lt;input&gt; works. If this attribute is not specified, the default type adopted is text.
+/// - [name]: Name of the form control. Submitted with the form as part of a name/value pair
+/// - [value]: The initial value of the control
+/// - [disabled]: Indicates that the user should not be able to interact with the input. Disabled inputs are typically rendered with a dimmer color or using some other form of indication that the field is not available for use.
+Component input({InputType? type, String? name, String? value, bool? disabled, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+  return DomComponent(
+    tag: 'input',
+    key: key,
+    id: id,
+    classes: classes,
+    styles: styles,
+    attributes: {
+      ...attributes ?? {},
+      if (type != null) 'type': type.value,
+      if (name != null) 'name': name,
+      if (value != null) 'value': value,
+      if (disabled == true) 'disabled': '',
+    },
+    events: events,
+    child: child,
+    children: children,
+  );
+}
+
+/// The type for an &lt;input&gt; element.
+enum InputType {
+  /// A push button with no default behavior displaying the value of the value attribute, empty by default.
+  button('button'),
+  /// A check box allowing single values to be selected/deselected.
+  checkbox('checkbox'),
+  /// A control for specifying a color; opening a color picker when active in supporting browsers.
+  color('color'),
+  /// A control for entering a date (year, month, and day, with no time). Opens a date picker or numeric wheels for year, month, day when active in supporting browsers.
+  date('date'),
+  /// A control for entering a date and time, with no time zone. Opens a date picker or numeric wheels for date- and time-components when active in supporting browsers.
+  dateTimeLocal('datetime-local'),
+  /// A field for editing an email address. Looks like a text input, but has validation parameters and relevant keyboard in supporting browsers and devices with dynamic keyboards.
+  email('email'),
+  /// A control that lets the user select a file. Use the accept attribute to define the types of files that the control can select.
+  file('file'),
+  /// A control that is not displayed but whose value is submitted to the server.
+  hidden('hidden'),
+  /// A graphical submit button. Displays an image defined by the src attribute. The alt attribute displays if the image src is missing.
+  image('image'),
+  /// A control for entering a month and year, with no time zone.
+  month('month'),
+  /// A control for entering a number. Displays a spinner and adds default validation when supported. Displays a numeric keypad in some devices with dynamic keypads.
+  number('number'),
+  /// A single-line text field whose value is obscured. Will alert user if site is not secure.
+  password('password'),
+  /// A radio button, allowing a single value to be selected out of multiple choices with the same name value.
+  radio('radio'),
+  /// A control for entering a number whose exact value is not important. Displays as a range widget defaulting to the middle value. Used in conjunction min and max to define the range of acceptable values.
+  range('range'),
+  /// A button that resets the contents of the form to default values. Not recommended.
+  reset('reset'),
+  /// A single-line text field for entering search strings. Line-breaks are automatically removed from the input value. May include a delete icon in supporting browsers that can be used to clear the field. Displays a search icon instead of enter key on some devices with dynamic keypads.
+  search('search'),
+  /// A button that submits the form.
+  submit('submit'),
+  /// A control for entering a telephone number. Displays a telephone keypad in some devices with dynamic keypads.
+  tel('tel'),
+  /// The default value. A single-line text field. Line-breaks are automatically removed from the input value.
+  text('text'),
+  /// A control for entering a time value with no time zone.
+  time('time'),
+  /// A field for entering a URL. Looks like a text input, but has validation parameters and relevant keyboard in supporting browsers and devices with dynamic keyboards.
+  url('url'),
+  /// A control for entering a date consisting of a week-year number and a week number with no time zone.
+  week('week');
+
+  final String value;
+  const InputType(this.value);
+}
+
+/// The &lt;label&gt; HTML element represents a caption for an item in a user interface.
+///
+/// - [htmlFor]: The value of the for attribute must be a single id for a labelable form-related element in the same document as the &lt;label&gt; element. So, any given label element can be associated with only one form control.
+Component label({String? htmlFor, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+  return DomComponent(
+    tag: 'label',
+    key: key,
+    id: id,
+    classes: classes,
+    styles: styles,
+    attributes: {
+      ...attributes ?? {},
+      if (htmlFor != null) 'for': htmlFor,
+    },
+    events: events,
+    child: child,
+    children: children,
+  );
+}
+
+/// The &lt;datalist&gt; HTML element contains a set of &lt;option&gt; elements that represent the permissible or recommended options available to choose from within other controls.
+Component datalist({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+  return DomComponent(
+    tag: 'datalist',
+    key: key,
+    id: id,
+    classes: classes,
+    styles: styles,
+    attributes: attributes,
+    events: events,
+    child: child,
+    children: children,
+  );
+}
+
+/// The &lt;legend&gt; HTML element represents a caption for the content of its parent &lt;fieldset&gt;.
+Component legend({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+  return DomComponent(
+    tag: 'legend',
+    key: key,
+    id: id,
+    classes: classes,
+    styles: styles,
+    attributes: attributes,
+    events: events,
+    child: child,
+    children: children,
+  );
+}
+
+/// The &lt;meter&gt; HTML element represents either a scalar value within a known range or a fractional value.
+///
+/// - [value]: The current numeric value. This must be between the minimum and maximum values (min attribute and max attribute) if they are specified. If unspecified or malformed, the value is 0. If specified, but not within the range given by the min attribute and max attribute, the value is equal to the nearest end of the range.
+/// - [min]: The lower numeric bound of the measured range. This must be less than the maximum value (max attribute), if specified. If unspecified, the minimum value is 0.
+/// - [max]: The upper numeric bound of the measured range. This must be greater than the minimum value (min attribute), if specified. If unspecified, the maximum value is 1.
+/// - [low]: The upper numeric bound of the low end of the measured range. This must be greater than the minimum value (min attribute), and it also must be less than the high value and maximum value (high attribute and max attribute, respectively), if any are specified. If unspecified, or if less than the minimum value, the low value is equal to the minimum value.
+/// - [high]: The lower numeric bound of the high end of the measured range. This must be less than the maximum value (max attribute), and it also must be greater than the low value and minimum value (low attribute and min attribute, respectively), if any are specified. If unspecified, or if greater than the maximum value, the high value is equal to the maximum value.
+/// - [optimum]: Indicates the optimal numeric value. It must be within the range (as defined by the min attribute and max attribute). When used with the low attribute and high attribute, it gives an indication where along the range is considered preferable. For example, if it is between the min attribute and the low attribute, then the lower range is considered preferred. The browser may color the meter's bar differently depending on whether the value is less than or equal to the optimum value.
+Component meter({double? value, double? min, double? max, double? low, double? high, double? optimum, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+  return DomComponent(
+    tag: 'meter',
+    key: key,
+    id: id,
+    classes: classes,
+    styles: styles,
+    attributes: {
+      ...attributes ?? {},
+      if (value != null) 'value': '$value',
+      if (min != null) 'min': '$min',
+      if (max != null) 'max': '$max',
+      if (low != null) 'low': '$low',
+      if (high != null) 'high': '$high',
+      if (optimum != null) 'optimum': '$optimum',
+    },
+    events: events,
+    child: child,
+    children: children,
+  );
+}
+
+/// The &lt;progress&gt; HTML element displays an indicator showing the completion progress of a task, typically displayed as a progress bar.
+///
+/// - [value]: This attribute specifies how much of the task that has been completed. It must be a valid floating point number between 0 and max, or between 0 and 1 if max is omitted. If there is no value attribute, the progress bar is indeterminate; this indicates that an activity is ongoing with no indication of how long it is expected to take.
+/// - [max]: This attribute describes how much work the task indicated by the progress element requires. The max attribute, if present, must have a value greater than 0 and be a valid floating point number. The default value is 1.
+Component progress({double? value, double? max, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+  return DomComponent(
+    tag: 'progress',
+    key: key,
+    id: id,
+    classes: classes,
+    styles: styles,
+    attributes: {
+      ...attributes ?? {},
+      if (value != null) 'value': '$value',
+      if (max != null) 'max': '$max',
+    },
+    events: events,
+    child: child,
+    children: children,
+  );
+}
+
+/// The &lt;optgroup&gt; HTML element creates a grouping of options within a &lt;select&gt; element.
+///
+/// - [label]: The name of the group of options, which the browser can use when labeling the options in the user interface.
+/// - [disabled]: If this attribute is set, none of the items in this option group is selectable. Often browsers grey out such control and it won't receive any browsing events, like mouse clicks or focus-related ones.
+Component optgroup({required String label, bool? disabled, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+  return DomComponent(
+    tag: 'optgroup',
+    key: key,
+    id: id,
+    classes: classes,
+    styles: styles,
+    attributes: {
+      ...attributes ?? {},
+      'label': label,
+      if (disabled == true) 'disabled': '',
+    },
+    events: events,
+    child: child,
+    children: children,
+  );
+}
+
+/// The &lt;option&gt; HTML element is used to define an item contained in a &lt;select&gt;, an &lt;optgroup&gt;, or a &lt;datalist&gt; element. As such, &lt;option&gt; can represent menu items in popups and other lists of items in an HTML document.
+///
+/// - [label]: This attribute is text for the label indicating the meaning of the option. If the label attribute isn't defined, its value is that of the element text content.
+/// - [value]: The content of this attribute represents the value to be submitted with the form, should this option be selected. If this attribute is omitted, the value is taken from the text content of the option element.
+/// - [selected]: Indicates that the option is initially selected. If the &lt;option&gt; element is the descendant of a &lt;select&gt; element whose multiple attribute is not set, only one single &lt;option&gt; of this &lt;select&gt; element may have the selected attribute.
+/// - [disabled]: If this attribute is set, this option is not checkable. Often browsers grey out such control and it won't receive any browsing event, like mouse clicks or focus-related ones. If this attribute is not set, the element can still be disabled if one of its ancestors is a disabled &lt;optgroup&gt; element.
+Component option({String? label, String? value, bool? selected, bool? disabled, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+  return DomComponent(
+    tag: 'option',
+    key: key,
+    id: id,
+    classes: classes,
+    styles: styles,
+    attributes: {
+      ...attributes ?? {},
+      if (label != null) 'label': label,
+      if (value != null) 'value': value,
+      if (selected == true) 'selected': '',
+      if (disabled == true) 'disabled': '',
+    },
+    events: events,
+    child: child,
+    children: children,
+  );
+}
+
+/// The <select> HTML element represents a control that provides a menu of options.
+///
+/// - [name]: This attribute is used to specify the name of the control.
+/// - [multiple]: Indicates that multiple options can be selected in the list. If it is not specified, then only one option can be selected at a time. When multiple is specified, most browsers will show a scrolling list box instead of a single line dropdown.
+/// - [required]: Indicating that an option with a non-empty string value must be selected.
+/// - [disabled]: Indicates that the user cannot interact with the control. If this attribute is not specified, the control inherits its setting from the containing element, for example <fieldset>; if there is no containing element with the disabled attribute set, then the control is enabled.
+/// - [autofocus]: This attribute lets you specify that a form control should have input focus when the page loads. Only one form element in a document can have the autofocus attribute.
+/// - [autocomplete]: A string providing a hint for a user agent's autocomplete feature.
+/// - [size]: If the control is presented as a scrolling list box (e.g. when multiple is specified), this attribute represents the number of rows in the list that should be visible at one time. Browsers are not required to present a select element as a scrolled list box. The default value is 0.
+Component select({String? name, bool? multiple, bool? required, bool? disabled, bool? autofocus, String? autocomplete, int? size, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+  return DomComponent(
+    tag: 'select',
+    key: key,
+    id: id,
+    classes: classes,
+    styles: styles,
+    attributes: {
+      ...attributes ?? {},
+      if (name != null) 'name': name,
+      if (multiple == true) 'multiple': '',
+      if (required == true) 'required': '',
+      if (disabled == true) 'disabled': '',
+      if (autofocus == true) 'autofocus': '',
+      if (autocomplete != null) 'autocomplete': autocomplete,
+      if (size != null) 'size': '$size',
+    },
+    events: events,
+    child: child,
+    children: children,
+  );
+}
+
+/// The &lt;textarea&gt; HTML element represents a multi-line plain-text editing control, useful when you want to allow users to enter a sizeable amount of free-form text, for example a comment on a review or feedback form.
+///
+/// - [autoComplete]: Indicates whether the value of the control can be automatically completed by the browser.
+/// - [autofocus]: This attribute lets you specify that a form control should have input focus when the page loads. Only one form-associated element in a document can have this attribute specified.
+/// - [cols]: The visible width of the text control, in average character widths. If it is specified, it must be a positive integer. If it is not specified, the default value is 20.
+/// - [disabled]: Indicates that the user cannot interact with the control. If this attribute is not specified, the control inherits its setting from the containing element, for example &lt;fieldset&gt;; if there is no containing element when the disabled attribute is set, the control is enabled.
+/// - [minLength]: The minimum number of characters (UTF-16 code units) required that the user should enter.
+/// - [name]: The name of the control
+/// - [placeholder]: A hint to the user of what can be entered in the control. Carriage returns or line-feeds within the placeholder text must be treated as line breaks when rendering the hint.
+/// - [readonly]: Indicates that the user cannot modify the value of the control. Unlike the disabled attribute, the readonly attribute does not prevent the user from clicking or selecting in the control. The value of a read-only control is still submitted with the form.
+/// - [required]: This attribute specifies that the user must fill in a value before submitting a form.
+/// - [rows]: The number of visible text lines for the control. If it is specified, it must be a positive integer. If it is not specified, the default value is 2.
+/// - [spellCheck]: Specifies whether the &lt;textarea&gt; is subject to spell checking by the underlying browser/OS.
+/// - [wrap]: Indicates how the control wraps text. If this attribute is not specified, soft is its default value.
+Component textarea({AutoComplete? autoComplete, bool? autofocus, int? cols, bool? disabled, int? minLength, String? name, String? placeholder, bool? readonly, bool? required, int? rows, SpellCheck? spellCheck, TextWrap? wrap, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+  return DomComponent(
+    tag: 'textarea',
+    key: key,
+    id: id,
+    classes: classes,
+    styles: styles,
+    attributes: {
+      ...attributes ?? {},
+      if (autoComplete != null) 'autocomplete': autoComplete.value,
+      if (autofocus == true) 'autofocus': '',
+      if (cols != null) 'cols': '$cols',
+      if (disabled == true) 'disabled': '',
+      if (minLength != null) 'minlength': '$minLength',
+      if (name != null) 'name': name,
+      if (placeholder != null) 'placeholder': placeholder,
+      if (readonly == true) 'readonly': '',
+      if (required == true) 'required': '',
+      if (rows != null) 'rows': '$rows',
+      if (spellCheck != null) 'spellcheck': spellCheck.value,
+      if (wrap != null) 'wrap': wrap.value,
+    },
+    events: events,
+    child: child,
+    children: children,
+  );
+}
+
+/// Specifies whether an element is subject to spell checking by the underlying browser/OS.
+enum SpellCheck {
+  /// Indicates that the element needs to have its spelling and grammar checked.
+  isTrue('true'),
+  /// Indicates that the element is to act according to a default behavior, possibly based on the parent element's own spellcheck value.
+  isDefault('default'),
+  /// Indicates that the element should not be spell checked.
+  isFalse('false');
+
+  final String value;
+  const SpellCheck(this.value);
+}
+
+/// Indicates how the control wraps text.
+enum TextWrap {
+  /// The browser automatically inserts line breaks (CR+LF) so that each line has no more than the width of the control; the cols attribute must also be specified for this to take effect.
+  hard('hard'),
+  /// The browser ensures that all line breaks in the value consist of a CR+LF pair, but does not insert any additional line breaks.
+  soft('soft');
+
+  final String value;
+  const TextWrap(this.value);
 }

--- a/packages/jaspr/lib/src/html/media.dart
+++ b/packages/jaspr/lib/src/html/media.dart
@@ -9,7 +9,7 @@ part of jaspr_html;
 /// - [muted]: Indicates whether the audio will be initially silenced. Its default value is false.
 /// - [preload]: Provides a hint to the browser about what the author thinks will lead to the best user experience.
 /// - [src]: The URL of the audio to embed. This is subject to HTTP access controls. This is optional; you may instead use the &lt;source&gt; element within the audio block to specify the audio to embed.
-Component audio({bool? autoplay, bool? controls, CrossOrigin? crossOrigin, bool? loop, bool? muted, Preload? preload, String? src, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+Component audio(List<Component> children, {bool? autoplay, bool? controls, CrossOrigin? crossOrigin, bool? loop, bool? muted, Preload? preload, String? src, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events}) {
   return DomComponent(
     tag: 'audio',
     key: key,
@@ -27,7 +27,6 @@ Component audio({bool? autoplay, bool? controls, CrossOrigin? crossOrigin, bool?
       if (src != null) 'src': src,
     },
     events: events,
-    child: child,
     children: children,
   );
 }
@@ -110,7 +109,7 @@ enum MediaLoading {
 /// - [src]: The URL of the video to embed. This is optional; you may instead use the &lt;source&gt; element within the video block to specify the video to embed.
 /// - [width]: The width of the video's display area, in CSS pixels.
 /// - [height]: The height of the video's display area, in CSS pixels.
-Component video({bool? autoplay, bool? controls, CrossOrigin? crossOrigin, bool? loop, bool? muted, String? poster, Preload? preload, String? src, int? width, int? height, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+Component video(List<Component> children, {bool? autoplay, bool? controls, CrossOrigin? crossOrigin, bool? loop, bool? muted, String? poster, Preload? preload, String? src, int? width, int? height, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events}) {
   return DomComponent(
     tag: 'video',
     key: key,
@@ -131,7 +130,6 @@ Component video({bool? autoplay, bool? controls, CrossOrigin? crossOrigin, bool?
       if (height != null) 'height': '$height',
     },
     events: events,
-    child: child,
     children: children,
   );
 }
@@ -171,7 +169,7 @@ Component embed({required String src, String? type, int? width, int? height, Key
 /// - [referrerPolicy]: Indicates which referrer to send when fetching the frame's resource.
 /// - [width]: The width of the frame in CSS pixels. Default is 300.
 /// - [height]: The height of the frame in CSS pixels. Default is 150.
-Component iframe({required String src, String? allow, String? csp, MediaLoading? loading, String? name, String? sandbox, ReferrerPolicy? referrerPolicy, int? width, int? height, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+Component iframe(List<Component> children, {required String src, String? allow, String? csp, MediaLoading? loading, String? name, String? sandbox, ReferrerPolicy? referrerPolicy, int? width, int? height, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events}) {
   return DomComponent(
     tag: 'iframe',
     key: key,
@@ -191,7 +189,6 @@ Component iframe({required String src, String? allow, String? csp, MediaLoading?
       if (height != null) 'height': '$height',
     },
     events: events,
-    child: child,
     children: children,
   );
 }
@@ -226,7 +223,7 @@ enum ReferrerPolicy {
 /// - [type]: The content type of the resource specified by data. At least one of data and type must be defined.
 /// - [width]: The width of the displayed resource in CSS pixels.
 /// - [height]: The height of the displayed resource in CSS pixels.
-Component object({String? data, String? name, String? type, int? width, int? height, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+Component object(List<Component> children, {String? data, String? name, String? type, int? width, int? height, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events}) {
   return DomComponent(
     tag: 'object',
     key: key,
@@ -242,7 +239,6 @@ Component object({String? data, String? name, String? type, int? width, int? hei
       if (height != null) 'height': '$height',
     },
     events: events,
-    child: child,
     children: children,
   );
 }

--- a/packages/jaspr/lib/src/html/media.dart
+++ b/packages/jaspr/lib/src/html/media.dart
@@ -32,12 +32,31 @@ Component audio({bool? autoplay, bool? controls, CrossOrigin? crossOrigin, bool?
   );
 }
 
+
+/// Indicates if the fetching of the media must be done using a CORS request. Media data from a CORS request can be reused in the &lt;canvas&gt; element without being marked "tainted". If the crossorigin attribute is not specified, then a non-CORS request is sent (without the Origin request header), and the browser marks the media as tainted and restricts access to its data, preventing its usage in &lt;canvas&gt; elements. If the crossorigin attribute is specified, then a CORS request is sent (with the Origin request header); but if the server does not opt into allowing cross-origin access to the media data by the origin site (by not sending any Access-Control-Allow-Origin response header, or by not including the site's origin in any Access-Control-Allow-Origin response header it does send), then the browser blocks the media from loading, and logs a CORS error to the devtools console.
 enum CrossOrigin {
-  anonymous('anonymous'), useCredentials('use-credentials')
+  /// Sends a cross-origin request without a credential. In other words, it sends the Origin: HTTP header without a cookie, X.509 certificate, or performing HTTP Basic authentication. If the server does not give credentials to the origin site (by not setting the Access-Control-Allow-Origin: HTTP header), the image will be tainted, and its usage restricted.
+  anonymous('anonymous'),
+  /// Sends a cross-origin request with a credential. In other words, it sends the Origin: HTTP header with a cookie, a certificate, or performing HTTP Basic authentication. If the server does not give credentials to the origin site (through Access-Control-Allow-Credentials: HTTP header), the image will be tainted and its usage restricted.
+  useCredentials('use-credentials');
+
+  final String value;
+  const CrossOrigin(this.value);
 }
 
+
+/// Intended to provide a hint to the browser about what the author thinks will lead to the best user experience when loading a media object.
+/// The default value is different for each browser. The spec advises it to be set to [Preload.metadata].
 enum Preload {
-  none('none'), metadata('metadata'), auto('auto')
+  /// Indicates that the audio should not be preloaded.
+  none('none'),
+  /// Indicates that only audio metadata (e.g. length) is fetched.
+  metadata('metadata'),
+  /// Indicates that the whole audio file can be downloaded, even if the user is not expected to use it.
+  auto('auto');
+
+  final String value;
+  const Preload(this.value);
 }
 
 /// The &lt;img&gt; HTML element embeds an image into the document.
@@ -70,8 +89,16 @@ Component img({String? alt, CrossOrigin? crossOrigin, int? width, int? height, I
   );
 }
 
+
+/// Indicates how the browser should load the image. Loading is only deferred when JavaScript is enabled.
 enum ImageLoading {
-  eager('eager'), lazy('lazy')
+  /// Loads the image immediately, regardless of whether or not the image is currently within the visible viewport (this is the default value).
+  eager('eager'),
+  /// Defers loading the image until it reaches a calculated distance from the viewport, as defined by the browser. The intent is to avoid the network and storage bandwidth needed to handle the image until it's reasonably certain that it will be needed. This generally improves the performance of the content in most typical use cases.
+  lazy('lazy');
+
+  final String value;
+  const ImageLoading(this.value);
 }
 
 /// The &lt;video&gt; HTML element embeds a media player which supports video playback into the document. You can use &lt;video&gt; for audio content as well, but the &lt;audio&gt; element may provide a more appropriate user experience.

--- a/packages/jaspr/lib/src/html/media.dart
+++ b/packages/jaspr/lib/src/html/media.dart
@@ -1,0 +1,113 @@
+import '../../jaspr.dart';
+
+/// The &lt;audio&gt; HTML element is used to embed sound content in documents. It may contain one or more audio sources, represented using the src attribute or the &lt;source&gt; element: the browser will choose the most suitable one. It can also be the destination for streamed media, using a MediaStream.
+///
+/// - [autoplay]: A Boolean attribute: if specified, the audio will automatically begin playback as soon as it can do so, without waiting for the entire audio file to finish downloading.
+/// - [controls]: If this attribute is present, the browser will offer controls to allow the user to control audio playback, including volume, seeking, and pause/resume playback.
+/// - [crossOrigin]: Indicates whether to use CORS to fetch the related audio file.
+/// - [loop]: If specified, the audio player will automatically seek back to the start upon reaching the end of the audio.
+/// - [muted]: Indicates whether the audio will be initially silenced. Its default value is false.
+/// - [preload]: Provides a hint to the browser about what the author thinks will lead to the best user experience.
+/// - [src]: The URL of the audio to embed. This is subject to HTTP access controls. This is optional; you may instead use the &lt;source&gt; element within the audio block to specify the audio to embed.
+Component audio({bool? autoplay, bool? controls, CrossOrigin? crossOrigin, bool? loop, bool? muted, Preload? preload, String? src, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+  return DomComponent(
+    tag: 'audio',
+    key: key,
+    id: id,
+    classes: classes,
+    styles: styles,
+    attributes: {
+      ...attributes ?? {},
+      if (autoplay == true) 'autoplay': '',
+      if (controls == true) 'controls': '',
+      if (crossOrigin != null) 'crossorigin': crossOrigin.value,
+      if (loop == true) 'loop': '',
+      if (muted == true) 'muted': '',
+      if (preload != null) 'preload': preload.value,
+      if (src != null) 'src': src,
+    },
+    events: events,
+    child: child,
+    children: children,
+  );
+}
+
+enum CrossOrigin {
+  anonymous('anonymous'), useCredentials('use-credentials')
+}
+
+enum Preload {
+  none('none'), metadata('metadata'), auto('auto')
+}
+
+/// The &lt;img&gt; HTML element embeds an image into the document.
+///
+/// - [alt]: Defines an alternative text description of the image
+/// - [crossOrigin]: Indicates if the fetching of the image must be done using a CORS request.
+/// - [width]: The intrinsic width of the image in pixels.
+/// - [height]: The intrinsic height of the image, in pixels.
+/// - [loading]: Indicates how the browser should load the image.
+/// - [src]: The image URL.
+Component img({String? alt, CrossOrigin? crossOrigin, int? width, int? height, ImageLoading? loading, required String src, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+  return DomComponent(
+    tag: 'img',
+    key: key,
+    id: id,
+    classes: classes,
+    styles: styles,
+    attributes: {
+      ...attributes ?? {},
+      if (alt != null) 'alt': alt,
+      if (crossOrigin != null) 'crossorigin': crossOrigin.value,
+      if (width != null) 'width': '$width',
+      if (height != null) 'height': '$height',
+      if (loading != null) 'loading': loading.value,
+      'src': src,
+    },
+    events: events,
+    child: child,
+    children: children,
+  );
+}
+
+enum ImageLoading {
+  eager('eager'), lazy('lazy')
+}
+
+/// The &lt;video&gt; HTML element embeds a media player which supports video playback into the document. You can use &lt;video&gt; for audio content as well, but the &lt;audio&gt; element may provide a more appropriate user experience.
+///
+/// - [autoplay]: Indicates if the video automatically begins to play back as soon as it can do so without stopping to finish loading the data.
+/// - [controls]: If this attribute is present, the browser will offer controls to allow the user to control video playback, including volume, seeking, and pause/resume playback.
+/// - [crossOrigin]: Indicates whether to use CORS to fetch the related video.
+/// - [loop]: If specified, the browser will automatically seek back to the start upon reaching the end of the video.
+/// - [muted]: Indicates the default setting of the audio contained in the video. If set, the audio will be initially silenced. Its default value is false, meaning that the audio will be played when the video is played.
+/// - [poster]: A URL for an image to be shown while the video is downloading. If this attribute isn't specified, nothing is displayed until the first frame is available, then the first frame is shown as the poster frame.
+/// - [preload]: Provides a hint to the browser about what the author thinks will lead to the best user experience with regards to what content is loaded before the video is played.
+/// - [src]: The URL of the video to embed. This is optional; you may instead use the &lt;source&gt; element within the video block to specify the video to embed.
+/// - [width]: The width of the video's display area, in CSS pixels.
+/// - [height]: The height of the video's display area, in CSS pixels.
+Component video({bool? autoplay, bool? controls, CrossOrigin? crossOrigin, bool? loop, bool? muted, String? poster, Preload? preload, String? src, int? width, int? height, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+  return DomComponent(
+    tag: 'video',
+    key: key,
+    id: id,
+    classes: classes,
+    styles: styles,
+    attributes: {
+      ...attributes ?? {},
+      if (autoplay == true) 'autoplay': '',
+      if (controls == true) 'controls': '',
+      if (crossOrigin != null) 'crossorigin': crossOrigin.value,
+      if (loop == true) 'loop': '',
+      if (muted == true) 'muted': '',
+      if (poster != null) 'poster': poster,
+      if (preload != null) 'preload': preload.value,
+      if (src != null) 'src': src,
+      if (width != null) 'width': '$width',
+      if (height != null) 'height': '$height',
+    },
+    events: events,
+    child: child,
+    children: children,
+  );
+}

--- a/packages/jaspr/lib/src/html/media.dart
+++ b/packages/jaspr/lib/src/html/media.dart
@@ -1,4 +1,4 @@
-import '../../jaspr.dart';
+part of jaspr_html;
 
 /// The &lt;audio&gt; HTML element is used to embed sound content in documents. It may contain one or more audio sources, represented using the src attribute or the &lt;source&gt; element: the browser will choose the most suitable one. It can also be the destination for streamed media, using a MediaStream.
 ///
@@ -32,7 +32,6 @@ Component audio({bool? autoplay, bool? controls, CrossOrigin? crossOrigin, bool?
   );
 }
 
-
 /// Indicates if the fetching of the media must be done using a CORS request. Media data from a CORS request can be reused in the &lt;canvas&gt; element without being marked "tainted". If the crossorigin attribute is not specified, then a non-CORS request is sent (without the Origin request header), and the browser marks the media as tainted and restricts access to its data, preventing its usage in &lt;canvas&gt; elements. If the crossorigin attribute is specified, then a CORS request is sent (with the Origin request header); but if the server does not opt into allowing cross-origin access to the media data by the origin site (by not sending any Access-Control-Allow-Origin response header, or by not including the site's origin in any Access-Control-Allow-Origin response header it does send), then the browser blocks the media from loading, and logs a CORS error to the devtools console.
 enum CrossOrigin {
   /// Sends a cross-origin request without a credential. In other words, it sends the Origin: HTTP header without a cookie, X.509 certificate, or performing HTTP Basic authentication. If the server does not give credentials to the origin site (by not setting the Access-Control-Allow-Origin: HTTP header), the image will be tainted, and its usage restricted.
@@ -43,7 +42,6 @@ enum CrossOrigin {
   final String value;
   const CrossOrigin(this.value);
 }
-
 
 /// Intended to provide a hint to the browser about what the author thinks will lead to the best user experience when loading a media object.
 /// The default value is different for each browser. The spec advises it to be set to [Preload.metadata].
@@ -67,7 +65,8 @@ enum Preload {
 /// - [height]: The intrinsic height of the image, in pixels.
 /// - [loading]: Indicates how the browser should load the image.
 /// - [src]: The image URL.
-Component img({String? alt, CrossOrigin? crossOrigin, int? width, int? height, ImageLoading? loading, required String src, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+/// - [referrerPolicy]: Indicates which referrer to send when fetching the resource.
+Component img({String? alt, CrossOrigin? crossOrigin, int? width, int? height, MediaLoading? loading, required String src, ReferrerPolicy? referrerPolicy, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events}) {
   return DomComponent(
     tag: 'img',
     key: key,
@@ -82,23 +81,21 @@ Component img({String? alt, CrossOrigin? crossOrigin, int? width, int? height, I
       if (height != null) 'height': '$height',
       if (loading != null) 'loading': loading.value,
       'src': src,
+      if (referrerPolicy != null) 'referrerpolicy': referrerPolicy.value,
     },
     events: events,
-    child: child,
-    children: children,
   );
 }
 
-
-/// Indicates how the browser should load the image. Loading is only deferred when JavaScript is enabled.
-enum ImageLoading {
-  /// Loads the image immediately, regardless of whether or not the image is currently within the visible viewport (this is the default value).
+/// Indicates how the browser should load the media. Loading is only deferred when JavaScript is enabled.
+enum MediaLoading {
+  /// Loads the media immediately, regardless of whether or not the media is currently within the visible viewport (this is the default value).
   eager('eager'),
-  /// Defers loading the image until it reaches a calculated distance from the viewport, as defined by the browser. The intent is to avoid the network and storage bandwidth needed to handle the image until it's reasonably certain that it will be needed. This generally improves the performance of the content in most typical use cases.
+  /// Defers loading the media until it reaches a calculated distance from the viewport, as defined by the browser. The intent is to avoid the network and storage bandwidth needed to handle the media until it's reasonably certain that it will be needed. This generally improves the performance of the media in most typical use cases.
   lazy('lazy');
 
   final String value;
-  const ImageLoading(this.value);
+  const MediaLoading(this.value);
 }
 
 /// The &lt;video&gt; HTML element embeds a media player which supports video playback into the document. You can use &lt;video&gt; for audio content as well, but the &lt;audio&gt; element may provide a more appropriate user experience.
@@ -136,5 +133,138 @@ Component video({bool? autoplay, bool? controls, CrossOrigin? crossOrigin, bool?
     events: events,
     child: child,
     children: children,
+  );
+}
+
+/// The &lt;embed&gt; HTML element embeds external content at the specified point in the document. This content is provided by an external application or other source of interactive content such as a browser plug-in.
+///
+/// - [src]: The URL of the resource being embedded.
+/// - [type]: The MIME type to use to select the plug-in to instantiate.
+/// - [width]: The displayed width of the resource, in CSS pixels.
+/// - [height]: The displayed height of the resource, in CSS pixels.
+Component embed({required String src, String? type, int? width, int? height, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events}) {
+  return DomComponent(
+    tag: 'embed',
+    key: key,
+    id: id,
+    classes: classes,
+    styles: styles,
+    attributes: {
+      ...attributes ?? {},
+      'src': src,
+      if (type != null) 'type': type,
+      if (width != null) 'width': '$width',
+      if (height != null) 'height': '$height',
+    },
+    events: events,
+  );
+}
+
+/// The &lt;iframe&gt; HTML element represents a nested browsing context, embedding another HTML page into the current one.
+///
+/// - [src]: The URL of the page to embed. Use a value of about:blank to embed an empty page that conforms to the same-origin policy. Also note that programmatically removing an &lt;iframe&gt;'s src attribute (e.g. via Element.removeAttribute()) causes about:blank to be loaded in the frame in Firefox (from version 65), Chromium-based browsers, and Safari/iOS.
+/// - [allow]: Specifies a feature policy for the &lt;iframe&gt;. The policy defines what features are available to the &lt;iframe&gt; based on the origin of the request (e.g. access to the microphone, camera, battery, web-share API, etc.).
+/// - [csp]: A Content Security Policy enforced for the embedded resource.
+/// - [loading]: Indicates how the browser should load the iframe.
+/// - [name]: A targetable name for the embedded browsing context. This can be used in the target attribute of the &lt;a&gt;, &lt;form&gt;, or &lt;base&gt; elements; the formtarget attribute of the &lt;input&gt; or &lt;button&gt; elements; or the windowName parameter in the window.open() method.
+/// - [sandbox]: Applies extra restrictions to the content in the frame. The value of the attribute can either be empty to apply all restrictions, or space-separated tokens to lift particular restrictions.
+/// - [referrerPolicy]: Indicates which referrer to send when fetching the frame's resource.
+/// - [width]: The width of the frame in CSS pixels. Default is 300.
+/// - [height]: The height of the frame in CSS pixels. Default is 150.
+Component iframe({required String src, String? allow, String? csp, MediaLoading? loading, String? name, String? sandbox, ReferrerPolicy? referrerPolicy, int? width, int? height, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+  return DomComponent(
+    tag: 'iframe',
+    key: key,
+    id: id,
+    classes: classes,
+    styles: styles,
+    attributes: {
+      ...attributes ?? {},
+      'src': src,
+      if (allow != null) 'allow': allow,
+      if (csp != null) 'csp': csp,
+      if (loading != null) 'loading': loading.value,
+      if (name != null) 'name': name,
+      if (sandbox != null) 'sandbox': sandbox,
+      if (referrerPolicy != null) 'referrerpolicy': referrerPolicy.value,
+      if (width != null) 'width': '$width',
+      if (height != null) 'height': '$height',
+    },
+    events: events,
+    child: child,
+    children: children,
+  );
+}
+
+/// The Referrer-Policy controls how much referrer information (sent with the Referer header) should be included with requests.
+enum ReferrerPolicy {
+  /// The Referer header will not be sent.
+  noReferrer('no-referrer'),
+  /// The Referer header will not be sent to origins without TLS (HTTPS).
+  noReferrerWhenDowngrade('no-referrer-when-downgrade'),
+  /// The sent referrer will be limited to the origin of the referring page: its scheme, host, and port.
+  origin('origin'),
+  /// The referrer sent to other origins will be limited to the scheme, the host, and the port. Navigations on the same origin will still include the path.
+  originWhenCrossOrigin('origin-when-cross-origin'),
+  /// A referrer will be sent for same origin, but cross-origin requests will contain no referrer information.
+  sameOrigin('same-origin'),
+  /// Only send the origin of the document as the referrer when the protocol security level stays the same (HTTPS→HTTPS), but don't send it to a less secure destination (HTTPS→HTTP).
+  strictOrigin('strict-origin'),
+  /// (default): Send a full URL when performing a same-origin request, only send the origin when the protocol security level stays the same (HTTPS→HTTPS), and send no header to a less secure destination (HTTPS→HTTP).
+  strictOriginWhenCrossOrigin('strict-origin-when-cross-origin'),
+  /// The referrer will include the origin and the path (but not the fragment, password, or username). This value is unsafe, because it leaks origins and paths from TLS-protected resources to insecure origins.
+  unsafeUrl('unsafe-url');
+
+  final String value;
+  const ReferrerPolicy(this.value);
+}
+
+/// The &lt;object&gt; HTML element represents an external resource, which can be treated as an image, a nested browsing context, or a resource to be handled by a plugin.
+///
+/// - [data]: The address of the resource as a valid URL. At least one of data and type must be defined.
+/// - [name]: The name of valid browsing context (HTML5).
+/// - [type]: The content type of the resource specified by data. At least one of data and type must be defined.
+/// - [width]: The width of the displayed resource in CSS pixels.
+/// - [height]: The height of the displayed resource in CSS pixels.
+Component object({String? data, String? name, String? type, int? width, int? height, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+  return DomComponent(
+    tag: 'object',
+    key: key,
+    id: id,
+    classes: classes,
+    styles: styles,
+    attributes: {
+      ...attributes ?? {},
+      if (data != null) 'data': data,
+      if (name != null) 'name': name,
+      if (type != null) 'type': type,
+      if (width != null) 'width': '$width',
+      if (height != null) 'height': '$height',
+    },
+    events: events,
+    child: child,
+    children: children,
+  );
+}
+
+/// The &lt;source&gt; HTML element specifies multiple media resources for the &lt;picture&gt;, the &lt;audio&gt; element, or the &lt;video&gt; element. It is an empty element, meaning that it has no content and does not have a closing tag. It is commonly used to offer the same media content in multiple file formats in order to provide compatibility with a broad range of browsers given their differing support for image file formats and media file formats.
+///
+/// - [type]: The MIME media type of the resource, optionally with a codecs parameter.
+/// - [src]: Address of the media resource.
+///   
+///   Required if the source element's parent is an &lt;audio&gt; and &lt;video&gt; element, but not allowed if the source element's parent is a &lt;picture&gt; element.
+Component source({String? type, String? src, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events}) {
+  return DomComponent(
+    tag: 'source',
+    key: key,
+    id: id,
+    classes: classes,
+    styles: styles,
+    attributes: {
+      ...attributes ?? {},
+      if (type != null) 'type': type,
+      if (src != null) 'src': src,
+    },
+    events: events,
   );
 }

--- a/packages/jaspr/lib/src/html/other.dart
+++ b/packages/jaspr/lib/src/html/other.dart
@@ -3,7 +3,7 @@ part of jaspr_html;
 /// The &lt;details&gt; HTML element creates a disclosure widget in which information is visible only when the widget is toggled into an "open" state. A summary or label must be provided using the &lt;summary&gt; element.
 ///
 /// - [open]: Indicates whether or not the details — that is, the contents of the &lt;details&gt; element — are currently visible.
-Component details({bool? open, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+Component details(List<Component> children, {bool? open, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events}) {
   return DomComponent(
     tag: 'details',
     key: key,
@@ -15,7 +15,6 @@ Component details({bool? open, Key? key, String? id, Iterable<String>? classes, 
       if (open == true) 'open': '',
     },
     events: events,
-    child: child,
     children: children,
   );
 }
@@ -23,7 +22,7 @@ Component details({bool? open, Key? key, String? id, Iterable<String>? classes, 
 /// The &lt;dialog&gt; HTML element represents a dialog box or other interactive component, such as a dismissible alert, inspector, or subwindow.
 ///
 /// - [open]: Indicates that the dialog is active and can be interacted with. When the open attribute is not set, the dialog shouldn't be shown to the user.
-Component dialog({bool? open, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+Component dialog(List<Component> children, {bool? open, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events}) {
   return DomComponent(
     tag: 'dialog',
     key: key,
@@ -35,13 +34,12 @@ Component dialog({bool? open, Key? key, String? id, Iterable<String>? classes, M
       if (open == true) 'open': '',
     },
     events: events,
-    child: child,
     children: children,
   );
 }
 
 /// The &lt;summary&gt; HTML element specifies a summary, caption, or legend for a &lt;details&gt; element's disclosure box. Clicking the &lt;summary&gt; element toggles the state of the parent &lt;details&gt; element open and closed.
-Component summary({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+Component summary(List<Component> children, {Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events}) {
   return DomComponent(
     tag: 'summary',
     key: key,
@@ -50,7 +48,6 @@ Component summary({Key? key, String? id, Iterable<String>? classes, Map<String, 
     styles: styles,
     attributes: attributes,
     events: events,
-    child: child,
     children: children,
   );
 }

--- a/packages/jaspr/lib/src/html/other.dart
+++ b/packages/jaspr/lib/src/html/other.dart
@@ -1,0 +1,56 @@
+part of jaspr_html;
+
+/// The &lt;details&gt; HTML element creates a disclosure widget in which information is visible only when the widget is toggled into an "open" state. A summary or label must be provided using the &lt;summary&gt; element.
+///
+/// - [open]: Indicates whether or not the details — that is, the contents of the &lt;details&gt; element — are currently visible.
+Component details({bool? open, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+  return DomComponent(
+    tag: 'details',
+    key: key,
+    id: id,
+    classes: classes,
+    styles: styles,
+    attributes: {
+      ...attributes ?? {},
+      if (open == true) 'open': '',
+    },
+    events: events,
+    child: child,
+    children: children,
+  );
+}
+
+/// The &lt;dialog&gt; HTML element represents a dialog box or other interactive component, such as a dismissible alert, inspector, or subwindow.
+///
+/// - [open]: Indicates that the dialog is active and can be interacted with. When the open attribute is not set, the dialog shouldn't be shown to the user.
+Component dialog({bool? open, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+  return DomComponent(
+    tag: 'dialog',
+    key: key,
+    id: id,
+    classes: classes,
+    styles: styles,
+    attributes: {
+      ...attributes ?? {},
+      if (open == true) 'open': '',
+    },
+    events: events,
+    child: child,
+    children: children,
+  );
+}
+
+/// The &lt;summary&gt; HTML element specifies a summary, caption, or legend for a &lt;details&gt; element's disclosure box. Clicking the &lt;summary&gt; element toggles the state of the parent &lt;details&gt; element open and closed.
+Component summary({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+  return DomComponent(
+    tag: 'summary',
+    key: key,
+    id: id,
+    classes: classes,
+    styles: styles,
+    attributes: attributes,
+    events: events,
+    child: child,
+    children: children,
+  );
+}

--- a/packages/jaspr/lib/src/html/text.dart
+++ b/packages/jaspr/lib/src/html/text.dart
@@ -1,0 +1,195 @@
+import '../../jaspr.dart';
+
+/// The &lt;a&gt; HTML element (or anchor element), with its href attribute, creates a hyperlink to web pages, files, email addresses, locations in the same page, or anything else a URL can address.
+/// 
+/// Content within each &lt;a&gt; should indicate the link's destination. If the href attribute is present, pressing the enter key while focused on the &lt;a&gt; element will activate it.
+///
+/// - [download]: Causes the browser to treat the linked URL as a download. Can be used with or without a value:
+///   
+///   Without a value, the browser will suggest a filename/extension, generated from various sources:
+///   The Content-Disposition HTTP header
+///   The final segment in the URL path
+///   The media type (from the Content-Type header, the start of a data: URL, or Blob.type for a blob: URL)
+///   Defining a value suggests it as the filename. / and \ characters are converted to underscores (_). Filesystems may forbid other characters in filenames, so browsers will adjust the suggested name if necessary.
+/// - [href]: The URL that the hyperlink points to. Links are not restricted to HTTP-based URLs — they can use any URL scheme supported by browsers:
+///   
+///   Sections of a page with fragment URLs
+///   Pieces of media files with media fragments
+///   Telephone numbers with tel: URLs
+///   Email addresses with mailto: URLs
+///   While web browsers may not support other URL schemes, web sites can with registerProtocolHandler()
+/// - [target]: Where to display the linked URL, as the name for a browsing context (a tab, window, or &lt;iframe&gt;).
+/// - [type]: Hints at the linked URL's format with a MIME type. No built-in functionality.
+Component a({String? download, required String href, Target? target, String? type, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+  return DomComponent(
+    tag: 'a',
+    key: key,
+    id: id,
+    classes: classes,
+    styles: styles,
+    attributes: {
+      ...attributes ?? {},
+      if (download != null) 'download': download,
+      'href': href,
+      if (target != null) 'target': target.value,
+      if (type != null) 'type': type,
+    },
+    events: events,
+    child: child,
+    children: children,
+  );
+}
+
+enum Target {
+  self('_self'), blank('_blank'), parent('_parent'), top('_top')
+}
+
+/// The &lt;b&gt; HTML element is used to draw the reader's attention to the element's contents, which are not otherwise granted special importance. This was formerly known as the Boldface element, and most browsers still draw the text in boldface. However, you should not use &lt;b&gt; for styling text; instead, you should use the CSS font-weight property to create boldface text, or the &lt;strong&gt; element to indicate that text is of special importance.
+Component b({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+  return DomComponent(
+    tag: 'b',
+    key: key,
+    id: id,
+    classes: classes,
+    styles: styles,
+    attributes: attributes,
+    events: events,
+    child: child,
+    children: children,
+  );
+}
+
+/// The &lt;br&gt; HTML element produces a line break in text (carriage-return). It is useful for writing a poem or an address, where the division of lines is significant.
+Component br({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+  return DomComponent(
+    tag: 'br',
+    key: key,
+    id: id,
+    classes: classes,
+    styles: styles,
+    attributes: attributes,
+    events: events,
+    child: child,
+    children: children,
+  );
+}
+
+/// The &lt;code&gt; HTML element displays its contents styled in a fashion intended to indicate that the text is a short fragment of computer code. By default, the content text is displayed using the user agent's default monospace font.
+Component code({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+  return DomComponent(
+    tag: 'code',
+    key: key,
+    id: id,
+    classes: classes,
+    styles: styles,
+    attributes: attributes,
+    events: events,
+    child: child,
+    children: children,
+  );
+}
+
+/// The &lt;em&gt; HTML element marks text that has stress emphasis. The &lt;em&gt; element can be nested, with each level of nesting indicating a greater degree of emphasis.
+Component em({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+  return DomComponent(
+    tag: 'em',
+    key: key,
+    id: id,
+    classes: classes,
+    styles: styles,
+    attributes: attributes,
+    events: events,
+    child: child,
+    children: children,
+  );
+}
+
+/// The &lt;i&gt; HTML element represents a range of text that is set off from the normal text for some reason, such as idiomatic text, technical terms, taxonomical designations, among others. Historically, these have been presented using italicized type, which is the original source of the &lt;i&gt; naming of this element.
+Component i({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+  return DomComponent(
+    tag: 'i',
+    key: key,
+    id: id,
+    classes: classes,
+    styles: styles,
+    attributes: attributes,
+    events: events,
+    child: child,
+    children: children,
+  );
+}
+
+/// The &lt;s&gt; HTML element renders text with a strikethrough, or a line through it. Use the &lt;s&gt; element to represent things that are no longer relevant or no longer accurate. However, &lt;s&gt; is not appropriate when indicating document edits; for that, use the &lt;del&gt; and &lt;ins&gt; elements, as appropriate.
+Component s({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+  return DomComponent(
+    tag: 's',
+    key: key,
+    id: id,
+    classes: classes,
+    styles: styles,
+    attributes: attributes,
+    events: events,
+    child: child,
+    children: children,
+  );
+}
+
+/// The &lt;small&gt; HTML element represents side-comments and small print, like copyright and legal text, independent of its styled presentation. By default, it renders text within it one font-size smaller, such as from small to x-small.
+Component small({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+  return DomComponent(
+    tag: 'small',
+    key: key,
+    id: id,
+    classes: classes,
+    styles: styles,
+    attributes: attributes,
+    events: events,
+    child: child,
+    children: children,
+  );
+}
+
+/// The &lt;span&gt; HTML element is a generic inline container for phrasing content, which does not inherently represent anything. It can be used to group elements for styling purposes (using the class or id attributes), or because they share attribute values, such as lang. It should be used only when no other semantic element is appropriate. &lt;span&gt; is very much like a &lt;div&gt; element, but &lt;div&gt; is a block-level element whereas a &lt;span&gt; is an inline element.
+Component span({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+  return DomComponent(
+    tag: 'span',
+    key: key,
+    id: id,
+    classes: classes,
+    styles: styles,
+    attributes: attributes,
+    events: events,
+    child: child,
+    children: children,
+  );
+}
+
+/// The &lt;strong&gt; HTML element indicates that its contents have strong importance, seriousness, or urgency. Browsers typically render the contents in bold type.
+Component strong({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+  return DomComponent(
+    tag: 'strong',
+    key: key,
+    id: id,
+    classes: classes,
+    styles: styles,
+    attributes: attributes,
+    events: events,
+    child: child,
+    children: children,
+  );
+}
+
+/// The &lt;u&gt; HTML element represents a span of inline text which should be rendered in a way that indicates that it has a non-textual annotation. This is rendered by default as a simple solid underline, but may be altered using CSS.
+Component u({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+  return DomComponent(
+    tag: 'u',
+    key: key,
+    id: id,
+    classes: classes,
+    styles: styles,
+    attributes: attributes,
+    events: events,
+    child: child,
+    children: children,
+  );
+}

--- a/packages/jaspr/lib/src/html/text.dart
+++ b/packages/jaspr/lib/src/html/text.dart
@@ -40,8 +40,20 @@ Component a({String? download, required String href, Target? target, String? typ
   );
 }
 
+
+/// The target attribute for an anchor tag. Defines where to display the linked URL, as the name for a browsing context (a tab, window, or &lt;iframe&gt;).
 enum Target {
-  self('_self'), blank('_blank'), parent('_parent'), top('_top')
+  /// The current browsing context. (Default)
+  self('_self'),
+  /// Usually a new tab, but users can configure browsers to open a new window instead.
+  blank('_blank'),
+  /// The parent browsing context of the current one. If no parent, behaves as [Target.self].
+  parent('_parent'),
+  /// The topmost browsing context (the "highest" context that's an ancestor of the current one). If no ancestors, behaves as [Target.self].
+  top('_top');
+
+  final String value;
+  const Target(this.value);
 }
 
 /// The &lt;b&gt; HTML element is used to draw the reader's attention to the element's contents, which are not otherwise granted special importance. This was formerly known as the Boldface element, and most browsers still draw the text in boldface. However, you should not use &lt;b&gt; for styling text; instead, you should use the CSS font-weight property to create boldface text, or the &lt;strong&gt; element to indicate that text is of special importance.

--- a/packages/jaspr/lib/src/html/text.dart
+++ b/packages/jaspr/lib/src/html/text.dart
@@ -21,7 +21,7 @@ part of jaspr_html;
 /// - [target]: Where to display the linked URL, as the name for a browsing context (a tab, window, or &lt;iframe&gt;).
 /// - [type]: Hints at the linked URL's format with a MIME type. No built-in functionality.
 /// - [referrerPolicy]: How much of the referrer to send when following the link.
-Component a({String? download, required String href, Target? target, String? type, ReferrerPolicy? referrerPolicy, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+Component a(List<Component> children, {String? download, required String href, Target? target, String? type, ReferrerPolicy? referrerPolicy, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events}) {
   return DomComponent(
     tag: 'a',
     key: key,
@@ -37,7 +37,6 @@ Component a({String? download, required String href, Target? target, String? typ
       if (referrerPolicy != null) 'referrerpolicy': referrerPolicy.value,
     },
     events: events,
-    child: child,
     children: children,
   );
 }
@@ -58,7 +57,7 @@ enum Target {
 }
 
 /// The &lt;b&gt; HTML element is used to draw the reader's attention to the element's contents, which are not otherwise granted special importance. This was formerly known as the Boldface element, and most browsers still draw the text in boldface. However, you should not use &lt;b&gt; for styling text; instead, you should use the CSS font-weight property to create boldface text, or the &lt;strong&gt; element to indicate that text is of special importance.
-Component b({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+Component b(List<Component> children, {Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events}) {
   return DomComponent(
     tag: 'b',
     key: key,
@@ -67,7 +66,6 @@ Component b({Key? key, String? id, Iterable<String>? classes, Map<String, String
     styles: styles,
     attributes: attributes,
     events: events,
-    child: child,
     children: children,
   );
 }
@@ -86,7 +84,7 @@ Component br({Key? key, String? id, Iterable<String>? classes, Map<String, Strin
 }
 
 /// The &lt;code&gt; HTML element displays its contents styled in a fashion intended to indicate that the text is a short fragment of computer code. By default, the content text is displayed using the user agent's default monospace font.
-Component code({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+Component code(List<Component> children, {Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events}) {
   return DomComponent(
     tag: 'code',
     key: key,
@@ -95,13 +93,12 @@ Component code({Key? key, String? id, Iterable<String>? classes, Map<String, Str
     styles: styles,
     attributes: attributes,
     events: events,
-    child: child,
     children: children,
   );
 }
 
 /// The &lt;em&gt; HTML element marks text that has stress emphasis. The &lt;em&gt; element can be nested, with each level of nesting indicating a greater degree of emphasis.
-Component em({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+Component em(List<Component> children, {Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events}) {
   return DomComponent(
     tag: 'em',
     key: key,
@@ -110,13 +107,12 @@ Component em({Key? key, String? id, Iterable<String>? classes, Map<String, Strin
     styles: styles,
     attributes: attributes,
     events: events,
-    child: child,
     children: children,
   );
 }
 
 /// The &lt;i&gt; HTML element represents a range of text that is set off from the normal text for some reason, such as idiomatic text, technical terms, taxonomical designations, among others. Historically, these have been presented using italicized type, which is the original source of the &lt;i&gt; naming of this element.
-Component i({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+Component i(List<Component> children, {Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events}) {
   return DomComponent(
     tag: 'i',
     key: key,
@@ -125,13 +121,12 @@ Component i({Key? key, String? id, Iterable<String>? classes, Map<String, String
     styles: styles,
     attributes: attributes,
     events: events,
-    child: child,
     children: children,
   );
 }
 
 /// The &lt;s&gt; HTML element renders text with a strikethrough, or a line through it. Use the &lt;s&gt; element to represent things that are no longer relevant or no longer accurate. However, &lt;s&gt; is not appropriate when indicating document edits; for that, use the &lt;del&gt; and &lt;ins&gt; elements, as appropriate.
-Component s({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+Component s(List<Component> children, {Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events}) {
   return DomComponent(
     tag: 's',
     key: key,
@@ -140,13 +135,12 @@ Component s({Key? key, String? id, Iterable<String>? classes, Map<String, String
     styles: styles,
     attributes: attributes,
     events: events,
-    child: child,
     children: children,
   );
 }
 
 /// The &lt;small&gt; HTML element represents side-comments and small print, like copyright and legal text, independent of its styled presentation. By default, it renders text within it one font-size smaller, such as from small to x-small.
-Component small({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+Component small(List<Component> children, {Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events}) {
   return DomComponent(
     tag: 'small',
     key: key,
@@ -155,13 +149,12 @@ Component small({Key? key, String? id, Iterable<String>? classes, Map<String, St
     styles: styles,
     attributes: attributes,
     events: events,
-    child: child,
     children: children,
   );
 }
 
 /// The &lt;span&gt; HTML element is a generic inline container for phrasing content, which does not inherently represent anything. It can be used to group elements for styling purposes (using the class or id attributes), or because they share attribute values, such as lang. It should be used only when no other semantic element is appropriate. &lt;span&gt; is very much like a &lt;div&gt; element, but &lt;div&gt; is a block-level element whereas a &lt;span&gt; is an inline element.
-Component span({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+Component span(List<Component> children, {Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events}) {
   return DomComponent(
     tag: 'span',
     key: key,
@@ -170,13 +163,12 @@ Component span({Key? key, String? id, Iterable<String>? classes, Map<String, Str
     styles: styles,
     attributes: attributes,
     events: events,
-    child: child,
     children: children,
   );
 }
 
 /// The &lt;strong&gt; HTML element indicates that its contents have strong importance, seriousness, or urgency. Browsers typically render the contents in bold type.
-Component strong({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+Component strong(List<Component> children, {Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events}) {
   return DomComponent(
     tag: 'strong',
     key: key,
@@ -185,13 +177,12 @@ Component strong({Key? key, String? id, Iterable<String>? classes, Map<String, S
     styles: styles,
     attributes: attributes,
     events: events,
-    child: child,
     children: children,
   );
 }
 
 /// The &lt;u&gt; HTML element represents a span of inline text which should be rendered in a way that indicates that it has a non-textual annotation. This is rendered by default as a simple solid underline, but may be altered using CSS.
-Component u({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+Component u(List<Component> children, {Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events}) {
   return DomComponent(
     tag: 'u',
     key: key,
@@ -200,7 +191,6 @@ Component u({Key? key, String? id, Iterable<String>? classes, Map<String, String
     styles: styles,
     attributes: attributes,
     events: events,
-    child: child,
     children: children,
   );
 }

--- a/packages/jaspr/lib/src/html/text.dart
+++ b/packages/jaspr/lib/src/html/text.dart
@@ -1,4 +1,4 @@
-import '../../jaspr.dart';
+part of jaspr_html;
 
 /// The &lt;a&gt; HTML element (or anchor element), with its href attribute, creates a hyperlink to web pages, files, email addresses, locations in the same page, or anything else a URL can address.
 /// 
@@ -20,7 +20,8 @@ import '../../jaspr.dart';
 ///   While web browsers may not support other URL schemes, web sites can with registerProtocolHandler()
 /// - [target]: Where to display the linked URL, as the name for a browsing context (a tab, window, or &lt;iframe&gt;).
 /// - [type]: Hints at the linked URL's format with a MIME type. No built-in functionality.
-Component a({String? download, required String href, Target? target, String? type, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+/// - [referrerPolicy]: How much of the referrer to send when following the link.
+Component a({String? download, required String href, Target? target, String? type, ReferrerPolicy? referrerPolicy, Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
   return DomComponent(
     tag: 'a',
     key: key,
@@ -33,6 +34,7 @@ Component a({String? download, required String href, Target? target, String? typ
       'href': href,
       if (target != null) 'target': target.value,
       if (type != null) 'type': type,
+      if (referrerPolicy != null) 'referrerpolicy': referrerPolicy.value,
     },
     events: events,
     child: child,
@@ -40,8 +42,7 @@ Component a({String? download, required String href, Target? target, String? typ
   );
 }
 
-
-/// The target attribute for an anchor tag. Defines where to display the linked URL, as the name for a browsing context (a tab, window, or &lt;iframe&gt;).
+/// The name/keyword for a browsing context (a tab, window, or &lt;iframe&gt;).
 enum Target {
   /// The current browsing context. (Default)
   self('_self'),
@@ -72,7 +73,7 @@ Component b({Key? key, String? id, Iterable<String>? classes, Map<String, String
 }
 
 /// The &lt;br&gt; HTML element produces a line break in text (carriage-return). It is useful for writing a poem or an address, where the division of lines is significant.
-Component br({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {
+Component br({Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events}) {
   return DomComponent(
     tag: 'br',
     key: key,
@@ -81,8 +82,6 @@ Component br({Key? key, String? id, Iterable<String>? classes, Map<String, Strin
     styles: styles,
     attributes: attributes,
     events: events,
-    child: child,
-    children: children,
   );
 }
 

--- a/packages/jaspr/tool/data/html.json
+++ b/packages/jaspr/tool/data/html.json
@@ -1,0 +1,368 @@
+{
+  "content": {
+    "article": {
+      "doc": "The &lt;article&gt; HTML element represents a self-contained composition in a document, page, application, or site, which is intended to be independently distributable or reusable (e.g., in syndication). Examples include: a forum post, a magazine or newspaper article, or a blog entry, a product card, a user-submitted comment, an interactive widget or gadget, or any other independent item of content."
+    },
+    "aside": {
+      "doc": "The &lt;aside&gt; HTML element represents a portion of a document whose content is only indirectly related to the document's main content. Asides are frequently presented as sidebars or call-out boxes."
+    },
+    "footer": {
+      "doc": "The &lt;footer&gt; HTML element represents a footer for its nearest ancestor sectioning content or sectioning root element. A &lt;footer&gt; typically contains information about the author of the section, copyright data or links to related documents."
+    },
+    "header": {
+      "doc": "The &lt;header&gt; HTML element represents introductory content, typically a group of introductory or navigational aids. It may contain some heading elements but also a logo, a search form, an author name, and other elements."
+    },
+    "h1": {
+      "doc": "The &lt;h1&gt; to &lt;h6&gt; HTML elements represent six levels of section headings. &lt;h1&gt; is the highest section level and &lt;h6&gt; is the lowest."
+    },
+    "h2": {
+      "doc": "The &lt;h1&gt; to &lt;h6&gt; HTML elements represent six levels of section headings. &lt;h1&gt; is the highest section level and &lt;h6&gt; is the lowest."
+    },
+    "h3": {
+      "doc": "The &lt;h1&gt; to &lt;h6&gt; HTML elements represent six levels of section headings. &lt;h1&gt; is the highest section level and &lt;h6&gt; is the lowest."
+    },
+    "h4": {
+      "doc": "The &lt;h1&gt; to &lt;h6&gt; HTML elements represent six levels of section headings. &lt;h1&gt; is the highest section level and &lt;h6&gt; is the lowest."
+    },
+    "h5": {
+      "doc": "The &lt;h1&gt; to &lt;h6&gt; HTML elements represent six levels of section headings. &lt;h1&gt; is the highest section level and &lt;h6&gt; is the lowest."
+    },
+    "h6": {
+      "doc": "The &lt;h1&gt; to &lt;h6&gt; HTML elements represent six levels of section headings. &lt;h1&gt; is the highest section level and &lt;h6&gt; is the lowest."
+    },
+    "main": {
+      "doc": "The &lt;main&gt; HTML element represents the dominant content of the &lt;body&gt; of a document. The main content area consists of content that is directly related to or expands upon the central topic of a document, or the central functionality of an application."
+    },
+    "nav": {
+      "doc": "The &lt;nav&gt; HTML element represents a section of a page whose purpose is to provide navigation links, either within the current document or to other documents. Common examples of navigation sections are menus, tables of contents, and indexes."
+    },
+    "section": {
+      "doc": "The &lt;section&gt; HTML element represents a generic standalone section of a document, which doesn't have a more specific semantic element to represent it. Sections should always have a heading, with very few exceptions."
+    },
+    "div": {
+      "doc": "The &lt;div&gt; HTML element is the generic container for flow content. It has no effect on the content or layout until styled in some way using CSS (e.g. styling is directly applied to it, or some kind of layout model like Flexbox is applied to its parent element)."
+    },
+    "ul": {
+      "doc": "The &lt;ul&gt; HTML element represents an unordered list of items, typically rendered as a bulleted list."
+    },
+    "ol": {
+      "doc": "The &lt;ol&gt; HTML element represents an ordered list of items — typically rendered as a numbered list.",
+      "attributes": {
+        "reversed": {
+          "doc": "This Boolean attribute specifies that the list's items are in reverse order. Items will be numbered from high to low.",
+          "type": "boolean"
+        },
+        "start": {
+          "doc": "An integer to start counting from for the list items. Always an Arabic numeral (1, 2, 3, etc.), even when the numbering type is letters or Roman numerals. For example, to start numbering elements from the letter \"d\" or the Roman numeral \"iv,\" use start=\"4\".",
+          "type": "int"
+        },
+        "type": {
+          "doc": "Sets the numbering type\nThe specified type is used for the entire list unless a different type attribute is used on an enclosed &lt;li&gt; element.",
+          "type": {
+            "name": "ListType",
+            "doc": "Them numbering type for a list element.",
+            "values": {
+              "lowercaseLetters": {
+                "value": "a",
+                "doc": "For lowercase letters"
+              },
+              "uppercaseLetters": {
+                "value": "A",
+                "doc": "For uppercase letters"
+              },
+              "lowercaseRomanNumerals": {
+                "value": "i",
+                "doc": "For lowercase Roman numerals"
+              },
+              "uppercaseRomanNumerals": {
+                "value": "I",
+                "doc": "For uppercase Roman numerals"
+              },
+              "numbers": {
+                "value": "1",
+                "doc": "For numbers (default)"
+              }
+            }
+          }
+        }
+      }
+    },
+    "li": {
+      "doc": "The &lt;li&gt; HTML element is used to represent an item in a list. It must be contained in a parent element: an ordered list (&lt;ol&gt;), an unordered list (&lt;ul&gt;), or a menu (&lt;menu&gt;). In menus and unordered lists, list items are usually displayed using bullet points. In ordered lists, they are usually displayed with an ascending counter on the left, such as a number or letter.",
+      "attributes": {
+        "value": {
+          "doc": "This integer attribute indicates the current ordinal value of the list item as defined by the &lt;ol&gt; element. The only allowed value for this attribute is a number, even if the list is displayed with Roman numerals or letters. List items that follow this one continue numbering from the value set. The value attribute has no meaning for unordered lists (&lt;ul&gt;) or for menus (&lt;menu&gt;).",
+          "type": "int"
+        }
+      }
+    },
+    "hr": {
+      "doc": "The &lt;hr&gt; HTML element represents a thematic break between paragraph-level elements: for example, a change of scene in a story, or a shift of topic within a section."
+    },
+    "p": {
+      "doc": "The &lt;p&gt; HTML element represents a paragraph. Paragraphs are usually represented in visual media as blocks of text separated from adjacent blocks by blank lines and/or first-line indentation, but HTML paragraphs can be any structural grouping of related content, such as images or form fields."
+    },
+    "pre": {
+      "doc": "The &lt;pre&gt; HTML element represents preformatted text which is to be presented exactly as written in the HTML file. The text is typically rendered using a non-proportional, or monospaced, font. Whitespace inside this element is displayed as written."
+    }
+  },
+  "text": {
+    "a": {
+      "doc": "The &lt;a&gt; HTML element (or anchor element), with its href attribute, creates a hyperlink to web pages, files, email addresses, locations in the same page, or anything else a URL can address.\n\nContent within each &lt;a&gt; should indicate the link's destination. If the href attribute is present, pressing the enter key while focused on the &lt;a&gt; element will activate it.",
+      "attributes":{
+        "download": {
+          "doc": "Causes the browser to treat the linked URL as a download. Can be used with or without a value:\n\nWithout a value, the browser will suggest a filename/extension, generated from various sources:\nThe Content-Disposition HTTP header\nThe final segment in the URL path\nThe media type (from the Content-Type header, the start of a data: URL, or Blob.type for a blob: URL)\nDefining a value suggests it as the filename. / and \\ characters are converted to underscores (_). Filesystems may forbid other characters in filenames, so browsers will adjust the suggested name if necessary.",
+          "type": "string"
+        },
+        "href": {
+          "doc": "The URL that the hyperlink points to. Links are not restricted to HTTP-based URLs — they can use any URL scheme supported by browsers:\n\nSections of a page with fragment URLs\nPieces of media files with media fragments\nTelephone numbers with tel: URLs\nEmail addresses with mailto: URLs\nWhile web browsers may not support other URL schemes, web sites can with registerProtocolHandler()",
+          "type": "string",
+          "required": true
+        },
+        "target": {
+          "doc": "Where to display the linked URL, as the name for a browsing context (a tab, window, or &lt;iframe&gt;).",
+          "type": {
+            "name": "Target",
+            "doc": "The target attribute for an anchor tag. Defines where to display the linked URL, as the name for a browsing context (a tab, window, or &lt;iframe&gt;).",
+            "values": {
+              "self": {
+                "value": "_self",
+                "doc": "The current browsing context. (Default)"
+              },
+              "blank": {
+                "value": "_blank",
+                "doc": "Usually a new tab, but users can configure browsers to open a new window instead."
+              },
+              "parent": {
+                "value": "_parent",
+                "doc": "The parent browsing context of the current one. If no parent, behaves as [Target.self]."
+              },
+              "top": {
+                "value": "_top",
+                "doc": "The topmost browsing context (the \"highest\" context that's an ancestor of the current one). If no ancestors, behaves as [Target.self]."
+              }
+            }
+          }
+        },
+        "type": {
+          "doc": "Hints at the linked URL's format with a MIME type. No built-in functionality.",
+          "type": "string"
+        }
+      }
+    },
+    "b": {
+      "doc": "The &lt;b&gt; HTML element is used to draw the reader's attention to the element's contents, which are not otherwise granted special importance. This was formerly known as the Boldface element, and most browsers still draw the text in boldface. However, you should not use &lt;b&gt; for styling text; instead, you should use the CSS font-weight property to create boldface text, or the &lt;strong&gt; element to indicate that text is of special importance."
+    },
+    "br": {
+      "doc": "The &lt;br&gt; HTML element produces a line break in text (carriage-return). It is useful for writing a poem or an address, where the division of lines is significant.",
+      "self_closing": true
+    },
+    "code": {
+      "doc": "The &lt;code&gt; HTML element displays its contents styled in a fashion intended to indicate that the text is a short fragment of computer code. By default, the content text is displayed using the user agent's default monospace font."
+    },
+    "em": {
+      "doc": "The &lt;em&gt; HTML element marks text that has stress emphasis. The &lt;em&gt; element can be nested, with each level of nesting indicating a greater degree of emphasis."
+    },
+    "i": {
+      "doc": "The &lt;i&gt; HTML element represents a range of text that is set off from the normal text for some reason, such as idiomatic text, technical terms, taxonomical designations, among others. Historically, these have been presented using italicized type, which is the original source of the &lt;i&gt; naming of this element."
+    },
+    "s": {
+      "doc": "The &lt;s&gt; HTML element renders text with a strikethrough, or a line through it. Use the &lt;s&gt; element to represent things that are no longer relevant or no longer accurate. However, &lt;s&gt; is not appropriate when indicating document edits; for that, use the &lt;del&gt; and &lt;ins&gt; elements, as appropriate."
+    },
+    "small": {
+      "doc": "The &lt;small&gt; HTML element represents side-comments and small print, like copyright and legal text, independent of its styled presentation. By default, it renders text within it one font-size smaller, such as from small to x-small."
+    },
+    "span": {
+      "doc": "The &lt;span&gt; HTML element is a generic inline container for phrasing content, which does not inherently represent anything. It can be used to group elements for styling purposes (using the class or id attributes), or because they share attribute values, such as lang. It should be used only when no other semantic element is appropriate. &lt;span&gt; is very much like a &lt;div&gt; element, but &lt;div&gt; is a block-level element whereas a &lt;span&gt; is an inline element."
+    },
+    "strong": {
+      "doc": "The &lt;strong&gt; HTML element indicates that its contents have strong importance, seriousness, or urgency. Browsers typically render the contents in bold type."
+    },
+    "u": {
+      "doc": "The &lt;u&gt; HTML element represents a span of inline text which should be rendered in a way that indicates that it has a non-textual annotation. This is rendered by default as a simple solid underline, but may be altered using CSS."
+    }
+  },
+  "media": {
+    "audio": {
+      "doc": "The &lt;audio&gt; HTML element is used to embed sound content in documents. It may contain one or more audio sources, represented using the src attribute or the &lt;source&gt; element: the browser will choose the most suitable one. It can also be the destination for streamed media, using a MediaStream.",
+      "attributes": {
+        "autoplay": {
+          "doc": "A Boolean attribute: if specified, the audio will automatically begin playback as soon as it can do so, without waiting for the entire audio file to finish downloading.",
+          "type": "boolean"
+        },
+        "controls": {
+          "doc": "If this attribute is present, the browser will offer controls to allow the user to control audio playback, including volume, seeking, and pause/resume playback.",
+          "type": "boolean"
+        },
+        "crossorigin": {
+          "name": "crossOrigin",
+          "doc": "Indicates whether to use CORS to fetch the related audio file.",
+          "type": {
+            "name": "CrossOrigin",
+            "doc": "Indicates if the fetching of the media must be done using a CORS request. Media data from a CORS request can be reused in the &lt;canvas&gt; element without being marked \"tainted\". If the crossorigin attribute is not specified, then a non-CORS request is sent (without the Origin request header), and the browser marks the media as tainted and restricts access to its data, preventing its usage in &lt;canvas&gt; elements. If the crossorigin attribute is specified, then a CORS request is sent (with the Origin request header); but if the server does not opt into allowing cross-origin access to the media data by the origin site (by not sending any Access-Control-Allow-Origin response header, or by not including the site's origin in any Access-Control-Allow-Origin response header it does send), then the browser blocks the media from loading, and logs a CORS error to the devtools console.",
+            "values": {
+              "anonymous": {
+                "doc": "Sends a cross-origin request without a credential. In other words, it sends the Origin: HTTP header without a cookie, X.509 certificate, or performing HTTP Basic authentication. If the server does not give credentials to the origin site (by not setting the Access-Control-Allow-Origin: HTTP header), the image will be tainted, and its usage restricted."
+              },
+              "useCredentials": {
+                "value": "use-credentials",
+                "doc": "Sends a cross-origin request with a credential. In other words, it sends the Origin: HTTP header with a cookie, a certificate, or performing HTTP Basic authentication. If the server does not give credentials to the origin site (through Access-Control-Allow-Credentials: HTTP header), the image will be tainted and its usage restricted."
+              }
+            }
+          }
+        },
+        "loop": {
+          "doc": "If specified, the audio player will automatically seek back to the start upon reaching the end of the audio.",
+          "type": "boolean"
+        },
+        "muted": {
+          "doc": "Indicates whether the audio will be initially silenced. Its default value is false.",
+          "type": "boolean"
+        },
+        "preload": {
+          "doc": "Provides a hint to the browser about what the author thinks will lead to the best user experience.",
+          "type": {
+            "name": "Preload",
+            "doc": "Intended to provide a hint to the browser about what the author thinks will lead to the best user experience when loading a media object.\nThe default value is different for each browser. The spec advises it to be set to [Preload.metadata].",
+            "values": {
+              "none": {
+                "doc": "Indicates that the audio should not be preloaded."
+              },
+              "metadata": {
+                "doc": "Indicates that only audio metadata (e.g. length) is fetched."
+              },
+              "auto": {
+                "doc": "Indicates that the whole audio file can be downloaded, even if the user is not expected to use it."
+              }
+            }
+          }
+        },
+        "src": {
+          "doc": "The URL of the audio to embed. This is subject to HTTP access controls. This is optional; you may instead use the &lt;source&gt; element within the audio block to specify the audio to embed.",
+          "type": "string"
+        }
+      }
+    },
+    "img": {
+      "doc": "The &lt;img&gt; HTML element embeds an image into the document.",
+      "attributes": {
+        "alt": {
+          "doc": "Defines an alternative text description of the image",
+          "type": "string"
+        },
+        "crossorigin": {
+          "name": "crossOrigin",
+          "doc": "Indicates if the fetching of the image must be done using a CORS request.",
+          "type": "enum:CrossOrigin"
+        },
+        "width": {
+          "doc": "The intrinsic width of the image in pixels.",
+          "type": "int"
+        },
+        "height": {
+          "doc": "The intrinsic height of the image, in pixels.",
+          "type": "int"
+        },
+        "loading": {
+          "doc": "Indicates how the browser should load the image.",
+          "type": {
+            "name": "ImageLoading",
+            "doc": "Indicates how the browser should load the image. Loading is only deferred when JavaScript is enabled.",
+            "values": {
+              "eager": {
+                "doc": "Loads the image immediately, regardless of whether or not the image is currently within the visible viewport (this is the default value)."
+              },
+              "lazy": {
+                "doc": "Defers loading the image until it reaches a calculated distance from the viewport, as defined by the browser. The intent is to avoid the network and storage bandwidth needed to handle the image until it's reasonably certain that it will be needed. This generally improves the performance of the content in most typical use cases."
+              }
+            }
+          }
+        },
+        "src": {
+          "doc": "The image URL.",
+          "type": "string",
+          "required": true
+        }
+      }
+    },
+    "video": {
+      "doc": "The &lt;video&gt; HTML element embeds a media player which supports video playback into the document. You can use &lt;video&gt; for audio content as well, but the &lt;audio&gt; element may provide a more appropriate user experience.",
+      "attributes": {
+        "autoplay": {
+          "doc": "Indicates if the video automatically begins to play back as soon as it can do so without stopping to finish loading the data.",
+          "type": "boolean"
+        },
+        "controls": {
+          "doc": "If this attribute is present, the browser will offer controls to allow the user to control video playback, including volume, seeking, and pause/resume playback.",
+          "type": "boolean"
+        },
+        "crossorigin": {
+          "name": "crossOrigin",
+          "doc": "Indicates whether to use CORS to fetch the related video.",
+          "type": "enum:CrossOrigin"
+        },
+        "loop": {
+          "doc": "If specified, the browser will automatically seek back to the start upon reaching the end of the video.",
+          "type": "boolean"
+        },
+        "muted": {
+          "doc": "Indicates the default setting of the audio contained in the video. If set, the audio will be initially silenced. Its default value is false, meaning that the audio will be played when the video is played.",
+          "type": "boolean"
+        },
+        "poster": {
+          "doc": "A URL for an image to be shown while the video is downloading. If this attribute isn't specified, nothing is displayed until the first frame is available, then the first frame is shown as the poster frame.",
+          "type": "string"
+        },
+        "preload": {
+          "doc": "Provides a hint to the browser about what the author thinks will lead to the best user experience with regards to what content is loaded before the video is played.",
+          "type": "enum:Preload"
+        },
+        "src": {
+          "doc": "The URL of the video to embed. This is optional; you may instead use the &lt;source&gt; element within the video block to specify the video to embed.",
+          "type": "string"
+        },
+        "width": {
+          "doc": "The width of the video's display area, in CSS pixels.",
+          "type": "int"
+        },
+        "height": {
+          "doc": "The height of the video's display area, in CSS pixels.",
+          "type": "int"
+        }
+      }
+    }
+  },
+  "forms": {
+    "button": {
+      "doc": "The &lt;button&gt; HTML element is an interactive element activated by a user with a mouse, keyboard, finger, voice command, or other assistive technology. Once activated, it then performs a programmable action, such as submitting a form or opening a dialog.",
+      "attributes": {
+        "autofocus": {
+          "doc": "Specifies that the button should have input focus when the page loads. Only one element in a document can have this attribute.",
+          "type": "boolean"
+        },
+        "disabled": {
+          "doc": "Prevents the user from interacting with the button: it cannot be pressed or focused.",
+          "type": "boolean"
+        },
+        "type": {
+          "doc": "The default behavior of the button.",
+          "type": {
+            "name": "ButtonType",
+            "doc": "Defines the default behavior of a button.",
+            "values": {
+              "submit": {
+                "doc": "The button submits the form data to the server. This is the default if the attribute is not specified for buttons associated with a &lt;form&gt;, or if the attribute is an empty or invalid value."
+              },
+              "reset": {
+                "doc": "The button resets all the controls to their initial values, like &lt;input type=\"reset\"&gt;. (This behavior tends to annoy users.)"
+              },
+              "button": {
+                "doc": "The button has no default behavior, and does nothing when pressed by default. It can have client-side scripts listen to the element's events, which are triggered when the events occur."
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/jaspr/tool/data/html.json
+++ b/packages/jaspr/tool/data/html.json
@@ -30,9 +30,6 @@
     "h6": {
       "doc": "The &lt;h1&gt; to &lt;h6&gt; HTML elements represent six levels of section headings. &lt;h1&gt; is the highest section level and &lt;h6&gt; is the lowest."
     },
-    "main": {
-      "doc": "The &lt;main&gt; HTML element represents the dominant content of the &lt;body&gt; of a document. The main content area consists of content that is directly related to or expands upon the central topic of a document, or the central functionality of an application."
-    },
     "nav": {
       "doc": "The &lt;nav&gt; HTML element represents a section of a page whose purpose is to provide navigation links, either within the current document or to other documents. Common examples of navigation sections are menus, tables of contents, and indexes."
     },
@@ -106,7 +103,8 @@
       }
     },
     "hr": {
-      "doc": "The &lt;hr&gt; HTML element represents a thematic break between paragraph-level elements: for example, a change of scene in a story, or a shift of topic within a section."
+      "doc": "The &lt;hr&gt; HTML element represents a thematic break between paragraph-level elements: for example, a change of scene in a story, or a shift of topic within a section.",
+      "self_closing": true
     },
     "p": {
       "doc": "The &lt;p&gt; HTML element represents a paragraph. Paragraphs are usually represented in visual media as blocks of text separated from adjacent blocks by blank lines and/or first-line indentation, but HTML paragraphs can be any structural grouping of related content, such as images or form fields."

--- a/packages/jaspr/tool/data/html.json
+++ b/packages/jaspr/tool/data/html.json
@@ -39,6 +39,15 @@
     "section": {
       "doc": "The &lt;section&gt; HTML element represents a generic standalone section of a document, which doesn't have a more specific semantic element to represent it. Sections should always have a heading, with very few exceptions."
     },
+    "blockquote": {
+      "doc": "The &lt;blockquote&gt; HTML element indicates that the enclosed text is an extended quotation. Usually, this is rendered visually by indentation. A URL for the source of the quotation may be given using the cite attribute, while a text representation of the source can be given using the &lt;cite&gt; element.",
+      "attributes": {
+        "cite": {
+          "doc": "A URL that designates a source document or message for the information quoted. This attribute is intended to point to information explaining the context or the reference for the quote.",
+          "type": "string"
+        }
+      }
+    },
     "div": {
       "doc": "The &lt;div&gt; HTML element is the generic container for flow content. It has no effect on the content or layout until styled in some way using CSS (e.g. styling is directly applied to it, or some kind of layout model like Flexbox is applied to its parent element)."
     },
@@ -123,7 +132,7 @@
           "doc": "Where to display the linked URL, as the name for a browsing context (a tab, window, or &lt;iframe&gt;).",
           "type": {
             "name": "Target",
-            "doc": "The target attribute for an anchor tag. Defines where to display the linked URL, as the name for a browsing context (a tab, window, or &lt;iframe&gt;).",
+            "doc": "The name/keyword for a browsing context (a tab, window, or &lt;iframe&gt;).",
             "values": {
               "self": {
                 "value": "_self",
@@ -147,6 +156,11 @@
         "type": {
           "doc": "Hints at the linked URL's format with a MIME type. No built-in functionality.",
           "type": "string"
+        },
+        "referrerpolicy": {
+          "name": "referrerPolicy",
+          "doc": "How much of the referrer to send when following the link.",
+          "type": "enum:ReferrerPolicy"
         }
       }
     },
@@ -245,6 +259,7 @@
     },
     "img": {
       "doc": "The &lt;img&gt; HTML element embeds an image into the document.",
+      "self_closing": true,
       "attributes": {
         "alt": {
           "doc": "Defines an alternative text description of the image",
@@ -266,14 +281,14 @@
         "loading": {
           "doc": "Indicates how the browser should load the image.",
           "type": {
-            "name": "ImageLoading",
-            "doc": "Indicates how the browser should load the image. Loading is only deferred when JavaScript is enabled.",
+            "name": "MediaLoading",
+            "doc": "Indicates how the browser should load the media. Loading is only deferred when JavaScript is enabled.",
             "values": {
               "eager": {
-                "doc": "Loads the image immediately, regardless of whether or not the image is currently within the visible viewport (this is the default value)."
+                "doc": "Loads the media immediately, regardless of whether or not the media is currently within the visible viewport (this is the default value)."
               },
               "lazy": {
-                "doc": "Defers loading the image until it reaches a calculated distance from the viewport, as defined by the browser. The intent is to avoid the network and storage bandwidth needed to handle the image until it's reasonably certain that it will be needed. This generally improves the performance of the content in most typical use cases."
+                "doc": "Defers loading the media until it reaches a calculated distance from the viewport, as defined by the browser. The intent is to avoid the network and storage bandwidth needed to handle the media until it's reasonably certain that it will be needed. This generally improves the performance of the media in most typical use cases."
               }
             }
           }
@@ -282,6 +297,11 @@
           "doc": "The image URL.",
           "type": "string",
           "required": true
+        },
+        "referrerpolicy": {
+          "name": "referrerPolicy",
+          "doc": "Indicates which referrer to send when fetching the resource.",
+          "type": "enum:ReferrerPolicy"
         }
       }
     },
@@ -330,6 +350,147 @@
           "type": "int"
         }
       }
+    },
+    "embed": {
+      "doc": "The &lt;embed&gt; HTML element embeds external content at the specified point in the document. This content is provided by an external application or other source of interactive content such as a browser plug-in.",
+      "self_closing": true,
+      "attributes": {
+        "src": {
+          "doc": "The URL of the resource being embedded.",
+          "type": "string",
+          "required": true
+        },
+        "type": {
+          "doc": "The MIME type to use to select the plug-in to instantiate.",
+          "type": "string"
+        },
+        "width": {
+          "doc": "The displayed width of the resource, in CSS pixels.",
+          "type": "int"
+        },
+        "height": {
+          "doc": "The displayed height of the resource, in CSS pixels.",
+          "type": "int"
+        }
+      }
+    },
+    "iframe": {
+      "doc": "The &lt;iframe&gt; HTML element represents a nested browsing context, embedding another HTML page into the current one.",
+      "attributes": {
+        "src": {
+          "doc": "The URL of the page to embed. Use a value of about:blank to embed an empty page that conforms to the same-origin policy. Also note that programmatically removing an &lt;iframe&gt;'s src attribute (e.g. via Element.removeAttribute()) causes about:blank to be loaded in the frame in Firefox (from version 65), Chromium-based browsers, and Safari/iOS.",
+          "type": "string",
+          "required": true
+        },
+        "allow": {
+          "doc": "Specifies a feature policy for the &lt;iframe&gt;. The policy defines what features are available to the &lt;iframe&gt; based on the origin of the request (e.g. access to the microphone, camera, battery, web-share API, etc.).",
+          "type": "string"
+        },
+        "csp": {
+          "doc": "A Content Security Policy enforced for the embedded resource.",
+          "type": "string"
+        },
+        "loading": {
+          "doc": "Indicates how the browser should load the iframe.",
+          "type": "enum:MediaLoading"
+        },
+        "name": {
+          "doc": "A targetable name for the embedded browsing context. This can be used in the target attribute of the &lt;a&gt;, &lt;form&gt;, or &lt;base&gt; elements; the formtarget attribute of the &lt;input&gt; or &lt;button&gt; elements; or the windowName parameter in the window.open() method.",
+          "type": "string"
+        },
+        "sandbox": {
+          "doc": "Applies extra restrictions to the content in the frame. The value of the attribute can either be empty to apply all restrictions, or space-separated tokens to lift particular restrictions.",
+          "type": "string"
+        },
+        "referrerpolicy": {
+          "name": "referrerPolicy",
+          "doc": "Indicates which referrer to send when fetching the frame's resource.",
+          "type": {
+            "name": "ReferrerPolicy",
+            "doc": "The Referrer-Policy controls how much referrer information (sent with the Referer header) should be included with requests.",
+            "values": {
+              "noReferrer": {
+                "value": "no-referrer",
+                "doc": "The Referer header will not be sent."
+              },
+              "noReferrerWhenDowngrade": {
+                "value": "no-referrer-when-downgrade",
+                "doc": "The Referer header will not be sent to origins without TLS (HTTPS)."
+              },
+              "origin": {
+                "doc": "The sent referrer will be limited to the origin of the referring page: its scheme, host, and port."
+              },
+              "originWhenCrossOrigin": {
+                "value": "origin-when-cross-origin",
+                "doc": "The referrer sent to other origins will be limited to the scheme, the host, and the port. Navigations on the same origin will still include the path."
+              },
+              "sameOrigin": {
+                "value": "same-origin",
+                "doc": "A referrer will be sent for same origin, but cross-origin requests will contain no referrer information."
+              },
+              "strictOrigin": {
+                "value": "strict-origin",
+                "doc": "Only send the origin of the document as the referrer when the protocol security level stays the same (HTTPS→HTTPS), but don't send it to a less secure destination (HTTPS→HTTP)."
+              },
+              "strictOriginWhenCrossOrigin": {
+                "value": "strict-origin-when-cross-origin",
+                "doc": "(default): Send a full URL when performing a same-origin request, only send the origin when the protocol security level stays the same (HTTPS→HTTPS), and send no header to a less secure destination (HTTPS→HTTP)."
+              },
+              "unsafeUrl": {
+                "value": "unsafe-url",
+                "doc": "The referrer will include the origin and the path (but not the fragment, password, or username). This value is unsafe, because it leaks origins and paths from TLS-protected resources to insecure origins."
+              }
+            }
+          }
+        },
+        "width": {
+          "doc": "The width of the frame in CSS pixels. Default is 300.",
+          "type": "int"
+        },
+        "height": {
+          "doc": "The height of the frame in CSS pixels. Default is 150.",
+          "type": "int"
+        }
+      }
+    },
+    "object": {
+      "doc": "The &lt;object&gt; HTML element represents an external resource, which can be treated as an image, a nested browsing context, or a resource to be handled by a plugin.",
+      "attributes": {
+        "data": {
+          "doc": "The address of the resource as a valid URL. At least one of data and type must be defined.",
+          "type": "string"
+        },
+        "name": {
+          "doc": "The name of valid browsing context (HTML5).",
+          "type": "string"
+        },
+        "type": {
+          "doc": "The content type of the resource specified by data. At least one of data and type must be defined.",
+          "type": "string"
+        },
+        "width": {
+          "doc": "The width of the displayed resource in CSS pixels.",
+          "type": "int"
+        },
+        "height": {
+          "doc": "The height of the displayed resource in CSS pixels.",
+          "type": "int"
+        }
+      }
+    },
+    "source": {
+      "doc": "The &lt;source&gt; HTML element specifies multiple media resources for the &lt;picture&gt;, the &lt;audio&gt; element, or the &lt;video&gt; element. It is an empty element, meaning that it has no content and does not have a closing tag. It is commonly used to offer the same media content in multiple file formats in order to provide compatibility with a broad range of browsers given their differing support for image file formats and media file formats.",
+      "self_closing": true,
+      "attributes": {
+        "type": {
+          "doc": "The MIME media type of the resource, optionally with a codecs parameter.",
+          "type": "string"
+        },
+        "src": {
+          "doc": "Address of the media resource.\n\nRequired if the source element's parent is an &lt;audio&gt; and &lt;video&gt; element, but not allowed if the source element's parent is a &lt;picture&gt; element.",
+          "type": "string"
+        }
+      }
     }
   },
   "forms": {
@@ -363,6 +524,410 @@
           }
         }
       }
+    },
+    "form": {
+      "doc": "The &lt;form&gt; HTML element represents a document section containing interactive controls for submitting information.",
+      "attributes": {
+        "action": {
+          "doc": "The URL that processes the form submission. This value can be overridden by a formaction attribute on a &lt;button&gt;, &lt;input type=\"submit\"&gt;, or &lt;input type=\"image\"&gt; element. This attribute is ignored when method=\"dialog\" is set.",
+          "type": "string"
+        },
+        "method": {
+          "doc": "The HTTP method to submit the form with.\n\nThis value is overridden by formmethod attributes on &lt;button&gt;, &lt;input type=\"submit\"&gt;, or &lt;input type=\"image\"&gt; elements.",
+          "type": {
+            "name": "FormMethod",
+            "doc": "The HTTP method to submit a form with.",
+            "values": {
+              "post": {
+                "doc": "The POST method; form data sent as the request body."
+              },
+              "get": {
+                "doc": "The GET method; form data appended to the action URL with a ? separator. Use this method when the form has no side-effects."
+              },
+              "dialog": {
+                "doc": "When the form is inside a &lt;dialog&gt;, closes the dialog and throws a submit event on submission without submitting data or clearing the form."
+              }
+            }
+          }
+        },
+        "enctype": {
+          "name": "encType",
+          "doc": "If the value of the method attribute is post, enctype is the MIME type of the form submission.",
+          "type": {
+            "name": "FormEncType",
+            "doc": "The MIME type of a form submission.",
+            "values": {
+              "formUrlEncoded": {
+                "value": "application/x-www-form-urlencoded",
+                "doc": "The default value"
+              },
+              "multiPart": {
+                "value": "multipart/form-data",
+                "doc": "Use this if the form contains &lt;input&gt; elements with type=file."
+              },
+              "text": {
+                "value": "text/plain",
+                "doc": "Introduced by HTML5 for debugging purposes."
+              }
+            }
+          }
+        },
+        "autocomplete": {
+          "name": "autoComplete",
+          "doc": "Indicates whether input elements can by default have their values automatically completed by the browser. autocomplete attributes on form elements override it on &lt;form&gt;.",
+          "type": {
+            "name": "AutoComplete",
+            "doc": "Indicates whether input elements can by default have their values automatically completed by the browser. autocomplete attributes on form elements override it on &lt;form&gt;.",
+            "values": {
+              "off": {
+                "doc": "The browser may not automatically complete entries."
+              },
+              "on": {
+                "doc": "The browser may automatically complete entries."
+              }
+            }
+          }
+        },
+        "name": {
+          "doc": "The name of the form. The value must not be the empty string, and must be unique among the form elements in the forms collection that it is in, if any.",
+          "type": "string"
+        },
+        "novalidate": {
+          "name": "noValidate",
+          "doc": "Indicates that the form shouldn't be validated when submitted. If this attribute is not set (and therefore the form is validated), it can be overridden by a formnovalidate attribute on a &lt;button&gt;, &lt;input type=\"submit\"&gt;, or &lt;input type=\"image\"&gt; element belonging to the form.",
+          "type": "boolean"
+        },
+        "target": {
+          "doc": "Indicates where to display the response after submitting the form. In HTML 4, this is the name/keyword for a frame. In HTML5, it is a name/keyword for a browsing context (for example, tab, window, or iframe).",
+          "type": "enum:Target"
+        }
+      }
+    },
+    "input": {
+      "doc": "The &lt;input&gt; HTML element is used to create interactive controls for web-based forms in order to accept data from the user; a wide variety of types of input data and control widgets are available, depending on the device and user agent. The &lt;input&gt; element is one of the most powerful and complex in all of HTML due to the sheer number of combinations of input types and attributes.",
+      "attributes": {
+        "type": {
+          "doc": "Defines how an &lt;input&gt; works. If this attribute is not specified, the default type adopted is text.",
+          "type": {
+            "name": "InputType",
+            "doc": "The type for an &lt;input&gt; element.",
+            "values": {
+              "button": {
+                "doc": "A push button with no default behavior displaying the value of the value attribute, empty by default."
+              },
+              "checkbox": {
+                "doc": "A check box allowing single values to be selected/deselected."
+              },
+              "color": {
+                "doc": "A control for specifying a color; opening a color picker when active in supporting browsers."
+              },
+              "date": {
+                "doc": "A control for entering a date (year, month, and day, with no time). Opens a date picker or numeric wheels for year, month, day when active in supporting browsers."
+              },
+              "dateTimeLocal": {
+                "value": "datetime-local",
+                "doc": "A control for entering a date and time, with no time zone. Opens a date picker or numeric wheels for date- and time-components when active in supporting browsers."
+              },
+              "email": {
+                "doc": "A field for editing an email address. Looks like a text input, but has validation parameters and relevant keyboard in supporting browsers and devices with dynamic keyboards."
+              },
+              "file": {
+                "doc": "A control that lets the user select a file. Use the accept attribute to define the types of files that the control can select."
+              },
+              "hidden": {
+                "doc": "A control that is not displayed but whose value is submitted to the server."
+              },
+              "image": {
+                "doc": "A graphical submit button. Displays an image defined by the src attribute. The alt attribute displays if the image src is missing."
+              },
+              "month": {
+                "doc": "A control for entering a month and year, with no time zone."
+              },
+              "number": {
+                "doc": "A control for entering a number. Displays a spinner and adds default validation when supported. Displays a numeric keypad in some devices with dynamic keypads."
+              },
+              "password": {
+                "doc": "A single-line text field whose value is obscured. Will alert user if site is not secure."
+              },
+              "radio": {
+                "doc": "A radio button, allowing a single value to be selected out of multiple choices with the same name value."
+              },
+              "range": {
+                "doc": "A control for entering a number whose exact value is not important. Displays as a range widget defaulting to the middle value. Used in conjunction min and max to define the range of acceptable values."
+              },
+              "reset": {
+                "doc": "A button that resets the contents of the form to default values. Not recommended."
+              },
+              "search": {
+                "doc": "A single-line text field for entering search strings. Line-breaks are automatically removed from the input value. May include a delete icon in supporting browsers that can be used to clear the field. Displays a search icon instead of enter key on some devices with dynamic keypads."
+              },
+              "submit": {
+                "doc": "A button that submits the form."
+              },
+              "tel": {
+                "doc": "A control for entering a telephone number. Displays a telephone keypad in some devices with dynamic keypads."
+              },
+              "text": {
+                "doc": "The default value. A single-line text field. Line-breaks are automatically removed from the input value."
+              },
+              "time": {
+                "doc": "A control for entering a time value with no time zone."
+              },
+              "url": {
+                "doc": "A field for entering a URL. Looks like a text input, but has validation parameters and relevant keyboard in supporting browsers and devices with dynamic keyboards."
+              },
+              "week": {
+                "doc": "A control for entering a date consisting of a week-year number and a week number with no time zone."
+              }
+            }
+          }
+        },
+        "name": {
+          "doc": "Name of the form control. Submitted with the form as part of a name/value pair",
+          "type": "string"
+        },
+        "value": {
+          "doc": "The initial value of the control",
+          "type": "string"
+        },
+        "disabled": {
+          "doc": "Indicates that the user should not be able to interact with the input. Disabled inputs are typically rendered with a dimmer color or using some other form of indication that the field is not available for use.",
+          "type": "boolean"
+        }
+      }
+    },
+    "label": {
+      "doc": "The &lt;label&gt; HTML element represents a caption for an item in a user interface.",
+      "attributes": {
+        "for": {
+          "name": "htmlFor",
+          "doc": "The value of the for attribute must be a single id for a labelable form-related element in the same document as the &lt;label&gt; element. So, any given label element can be associated with only one form control.",
+          "type": "string"
+        }
+      }
+    },
+    "datalist": {
+      "doc": "The &lt;datalist&gt; HTML element contains a set of &lt;option&gt; elements that represent the permissible or recommended options available to choose from within other controls."
+    },
+    "legend": {
+      "doc": "The &lt;legend&gt; HTML element represents a caption for the content of its parent &lt;fieldset&gt;."
+    },
+    "meter": {
+      "doc": "The &lt;meter&gt; HTML element represents either a scalar value within a known range or a fractional value.",
+      "attributes": {
+        "value": {
+          "doc": "The current numeric value. This must be between the minimum and maximum values (min attribute and max attribute) if they are specified. If unspecified or malformed, the value is 0. If specified, but not within the range given by the min attribute and max attribute, the value is equal to the nearest end of the range.",
+          "type": "double"
+        },
+        "min": {
+          "doc": "The lower numeric bound of the measured range. This must be less than the maximum value (max attribute), if specified. If unspecified, the minimum value is 0.",
+          "type": "double"
+        },
+        "max": {
+          "doc": "The upper numeric bound of the measured range. This must be greater than the minimum value (min attribute), if specified. If unspecified, the maximum value is 1.",
+          "type": "double"
+        },
+        "low": {
+          "doc": "The upper numeric bound of the low end of the measured range. This must be greater than the minimum value (min attribute), and it also must be less than the high value and maximum value (high attribute and max attribute, respectively), if any are specified. If unspecified, or if less than the minimum value, the low value is equal to the minimum value.",
+          "type": "double"
+        },
+        "high": {
+          "doc": "The lower numeric bound of the high end of the measured range. This must be less than the maximum value (max attribute), and it also must be greater than the low value and minimum value (low attribute and min attribute, respectively), if any are specified. If unspecified, or if greater than the maximum value, the high value is equal to the maximum value.",
+          "type": "double"
+        },
+        "optimum": {
+          "doc": "Indicates the optimal numeric value. It must be within the range (as defined by the min attribute and max attribute). When used with the low attribute and high attribute, it gives an indication where along the range is considered preferable. For example, if it is between the min attribute and the low attribute, then the lower range is considered preferred. The browser may color the meter's bar differently depending on whether the value is less than or equal to the optimum value.",
+          "type": "double"
+        }
+      }
+    },
+    "progress": {
+      "doc": "The &lt;progress&gt; HTML element displays an indicator showing the completion progress of a task, typically displayed as a progress bar.",
+      "attributes": {
+        "value": {
+          "doc": "This attribute specifies how much of the task that has been completed. It must be a valid floating point number between 0 and max, or between 0 and 1 if max is omitted. If there is no value attribute, the progress bar is indeterminate; this indicates that an activity is ongoing with no indication of how long it is expected to take.",
+          "type": "double"
+        },
+        "max": {
+          "doc": "This attribute describes how much work the task indicated by the progress element requires. The max attribute, if present, must have a value greater than 0 and be a valid floating point number. The default value is 1.",
+          "type": "double"
+        }
+      }
+    },
+    "optgroup": {
+      "doc": "The &lt;optgroup&gt; HTML element creates a grouping of options within a &lt;select&gt; element.",
+      "attributes": {
+        "label": {
+          "doc": "The name of the group of options, which the browser can use when labeling the options in the user interface.",
+          "required": true,
+          "type": "string"
+        },
+        "disabled": {
+          "doc": "If this attribute is set, none of the items in this option group is selectable. Often browsers grey out such control and it won't receive any browsing events, like mouse clicks or focus-related ones.",
+          "type": "boolean"
+        }
+      }
+    },
+    "option": {
+      "doc": "The &lt;option&gt; HTML element is used to define an item contained in a &lt;select&gt;, an &lt;optgroup&gt;, or a &lt;datalist&gt; element. As such, &lt;option&gt; can represent menu items in popups and other lists of items in an HTML document.",
+      "attributes": {
+        "label": {
+          "doc": "This attribute is text for the label indicating the meaning of the option. If the label attribute isn't defined, its value is that of the element text content.",
+          "type": "string"
+        },
+        "value": {
+          "doc": "The content of this attribute represents the value to be submitted with the form, should this option be selected. If this attribute is omitted, the value is taken from the text content of the option element.",
+          "type": "string"
+        },
+        "selected": {
+          "doc": "Indicates that the option is initially selected. If the &lt;option&gt; element is the descendant of a &lt;select&gt; element whose multiple attribute is not set, only one single &lt;option&gt; of this &lt;select&gt; element may have the selected attribute.",
+          "type": "boolean"
+        },
+        "disabled": {
+          "doc": "If this attribute is set, this option is not checkable. Often browsers grey out such control and it won't receive any browsing event, like mouse clicks or focus-related ones. If this attribute is not set, the element can still be disabled if one of its ancestors is a disabled &lt;optgroup&gt; element.",
+          "type": "boolean"
+        }
+      }
+    },
+    "select": {
+      "doc": "The <select> HTML element represents a control that provides a menu of options.",
+      "attributes": {
+        "name": {
+          "doc": "This attribute is used to specify the name of the control.",
+          "type": "string"
+        },
+        "multiple": {
+          "doc": "Indicates that multiple options can be selected in the list. If it is not specified, then only one option can be selected at a time. When multiple is specified, most browsers will show a scrolling list box instead of a single line dropdown.",
+          "type": "boolean"
+        },
+        "required": {
+          "doc": "Indicating that an option with a non-empty string value must be selected.",
+          "type": "boolean"
+        },
+        "disabled": {
+          "doc": "Indicates that the user cannot interact with the control. If this attribute is not specified, the control inherits its setting from the containing element, for example <fieldset>; if there is no containing element with the disabled attribute set, then the control is enabled.",
+          "type": "boolean"
+        },
+        "autofocus": {
+          "doc": "This attribute lets you specify that a form control should have input focus when the page loads. Only one form element in a document can have the autofocus attribute.",
+          "type": "boolean"
+        },
+        "autocomplete": {
+          "doc": "A string providing a hint for a user agent's autocomplete feature.",
+          "type": "string"
+        },
+        "size": {
+          "doc": "If the control is presented as a scrolling list box (e.g. when multiple is specified), this attribute represents the number of rows in the list that should be visible at one time. Browsers are not required to present a select element as a scrolled list box. The default value is 0.",
+          "type": "int"
+        }
+      }
+    },
+    "textarea": {
+      "doc": "The &lt;textarea&gt; HTML element represents a multi-line plain-text editing control, useful when you want to allow users to enter a sizeable amount of free-form text, for example a comment on a review or feedback form.",
+      "attributes": {
+        "autocomplete": {
+          "name": "autoComplete",
+          "doc": "Indicates whether the value of the control can be automatically completed by the browser.",
+          "type": "enum:AutoComplete"
+        },
+        "autofocus": {
+          "doc": "This attribute lets you specify that a form control should have input focus when the page loads. Only one form-associated element in a document can have this attribute specified.",
+          "type": "boolean"
+        },
+        "cols": {
+          "doc": "The visible width of the text control, in average character widths. If it is specified, it must be a positive integer. If it is not specified, the default value is 20.",
+          "type": "int"
+        },
+        "disabled": {
+          "doc": "Indicates that the user cannot interact with the control. If this attribute is not specified, the control inherits its setting from the containing element, for example &lt;fieldset&gt;; if there is no containing element when the disabled attribute is set, the control is enabled.",
+          "type": "boolean"
+        },
+        "minlength": {
+          "name": "minLength",
+          "doc": "The minimum number of characters (UTF-16 code units) required that the user should enter.",
+          "type": "int"
+        },
+        "name": {
+          "doc": "The name of the control",
+          "type": "string"
+        },
+        "placeholder": {
+          "doc": "A hint to the user of what can be entered in the control. Carriage returns or line-feeds within the placeholder text must be treated as line breaks when rendering the hint.",
+          "type": "string"
+        },
+        "readonly": {
+          "doc": "Indicates that the user cannot modify the value of the control. Unlike the disabled attribute, the readonly attribute does not prevent the user from clicking or selecting in the control. The value of a read-only control is still submitted with the form.",
+          "type": "boolean"
+        },
+        "required": {
+          "doc": "This attribute specifies that the user must fill in a value before submitting a form.",
+          "type": "boolean"
+        },
+        "rows": {
+          "doc": "The number of visible text lines for the control. If it is specified, it must be a positive integer. If it is not specified, the default value is 2.",
+          "type": "int"
+        },
+        "spellcheck": {
+          "name": "spellCheck",
+          "doc": "Specifies whether the &lt;textarea&gt; is subject to spell checking by the underlying browser/OS.",
+          "type": {
+            "name": "SpellCheck",
+            "doc": "Specifies whether an element is subject to spell checking by the underlying browser/OS.",
+            "values": {
+              "isTrue": {
+                "value": "true",
+                "doc": "Indicates that the element needs to have its spelling and grammar checked."
+              },
+              "isDefault": {
+                "value": "default",
+                "doc": "Indicates that the element is to act according to a default behavior, possibly based on the parent element's own spellcheck value."
+              },
+              "isFalse": {
+                "value": "false",
+                "doc": "Indicates that the element should not be spell checked."
+              }
+            }
+          }
+        },
+        "wrap": {
+          "doc": "Indicates how the control wraps text. If this attribute is not specified, soft is its default value.",
+          "type": {
+            "name": "TextWrap",
+            "doc": "Indicates how the control wraps text.",
+            "values": {
+              "hard": {
+                "doc": "The browser automatically inserts line breaks (CR+LF) so that each line has no more than the width of the control; the cols attribute must also be specified for this to take effect."
+              },
+              "soft": {
+                "doc": "The browser ensures that all line breaks in the value consist of a CR+LF pair, but does not insert any additional line breaks."
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "other": {
+    "details": {
+      "doc": "The &lt;details&gt; HTML element creates a disclosure widget in which information is visible only when the widget is toggled into an \"open\" state. A summary or label must be provided using the &lt;summary&gt; element.",
+      "attributes": {
+        "open": {
+          "doc": "Indicates whether or not the details — that is, the contents of the &lt;details&gt; element — are currently visible.",
+          "type": "boolean"
+        }
+      }
+    },
+    "dialog": {
+      "doc": "The &lt;dialog&gt; HTML element represents a dialog box or other interactive component, such as a dismissible alert, inspector, or subwindow.",
+      "attributes": {
+        "open": {
+          "doc": "Indicates that the dialog is active and can be interacted with. When the open attribute is not set, the dialog shouldn't be shown to the user.",
+          "type": "boolean"
+        }
+      }
+    },
+    "summary": {
+      "doc": "The &lt;summary&gt; HTML element specifies a summary, caption, or legend for a &lt;details&gt; element's disclosure box. Clicking the &lt;summary&gt; element toggles the state of the parent &lt;details&gt; element open and closed."
     }
   }
 }

--- a/packages/jaspr/tool/generate_html.dart
+++ b/packages/jaspr/tool/generate_html.dart
@@ -23,8 +23,14 @@ void main() {
           content.writeln('/// - [$name]: ${attrs[attr]['doc'].split('\n').join('\n///   ')}');
         }
       }
+      content.write('Component $tag(');
 
-      content.write('Component $tag({');
+      var selfClosing = data['self_closing'] == true;
+
+      if (!selfClosing) {
+        content.write('List<Component> children, ');
+      }
+      content.write('{');
 
       if (attrs != null) {
         for (var attr in attrs.keys) {
@@ -65,14 +71,8 @@ void main() {
         }
       }
 
-      var selfClosing = data['self_closing'] == true;
-
       content.write(
-          'Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events');
-
-      if (!selfClosing) content.write(', Component? child, List<Component>? children');
-
-      content.write('}) {\n'
+          'Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events}) {\n'
           '  return DomComponent(\n'
           '    tag: \'$tag\',\n'
           '    key: key,\n'
@@ -127,8 +127,7 @@ void main() {
           '    events: events,\n');
 
       if (!selfClosing) {
-        content.write('    child: child,\n'
-            '    children: children,\n');
+        content.write('    children: children,\n');
       }
 
       content.writeln('  );\n'

--- a/packages/jaspr/tool/generate_html.dart
+++ b/packages/jaspr/tool/generate_html.dart
@@ -131,17 +131,27 @@ void main() {
               var name = type['name'] as String;
               var values = type['values'] as Map<String, dynamic>;
 
-              content.write('\nenum $name {\n  ');
+              content.write('\n');
+
+              content.write('\n${type['doc'].split('\n').map((t) => '/// $t\n').join()}');
+
+              content.write('enum $name {\n');
 
               for (var name in values.keys) {
                 var value = values[name]['value'] ?? name;
-                content.write('$name(\'$value\')');
+                content.write('  /// ${values[name]['doc'].split('\n').join('\n  /// ')}\n');
+                content.write('  $name(\'$value\')');
                 if (values.keys.last != name) {
-                  content.write(', ');
+                  content.write(',\n');
+                } else {
+                  content.write(';\n');
                 }
               }
 
-              content.writeln('\n}');
+              content.writeln('\n'
+                  '  final String value;\n'
+                  '  const $name(this.value);\n'
+                  '}');
             }
           }
         }

--- a/packages/jaspr/tool/generate_html.dart
+++ b/packages/jaspr/tool/generate_html.dart
@@ -8,7 +8,7 @@ void main() {
   for (var key in specJson.keys) {
     var group = specJson[key] as Map<String, dynamic>;
     var file = File('lib/src/html/$key.dart');
-    var content = StringBuffer("import '../../jaspr.dart';\n");
+    var content = StringBuffer("part of jaspr_html;\n");
 
     for (var tag in group.keys) {
       var data = group[tag] as Map<String, dynamic>;
@@ -46,6 +46,8 @@ void main() {
             content.write('bool');
           } else if (type == 'int') {
             content.write('int');
+          } else if (type == 'double') {
+            content.write('double');
           } else if (type is String && type.startsWith('enum:')) {
             var name = type.split(':')[1];
             content.write(name);
@@ -63,8 +65,14 @@ void main() {
         }
       }
 
+      var selfClosing = data['self_closing'] == true;
+
       content.write(
-          'Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events, Component? child, List<Component>? children}) {\n'
+          'Key? key, String? id, Iterable<String>? classes, Map<String, String>? styles, Map<String, String>? attributes, Map<String, EventCallback>? events');
+
+      if (!selfClosing) content.write(', Component? child, List<Component>? children');
+
+      content.write('}) {\n'
           '  return DomComponent(\n'
           '    tag: \'$tag\',\n'
           '    key: key,\n'
@@ -97,7 +105,7 @@ void main() {
             content.write('$name');
           } else if (type == 'boolean') {
             content.write("''");
-          } else if (type == 'int') {
+          } else if (type == 'int' || type == 'double') {
             content.write("'\$$name'");
           } else if (type is String && type.startsWith('enum:')) {
             content.write('$name.value');
@@ -115,11 +123,15 @@ void main() {
         content.write('attributes,\n');
       }
 
-      content.writeln(''
-          '    events: events,\n'
-          '    child: child,\n'
-          '    children: children,\n'
-          '  );\n'
+      content.write(''
+          '    events: events,\n');
+
+      if (!selfClosing) {
+        content.write('    child: child,\n'
+            '    children: children,\n');
+      }
+
+      content.writeln('  );\n'
           '}');
 
       if (attrs != null) {
@@ -130,8 +142,6 @@ void main() {
             if (type['values'] != null) {
               var name = type['name'] as String;
               var values = type['values'] as Map<String, dynamic>;
-
-              content.write('\n');
 
               content.write('\n${type['doc'].split('\n').map((t) => '/// $t\n').join()}');
 

--- a/packages/jaspr_pad/lib/main.mapper.g.dart
+++ b/packages/jaspr_pad/lib/main.mapper.g.dart
@@ -875,8 +875,8 @@ class IssueKindMapper extends EnumMapper<IssueKind> {
     }
   }
 
-  @override  dynamic encode(IssueKind value) {
-    switch (value) {
+  @override  dynamic encode(IssueKind self) {
+    switch (self) {
       case IssueKind.error: return 'error';
       case IssueKind.warning: return 'warning';
       case IssueKind.info: return 'info';
@@ -896,7 +896,7 @@ extension IssueKindMapperExtension on IssueKind {
 class Mapper {
   Mapper._();
 
-  static late MapperContainer i = MapperContainer(_mappers);
+  static MapperContainer i = MapperContainer(_mappers);
 
   static T fromValue<T>(dynamic value) => i.fromValue<T>(value);
   static T fromMap<T>(Map<String, dynamic> map) => i.fromMap<T>(map);

--- a/packages/jaspr_pad/pubspec.yaml
+++ b/packages/jaspr_pad/pubspec.yaml
@@ -6,7 +6,7 @@ homepage: https://github.com/schultek/jaspr
 issue_tracker: https://github.com/schultek/jaspr/issues
 
 environment:
-  sdk: '>=2.16.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
   analysis_server_lib: ^0.2.2
@@ -15,7 +15,7 @@ dependencies:
   dart_mappable: ^1.1.0
   googleapis: ^8.1.0
   googleapis_auth: ^1.3.0
-  jaspr: ^0.1.0
+  jaspr: ^0.2.0
   jaspr_riverpod: ^0.1.0
   markdown: ^5.0.0
   shelf_router: ^1.1.2

--- a/packages/jaspr_pad/samples/bulma/main.dart
+++ b/packages/jaspr_pad/samples/bulma/main.dart
@@ -1,4 +1,4 @@
-// [sample=5] Bulma CSS
+// [sample=6] Bulma CSS
 import 'package:jaspr/jaspr.dart';
 
 import 'button.dart';

--- a/packages/jaspr_pad/samples/html/main.dart
+++ b/packages/jaspr_pad/samples/html/main.dart
@@ -1,0 +1,43 @@
+// [sample=4] Jaspr Html
+// import this file for html utilities
+import 'package:jaspr/html.dart';
+import 'package:jaspr/jaspr.dart';
+
+void main() {
+  runApp(App());
+}
+
+class App extends StatelessComponent {
+  const App({Key? key}) : super(key: key);
+
+  @override
+  Iterable<Component> build(BuildContext context) sync* {
+    // you can then use the utility methods
+    // to write more simple & concise html
+    yield div([
+      // each element gets a list of child elements
+      h1([text('jaspr/html')]),
+      p([
+        // wrap your strings with `text()` to add alongside other components
+        text('This is some '),
+        b([text('html')]),
+        text(' content.'),
+      ]),
+      // some elements have typed attributes for easy access
+      a(href: "https://github.com/schultek/jaspr", target: Target.blank, [
+        img(src: "https://jasprpad.schultek.de/jaspr-192.png"),
+      ]),
+      // some elements don't have children
+      hr(),
+      // you can add events as usual
+      select(events: {
+        'change': (e) => print(e.target.value),
+      }, [
+        option(value: 'test', [text('Select me!')]),
+        option(value: 'other', selected: true, [text('Or me!')])
+      ]),
+      // most common and some uncommon elements are supported
+      progress(value: 85, max: 100, [])
+    ]);
+  }
+}

--- a/packages/jaspr_pad/samples/html/styles.css
+++ b/packages/jaspr_pad/samples/html/styles.css
@@ -1,0 +1,12 @@
+html, body {
+  height: 100%;
+  color: white;
+  font-family: sans-serif;
+}
+
+body {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}

--- a/packages/jaspr_pad/samples/weather-api/main.dart
+++ b/packages/jaspr_pad/samples/weather-api/main.dart
@@ -1,4 +1,4 @@
-// [sample=4] Weather Api
+// [sample=5] Weather Api
 import 'package:jaspr/jaspr.dart';
 
 import 'api.dart';

--- a/packages/jaspr_pad/templates/jaspr_basic/pubspec.yaml
+++ b/packages/jaspr_pad/templates/jaspr_basic/pubspec.yaml
@@ -4,11 +4,11 @@ version: 1.0.0
 publish_to: none
 
 environment:
-  sdk: '>=2.16.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
   http: ^0.13.4
-  jaspr: ^0.1.0
+  jaspr: ^0.2.0
   jaspr_riverpod: ^0.1.0
 
 dev_dependencies:

--- a/packages/jaspr_pad/templates/jaspr_export/pubspec.yaml
+++ b/packages/jaspr_pad/templates/jaspr_export/pubspec.yaml
@@ -4,10 +4,10 @@ version: 1.0.0
 publish_to: none
 
 environment:
-  sdk: '>=2.16.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
-  jaspr: ^0.1.0
+  jaspr: ^0.2.0
   jaspr_riverpod: ^0.1.0-dev.1
 
 dev_dependencies:

--- a/packages/jaspr_pad/web/styles.css
+++ b/packages/jaspr_pad/web/styles.css
@@ -1,3 +1,8 @@
+.header-gist-name {
+  flex: 1;
+  text-align: center;
+}
+
 .issue-item {
   padding: 2px 0px;
   user-select: none;


### PR DESCRIPTION
Related to #16

`jaspr/html.dart` should contain a list of utility components for common html elements. This is implemented as methods returning a single `DomComponent`. 

The methods are generated from a json file, in order to be easily adjustable for future api changes. The data is extracted manually from https://developer.mozilla.org/en-US/docs/Web/HTML/Element

Todos:

- [x] add most common elements with documentation and attributes
- [x] write generation script
- [x] add missing elements (~striked elements~ won't be supported for now)
  - ~address~, blockquote, ~dd, dl, dt, figure, figcaption, menu~
  - ~abbr, bdi, bdo, cite, data, dfn, kbd, mark, q, rp, rt, ruby, samp, sub, sup, time, var, wbr~
  - ~area, map, track~, embed, iframe, object, ~picture, portal~, source
  - ~svg, math, canvas, del, ins~
  - ~caption, col, colgroup, table, tbody, td, tfoot, th, thead, tr~ 
    - (table should be implemented as a separate component)
  - datalist, ~fieldset~, form, input, label, legend, meter, optgroup, option, ~output~, progress, select, textarea
  - details, dialog, summary
- ~add common events (e.g. for input or media elements)~ (maybe followup pr)
- [x] add wiki page
- [x] add jasprpad sample  
- ~add jasprpad tutorial step~ (followup pr)
