### PR TITLE
fix: Prevent an infinate loop on Windows in build executables

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -15,7 +15,7 @@ packages:
   - thirdparty/*
 
 scripts:
-  format: melos exec -- 'dart format . --line-length=120'
+  format: melos exec -- "dart format . --line-length=120"
   analyze: melos exec -- "dart analyze . --fatal-infos"
   test:
     run: |

--- a/packages/jaspr/CHANGELOG.md
+++ b/packages/jaspr/CHANGELOG.md
@@ -1,7 +1,7 @@
-## Unreleased
+## Unreleased patch
 
 - Fixed `melos format` on Windows
-- Fixed infinate loop attempting to find root directory on Windows when running a built jaspr executable
+- Fixed infinite loop attempting to find root directory on Windows when running a built jaspr executable
 
 ## 0.9.2
 

--- a/packages/jaspr/CHANGELOG.md
+++ b/packages/jaspr/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+- Fixed `melos format` on Windows
+- Fixed infinate loop attempting to find root directory on Windows when running a built jaspr executable
+
 ## 0.9.2
 
 - Fixed cli execution on windows

--- a/packages/jaspr/lib/src/server/server_handler.dart
+++ b/packages/jaspr/lib/src/server/server_handler.dart
@@ -172,8 +172,8 @@ Handler _sseProxyHandler() {
 final webDir = kDevWeb.isNotEmpty ? kDevWeb : join(_findRootProjectDir(), 'web');
 
 String _findRootProjectDir() {
-  var dir = dirname(Platform.script.path);
-  if (Platform.resolvedExecutable == Platform.script.path) return dir;
+  var dir = dirname(Platform.script.toFilePath());
+  if (Platform.resolvedExecutable == Platform.script.toFilePath()) return dir;
   while (dir.isNotEmpty && !File(join(dir, 'pubspec.yaml')).existsSync()) {
     dir = dirname(dir);
   }

--- a/packages/jaspr_test/lib/src/testers/server_tester.dart
+++ b/packages/jaspr_test/lib/src/testers/server_tester.dart
@@ -109,7 +109,11 @@ class ServerTester {
   /// Perform a virtual request to your app that renders the components and returns the
   /// resulting document.
   Future<DocumentResponse> request(String location) async {
-    var uri = Uri.parse('http://${app.server!.address.host}:${app.server!.port}$location');
+    var serverHost = app.server!.address.host;
+    if (serverHost == '0.0.0.0') {
+      serverHost = 'localhost';
+    }
+    var uri = Uri.parse('http://$serverHost:${app.server!.port}$location');
 
     int statusCode;
     String body;


### PR DESCRIPTION
## Description

When running jaspr through `dart .\lib\main.dart` or through a built Jaspr executable the _findRootProjectDir (in lib/src/server/server_handler.dart) would enter an infinite loop because `Platform.script.path` returns the the path with a leading slash.

This changes requests for `Platform.script.path` to `Platform.script.toFilePath()` which is more correct.

Also fix `melos format` on Windows and the real server test on Windows.

This also updates `modules/build` to a valid commit.

Fixes #130 

## Type of Change

- [ ] ❌ Breaking change
- [ ] ✨ New feature or improvement
- [x] 🛠️ Bug fix
- [ ] 🧹 Code refactor
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

## Ready Checklist

- [x] I've read the [Contribution Guide](https://github.com/schultek/jaspr/blob/main/CONTRIBUTING.md).
- [x] In case this PR changes one of the core packages, I've modified the respective **CHANGELOG.md** file using
      the [semantic_changelog](https://github.com/rrousselGit/semantic_changelog) format.
- [x] I updated/added relevant documentation (doc comments with `///`).
