### PR TITLE
Fix issue where title was always returning null

### DIFF
--- a/packages/jaspr_router/CHANGELOG.md
+++ b/packages/jaspr_router/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.4
+
+- `jaspr_router` fixed bug where `Router.of(context).matchList.title` always returned null.
+
 ## 0.2.3
 
 - `jaspr` upgraded to `0.8.0`

--- a/packages/jaspr_router/CHANGELOG.md
+++ b/packages/jaspr_router/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.2.4
+## Unreleased patch
 
 - `jaspr_router` fixed bug where `Router.of(context).matchList.title` always returned null.
 

--- a/packages/jaspr_router/lib/src/matching.dart
+++ b/packages/jaspr_router/lib/src/matching.dart
@@ -128,7 +128,12 @@ class RouteMatchList {
   /// The last matching route.
   RouteMatch get last => _matches.last;
 
-  String? get title => _matches.reversed.fold(null, (t, r) => t ?? (r is Route ? (r as Route).title : null));
+  // Returns the title of the deepest matching route
+  String? get title {
+    return _matches.reversed.fold(null, (String? t, RouteMatch r) {
+      return t ?? (r.route is Route ? (r.route as Route).title : null);
+    });
+  }
 
   /// The route matches.
   List<RouteMatch> get matches => _matches;

--- a/packages/jaspr_router/pubspec.yaml
+++ b/packages/jaspr_router/pubspec.yaml
@@ -1,6 +1,6 @@
 name: jaspr_router
 description: A routing component for jaspr.
-version: 0.2.4
+version: 0.2.3
 homepage: https://github.com/schultek/jaspr
 issue_tracker: https://github.com/schultek/jaspr/issues
 

--- a/packages/jaspr_router/pubspec.yaml
+++ b/packages/jaspr_router/pubspec.yaml
@@ -1,6 +1,6 @@
 name: jaspr_router
 description: A routing component for jaspr.
-version: 0.2.3
+version: 0.2.4
 homepage: https://github.com/schultek/jaspr
 issue_tracker: https://github.com/schultek/jaspr/issues
 
@@ -12,7 +12,7 @@ environment:
   sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
-  jaspr: ^0.8.0
+  jaspr: ^0.8.1
 
 dev_dependencies:
   jaspr_test: '>=0.1.0 <1.0.0'


### PR DESCRIPTION
## Description

`jaspr_router` was not returning the page title. Looks like a refactor didnt catch the type change of r to RouteMatch instead of Route. Have added typed paramaters to deter this from happening again, and resolved bug by referring to the inner route.

## Type of Change

<!-- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

## Ready Checklist

- [x] I've read the [Contribution Guide](https://github.com/schultek/jaspr/blob/main/CONTRIBUTING.md).
- [x] In case this PR changes one of the core packages, I've modified the respective **CHANGELOG.md** file using
      the [semantic_changelog](https://github.com/rrousselGit/semantic_changelog) format.
- [x] I updated/added relevant documentation (doc comments with `///`).

If you need help, consider asking for advice on the *#contribute* channel on [Discord](https://discord.gg/XGXrGEk4c6).
