### PR TITLE
Correcting the misinformation in the CLI mentioned in issue #123

### DIFF
--- a/packages/jaspr/CHANGELOG.md
+++ b/packages/jaspr/CHANGELOG.md
@@ -1,3 +1,7 @@
+## unreleased 0.9.1
+
+- Corrected information returned by the CLI after using `jaspr create -t client` from `jaspr serve` to `jaspr serve -no-ssr`
+
 ## 0.9.0
 
 - Added *Static Site Generation* support.

--- a/packages/jaspr_cli/lib/src/commands/create_command.dart
+++ b/packages/jaspr_cli/lib/src/commands/create_command.dart
@@ -96,11 +96,16 @@ class CreateCommand extends BaseCommand {
     var process = await Process.start('dart', ['pub', 'get'], workingDirectory: directory.absolute.path);
 
     await watchProcess(process, tag: Tag.cli, progress: 'Resolving dependencies...', hide: (s) => s.contains('+'));
-
+    
+    String necessaryServeFlag = '';
+    if(templateName == 'client'){
+      necessaryServeFlag = ' --no-ssr';
+    }
+    
     logger.write('\n'
         'Created project $name in $dir! In order to get started, run the following commands:\n\n'
         '  cd $dir\n'
-        '  jaspr serve\n');
+        '  jaspr serve$necessaryServeFlag\n');
 
     return ExitCode.success.code;
   }


### PR DESCRIPTION
Added a check to add the 'no-ssr' flag to the output information after creation, if necessary (=>client template).
Small function that is easily adaptable for other flags if necessary. This would unify the content of the created readme file and the information of the CLI.

Might be a smart idea to unify this logic with the template selection though, if the names might change. It basically double checks the name right now.
But I didnt want to interfere that far in the framework as i haven't worked with it yet.



- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🔨 Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✏️ Documentation
- [ ] 🗑️ Chore

Fixes #123 