### PR TITLE
Closes #193 Add optimization options to jaspr build command

### DIFF
--- a/packages/jaspr/CHANGELOG.md
+++ b/packages/jaspr/CHANGELOG.md
@@ -35,6 +35,8 @@
 
 - Support colon in DomValidator for attributes.
 
+- The `jaspr build` command now accepts an optimization option. Minification (`-O 2`) enabled by default.
+
 ## 0.10.0
 
 - **BREAKING** Restructured core libraries:

--- a/packages/jaspr_cli/lib/src/commands/build_command.dart
+++ b/packages/jaspr_cli/lib/src/commands/build_command.dart
@@ -36,6 +36,20 @@ class BuildCommand extends BaseCommand with ProxyHelper, FlutterHelper {
       },
       defaultsTo: 'exe',
     );
+    argParser.addOption(
+      'optimize',
+      abbr: 'O',
+      help: 'Set the dart2js compiler optimization level',
+      allowed: ['0', '1', '2', '3', '4'],
+      allowedHelp: {
+        '0': 'No optimizations (only meant for debugging the compiler).',
+        '1': 'Includes whole program analyses and inlining.',
+        '2': 'Safe production-oriented optimizations (like minification).',
+        '3': 'Potentially unsafe optimizations.',
+        '4': 'More aggressive unsafe optimizations.',
+      },
+      defaultsTo: '2',
+    );
   }
 
   @override
@@ -213,7 +227,7 @@ class BuildCommand extends BaseCommand with ProxyHelper, FlutterHelper {
         '--release',
         '--verbose',
         '--delete-conflicting-outputs',
-        '--define=${config!.usesJasprWebCompilers ? 'jaspr' : 'build'}_web_compilers:entrypoint=dart2js_args=["-Djaspr.flags.release=true"]'
+        '--define=${config!.usesJasprWebCompilers ? 'jaspr' : 'build'}_web_compilers:entrypoint=dart2js_args=["-Djaspr.flags.release=true","-O${argResults!['optimize']}"]'
       ],
       logger.writeServerLog,
     );


### PR DESCRIPTION
## Description

See #193 For details and rationale. 

The implementation here inherits form the dart2js optimization options:

```
>>> dart compile js -h

Usage: dart compile js [arguments] <dart entry point>
  -h, --help      Print this usage information.
  -h -v           Show detailed information about all options.
  -o, --output    Write the output to <file name>.
  -O<0,1,2,3,4>   Set the compiler optimization level (defaults to -O1).
     -O0          No optimizations (only meant for debugging the compiler).
     -O1          Default (includes whole program analyses and inlining).
     -O2          Safe production-oriented optimizations (like minification).
     -O3          Potentially unsafe optimizations (see -h -v for details).
     -O4          More agressive unsafe optimizations (see -h -v for details).
```

The new, analogous, `jaspr build` command options:

```
>>> jaspr build -h

-O, --optimize               Set the dart2js compiler optimization level

          [0]                No optimizations (only meant for debugging the compiler).
          [1]                Includes whole program analyses and inlining.
          [2] (default)      Safe production-oriented optimizations (like minification).
          [3]                Potentially unsafe optimizations.
          [4]                More aggressive unsafe optimizations.
``` 

Note that `dart compile js` uses `O1` as the default. Since `jaspr build` is intended for release/production, it seems that a better default here would be `O2`.

Users can change the optimization level via this command option. To revert to the previous build configuration, simply specify:

```
jaspr build --optimize 1
jaspr build  -O 1
```

## Results

New results using this updated `jaspr build` (without any options specified).

```
du -sh build/jaspr/web/*.js && du -sh build/jaspr/web/components/*.js
```

**Before**

```
1.0M	build/jaspr/web/main.clients.dart.js
560K	build/jaspr/web/main.clients.dart.js_1.part.js
1.5M	build/jaspr/web/components/app.client.dart.js
```

**After**

```
360K	build/jaspr/web/main.clients.dart.js
180K	build/jaspr/web/main.clients.dart.js_1.part.js
528K	build/jaspr/web/components/app.client.dart.js
```


## Type of Change

- ✨ New feature or improvement

## Ready Checklist

- [x] I've read the [Contribution Guide](https://github.com/schultek/jaspr/blob/main/CONTRIBUTING.md).
- [x] In case this PR changes one of the core packages, I've modified the respective **CHANGELOG.md** file using
      the [semantic_changelog](https://github.com/rrousselGit/semantic_changelog) format.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added myself to the AUTHORS file (optional, if you want to).

