### PR TITLE
fix: Forward errors to main isolate in renderHtml

### DIFF
--- a/packages/jaspr/CHANGELOG.md
+++ b/packages/jaspr/CHANGELOG.md
@@ -33,6 +33,8 @@
 
 - Fixed bug with `DomValidator`.
 
+- Fixed an issue where exceptions thrown while during `renderHtml` would not be passed to the spawning isolate.
+
 - Support colon in DomValidator for attributes.
 
 ## 0.10.0


### PR DESCRIPTION
## Description

Errors when calling `renderHtml` were silently failing and resulting in timeouts because the exception wasn't automatically passed to the spawning isolate. Add an separate `errorPort` to support sending the error to the calling isolate which will properly throw it back the the handler.

This probably also needs to be done for `renderData`.

Partially fixes #129

## Type of Change

🛠️ Bug fix 

## Ready Checklist

- [x] I've read the [Contribution Guide](https://github.com/schultek/jaspr/blob/main/CONTRIBUTING.md).
- [x] In case this PR changes one of the core packages, I've modified the respective **CHANGELOG.md** file using
      the [semantic_changelog](https://github.com/rrousselGit/semantic_changelog) format.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added myself to the AUTHORS file (optional, if you want to).