### PR TITLE
fix #138: [jaspr_riverpod] update vsyncOverride to flutterVsyncs

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,3 +6,4 @@
 Kilian Schulte (schultek) - Creator & Lead Developer
 Martin Jablečník (mjablecnik) - Contributor
 Jeff Ward (fuzzybinary) - Contributor
+Matthew Jaoudi (gadfly361) - Contributor

--- a/packages/jaspr_riverpod/CHANGELOG.md
+++ b/packages/jaspr_riverpod/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased 0.3.8
+## Unreleased patch
 
 - Upgrade `riverpod` to `v2.4.6`
 - Update `jaspr_riverpod`'s dependency on `riverpod`'s `vsyncOverride` to `flutterVsyncs`

--- a/packages/jaspr_riverpod/CHANGELOG.md
+++ b/packages/jaspr_riverpod/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased 0.3.8
+
+- Upgrade `riverpod` to `v2.4.6`
+- Update `jaspr_riverpod`'s dependency on `riverpod`'s `vsyncOverride` to `flutterVsyncs`
+
 ## 0.3.7
 
 - Fixed bug with SyncProvider.

--- a/packages/jaspr_riverpod/lib/src/framework.dart
+++ b/packages/jaspr_riverpod/lib/src/framework.dart
@@ -314,7 +314,7 @@ class _UncontrolledProviderScopeElement extends InheritedElement {
       debugCanModifyProviders ??= _debugCanModifyProviders;
     }
 
-    vsyncOverride ??= _jasprVsync;
+    flutterVsyncs.add(_jasprVsync);
     super.mount(parent, prevSibling);
   }
 
@@ -370,9 +370,7 @@ class _UncontrolledProviderScopeElement extends InheritedElement {
       debugCanModifyProviders = null;
     }
 
-    if (vsyncOverride == _jasprVsync) {
-      vsyncOverride = null;
-    }
+    flutterVsyncs.remove(_jasprVsync);
     super.unmount();
   }
 

--- a/packages/jaspr_riverpod/pubspec.yaml
+++ b/packages/jaspr_riverpod/pubspec.yaml
@@ -14,7 +14,7 @@ environment:
 dependencies:
   jaspr: ^0.9.0
   meta: ^1.9.1
-  riverpod: ^2.3.2
+  riverpod: ^2.4.6
 
 dev_dependencies:
   jaspr_test: '>=0.1.0 <1.0.0'


### PR DESCRIPTION
## Description

This PR is a fix for #138.

In riverpod,`vsyncOverride` was removed in riverpod v2.4.6 (https://github.com/rrousselGit/riverpod/pull/3072) and replaced with `flutterVsyncs`. This PR makes the same replacement in jaspr_riverpod.

## Type of Change

<!-- Put an `x` in all the boxes that apply: -->

- [ ] ❌ Breaking change
- [ ] ✨ New feature or improvement
- [x] 🛠️ Bug fix
- [ ] 🧹 Code refactor
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

## Ready Checklist

- [x] I've read the [Contribution Guide](https://github.com/schultek/jaspr/blob/main/CONTRIBUTING.md).
- [x] In case this PR changes one of the core packages, I've modified the respective **CHANGELOG.md** file using
      the [semantic_changelog](https://github.com/rrousselGit/semantic_changelog) format.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added myself to the AUTHORS file (optional, if you want to).

If you need help, consider asking for advice on the *#contribute* channel on [Discord](https://discord.gg/XGXrGEk4c6).
