### PR TITLE
fix: Add .exe extension to Windows SSR executables

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -5,3 +5,4 @@
 
 Kilian Schulte (schultek) - Creator & Lead Developer
 Martin Jablečník (mjablecnik) - Contributor
+Jeff Ward (fuzzybinary) - Contributor

--- a/packages/jaspr/CHANGELOG.md
+++ b/packages/jaspr/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Fixed `melos format` on Windows
 - Fixed infinite loop attempting to find root directory on Windows when running a built jaspr executable
+- Add `.exe` extension to the output of `jaspr build` on Windows.
 
 ## 0.9.2
 

--- a/packages/jaspr_cli/lib/src/commands/build_command.dart
+++ b/packages/jaspr_cli/lib/src/commands/build_command.dart
@@ -89,10 +89,22 @@ class BuildCommand extends BaseCommand with SsrHelper, FlutterHelper {
       await webResult;
 
       logger.write('Building server app...', progress: ProgressState.running);
+      String extension = '';
+      final target = argResults!['target'];
+      if (Platform.isWindows && target == 'exe') {
+        extension = '.exe';
+      }
 
       var process = await Process.start(
         'dart',
-        ['compile', argResults!['target'], entryPoint, '-o', './build/jaspr/app', '-Djaspr.flags.release=true'],
+        [
+          'compile',
+          argResults!['target'],
+          entryPoint,
+          '-o',
+          './build/jaspr/app$extension',
+          '-Djaspr.flags.release=true',
+        ],
       );
 
       await watchProcess('server build', process, tag: Tag.cli, progress: 'Building server app...');


### PR DESCRIPTION
## Description

The executable built by `jaspr build` doesn't have an extension, but on Windows the extension is necessary for Windows to recognize it as an executable.

This adds the `.exe` extension if `jaspr build` is running on Windows with the target set to `exe` (as opposed to any snapshots). It may be worth revisiting this logic to add extensions for the two snapshot targets as well.

## Type of Change

- [ ] ❌ Breaking change
- [ ] ✨ New feature or improvement
- [x] 🛠️ Bug fix
- [ ] 🧹 Code refactor
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

## Ready Checklist

- [x] I've read the [Contribution Guide](https://github.com/schultek/jaspr/blob/main/CONTRIBUTING.md).
- [x] In case this PR changes one of the core packages, I've modified the respective **CHANGELOG.md** file using
      the [semantic_changelog](https://github.com/rrousselGit/semantic_changelog) format.
- [ ] I updated/added relevant documentation (doc comments with `///`).
