### PR TITLE
Added main to DOM components

### DIFF
--- a/packages/jaspr/CHANGELOG.md
+++ b/packages/jaspr/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased patch
 
 - Fixed `DomValidator` to allow attributes with `.`.
+- Added main to DOM components.
 
 ## 0.11.1
 

--- a/packages/jaspr/lib/src/components/html/content.dart
+++ b/packages/jaspr/lib/src/components/html/content.dart
@@ -260,6 +260,26 @@ Component h6(List<Component> children,
   );
 }
 
+/// The &lt;main&gt; HTML element represents the primary content of a document, distinct from content that is repeated across multiple pages such as site headers, footers, and navigation bars.
+Component main_(List<Component> children,
+    {Key? key,
+    String? id,
+    String? classes,
+    Styles? styles,
+    Map<String, String>? attributes,
+    Map<String, EventCallback>? events}) {
+  return DomComponent(
+    tag: 'main',
+    key: key,
+    id: id,
+    classes: classes,
+    styles: styles,
+    attributes: attributes,
+    events: events,
+    children: children,
+  );
+}
+
 /// The &lt;nav&gt; HTML element represents a section of a page whose purpose is to provide navigation links, either within the current document or to other documents. Common examples of navigation sections are menus, tables of contents, and indexes.
 Component nav(List<Component> children,
     {Key? key,

--- a/packages/jaspr/tool/data/html.json
+++ b/packages/jaspr/tool/data/html.json
@@ -39,6 +39,10 @@
     "h6": {
       "doc": "The &lt;h1&gt; to &lt;h6&gt; HTML elements represent six levels of section headings. &lt;h1&gt; is the highest section level and &lt;h6&gt; is the lowest."
     },
+    "main_": {
+      "tag": "main",
+      "doc": "The &lt;main&gt; HTML element represents the primary content of a document, distinct from content that is repeated across multiple pages such as site headers, footers, and navigation bars."
+    },    
     "nav": {
       "doc": "The &lt;nav&gt; HTML element represents a section of a page whose purpose is to provide navigation links, either within the current document or to other documents. Common examples of navigation sections are menus, tables of contents, and indexes."
     },

--- a/packages/jaspr/tool/generate_html.dart
+++ b/packages/jaspr/tool/generate_html.dart
@@ -93,10 +93,13 @@ void main() {
         }
       }
 
+      // Forced tag name
+      final tagValue = data["tag"] ?? tag;
+
       content.write(
           'Key? key, String? id, String? classes, Styles? styles, Map<String, String>? attributes, Map<String, EventCallback>? events}) {\n'
           '  return DomComponent(\n'
-          '    tag: \'$tag\',\n'
+          '    tag: \'$tagValue\',\n'
           '    key: key,\n'
           '    id: id,\n'
           '    classes: classes,\n'


### PR DESCRIPTION
## Description

Changed the generate_html.dart to be able to pass a custom tag value from json definition file, in order to be able to create a "main" html tag usgin a custom function "main_" without have conflicts with the main() Dart method.

## Type of Change

✨ New feature or improvement

## Ready Checklist

- [X] I've read the [Contribution Guide](https://github.com/schultek/jaspr/blob/main/CONTRIBUTING.md).
- [X] In case this PR changes one of the core packages, I've modified the respective **CHANGELOG.md** file using
      the [semantic_changelog](https://github.com/rrousselGit/semantic_changelog) format.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added myself to the AUTHORS file (optional, if you want to).
