### PR TITLE
fix: DomValidator bug

### DIFF
--- a/packages/jaspr/CHANGELOG.md
+++ b/packages/jaspr/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased patch
+
+- Fixed bug with `DomValidator`.
+
 ## 0.10.0
 
 - **BREAKING** Restructured core libraries:

--- a/packages/jaspr/lib/src/server/markup_render_object.dart
+++ b/packages/jaspr/lib/src/server/markup_render_object.dart
@@ -133,7 +133,7 @@ class MarkupRenderObject extends RenderObject {
 
 /// DOM validator with sane defaults.
 class DomValidator {
-  static final _attributeRegExp = RegExp(r'^[a-z](?:[a-z0-9\-_]*[a-z0-9]+)?$');
+  static final _attributeRegExp = RegExp(r'^[a-z](?:[a-zA-Z0-9\-_]*[a-z0-9]+)?$');
   static final _elementRegExp = _attributeRegExp;
   static const _selfClosing = <String>{
     'area',


### PR DESCRIPTION
## Description

Fixed a bug where `Invalid argument(s): "xxxx" is not a valid attribute name.` error would appear for attributes with capital letters in the middle of name, such as 'viewBox' in `svg`.

## Type of Change

- [ ] ❌ Breaking change
- [ ] ✨ New feature or improvement
- [x] 🛠️ Bug fix
- [ ] 🧹 Code refactor
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

## Ready Checklist

- [x] I've read the [Contribution Guide](https://github.com/schultek/jaspr/blob/main/CONTRIBUTING.md).
- [x] In case this PR changes one of the core packages, I've modified the respective **CHANGELOG.md** file using
      the [semantic_changelog](https://github.com/rrousselGit/semantic_changelog) format.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added myself to the AUTHORS file (optional, if you want to).

If you need help, consider asking for advice on the *#contribute* channel on [Discord](https://discord.gg/XGXrGEk4c6).
