### PR TITLE
fix: add html unescape in hydrated data

### DIFF
--- a/packages/jaspr/CHANGELOG.md
+++ b/packages/jaspr/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased patch
+
+- Fixed missing html unescape in hydrated data.
+
 ## 0.13.3
 
 - Added support for custom models as parameters to `@client` components.

--- a/packages/jaspr/lib/src/browser/clients.dart
+++ b/packages/jaspr/lib/src/browser/clients.dart
@@ -75,7 +75,7 @@ void _applyClients(FutureOr<ClientBuilder> Function(String) fn) {
         start.text = '\$${comp.$1}';
 
         var params = ConfigParams(
-          jsonDecode(comp.$2?.replaceAll('&amp;', '&').replaceAll('&lt;', '<').replaceAll('&gt;', '>') ?? '{}'),
+          jsonDecode(comp.$2?.replaceAll('&lt;', '<').replaceAll('&gt;', '>').replaceAll('&amp;', '&') ?? '{}'),
         );
 
         var builder = fn(name);

--- a/packages/jaspr/lib/src/browser/clients.dart
+++ b/packages/jaspr/lib/src/browser/clients.dart
@@ -2,8 +2,6 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:html';
 
-import 'package:html/parser.dart';
-
 import '../framework/framework.dart';
 import 'browser_binding.dart';
 
@@ -76,7 +74,9 @@ void _applyClients(FutureOr<ClientBuilder> Function(String) fn) {
         // Remove the data string.
         start.text = '\$${comp.$1}';
 
-        var params = ConfigParams(jsonDecode(parseFragment(comp.$2 ?? '{}').text!));
+        var params = ConfigParams(
+          jsonDecode(comp.$2?.replaceAll('&amp;', '&').replaceAll('&lt;', '<').replaceAll('&gt;', '>') ?? '{}'),
+        );
 
         var builder = fn(name);
         if (builder is ClientBuilder) {

--- a/packages/jaspr/lib/src/browser/clients.dart
+++ b/packages/jaspr/lib/src/browser/clients.dart
@@ -2,6 +2,8 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:html';
 
+import 'package:html/parser.dart';
+
 import '../framework/framework.dart';
 import 'browser_binding.dart';
 
@@ -74,7 +76,7 @@ void _applyClients(FutureOr<ClientBuilder> Function(String) fn) {
         // Remove the data string.
         start.text = '\$${comp.$1}';
 
-        var params = ConfigParams(jsonDecode(comp.$2 ?? '{}'));
+        var params = ConfigParams(jsonDecode(parseFragment(comp.$2 ?? '{}').text!));
 
         var builder = fn(name);
         if (builder is ClientBuilder) {


### PR DESCRIPTION
## Description

In Jaspr, data is escaped and sent to the client while hydrating. However, there is no unescape process in the client now, so data which contain escapable characters like '&' is different from the server's original on the client. I fixed this by adding unescape progress in the client.

## Type of Change

<!-- Uncomment all that apply: -->

<!-- - ❌ Breaking change -->
<!-- - ✨ New feature or improvement -->
- 🛠️ Bug fix
<!-- - 🧹 Code refactor -->
<!-- - 📝 Documentation -->
<!-- - 🗑️ Chore -->

## Ready Checklist

- [x] I've read the [Contribution Guide](https://github.com/schultek/jaspr/blob/main/CONTRIBUTING.md).
- [x] In case this PR changes one of the core packages, I've modified the respective **CHANGELOG.md** file using
      the [semantic_changelog](https://github.com/rrousselGit/semantic_changelog) format.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added myself to the AUTHORS file (optional, if you want to).

<!-- 
  Feel free to expand this list if you have additional todos before your PR is ready. 
-->

<!--
  If you need help, consider asking for advice on the *#contribute* channel on [Discord](https://discord.gg/XGXrGEk4c6).
-->
