### PR TITLE
feat: allow response headers to be edited from context.binding

### DIFF
--- a/docs/advanced/backend.mdx
+++ b/docs/advanced/backend.mdx
@@ -22,7 +22,7 @@ There are two main functions, that enable this:
 
 - `Handler serveApp(AppHandler handler)` bundles everything jaspr does on the server into a custom shelf handler.
   The handler can then be passed to your backend or server implementation.
-- `String renderComponent(Component app)` directly renders the provided component into a html string.
+- `Response renderComponent(Component app)` directly renders the provided component into a Response.
 
 <Warning>
 When using your own backend setup, you can still do `jaspr serve`, however auto-reload won't work 

--- a/examples/backend_dart_frog/lib/utils.dart
+++ b/examples/backend_dart_frog/lib/utils.dart
@@ -25,14 +25,11 @@ Middleware serveJasprApp() {
 Future<Response> renderJasprComponent(RequestContext context, Component child) async {
   var base = context.read<BasePath>();
 
-  return Response(
-    body: await renderComponent(
-      Document(
-        base: base.path,
-        body: child,
-      ),
+  return await renderComponent(
+    Document(
+      base: base.path,
+      body: child,
     ),
-    headers: {'Content-Type': 'text/html'},
   );
 }
 

--- a/examples/backend_shelf/lib/main.dart
+++ b/examples/backend_shelf/lib/main.dart
@@ -32,15 +32,12 @@ void main() async {
 
   router.get('/hello', (request) async {
     // Render a single component manually
-    return Response.ok(
-      await renderComponent(Document(
-        // we still point to /app to correctly load all other resources,
-        // like js, css or image files
-        base: '/app',
-        body: Hello(),
-      )),
-      headers: {'Content-Type': 'text/html'},
-    );
+    return renderComponent(Document(
+      // we still point to /app to correctly load all other resources,
+      // like js, css or image files
+      base: '/app',
+      body: Hello(),
+    ));
   });
 
   var handler = const Pipeline() //

--- a/packages/jaspr/CHANGELOG.md
+++ b/packages/jaspr/CHANGELOG.md
@@ -12,6 +12,11 @@
 
 - Add `Attach` component
 
+- Allow response headers to be overrided via server context.binding
+  ```dart
+  (context.binding as ServerAppBinding).responseHeaders['Your-Custom-Header'] = "This is value";
+  ```
+
 ## 0.13.3
 
 - Added support for custom models as parameters to `@client` components.

--- a/packages/jaspr/lib/src/server/run_app.dart
+++ b/packages/jaspr/lib/src/server/run_app.dart
@@ -30,7 +30,7 @@ typedef RenderFunction = FutureOr<Response> Function(Component);
 typedef AppHandler = FutureOr<Response> Function(Request, RenderFunction render);
 
 /// Directly renders the provided component into a html string
-Future<String> renderComponent(Component app) async {
+Future<Response> renderComponent(Component app) async {
   _checkInitialized('renderComponent');
   var fileHandler = staticFileHandler();
   return render(RenderMode.html, _createSetup(app), Uri.parse('https://0.0.0.0/'), (name) async {

--- a/packages/jaspr/lib/src/server/server_handler.dart
+++ b/packages/jaspr/lib/src/server/server_handler.dart
@@ -68,9 +68,11 @@ Handler createHandler(SetupHandler handle, {http.Client? client, Handler? fileHa
         requestUri = requestUri.replace(path: '/${requestUri.path}');
       }
 
-      return Response.ok(
-        await render(isDataMode ? RenderMode.data : RenderMode.html, setup, requestUri, fileLoader),
-        headers: {'Content-Type': isDataMode ? 'application/json' : 'text/html'},
+      return render(
+        isDataMode ? RenderMode.data : RenderMode.html,
+        setup,
+        requestUri,
+        fileLoader,
       );
     });
   });


### PR DESCRIPTION
<!--
  Thanks for contributing! 💙

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
Allow server component to set headers via ServerAppBinding. Previously, jaspr return HTML string, but for this PR, I have change to Response instead which will construct headers with content type & body in single place `render` method.

In server component, to override header, just do as following:
```dart
(context.binding as ServerAppBinding).responseHeaders['Your-Custom-Header'] = "This is value";
```

Inspired by Ruby on Rails where you can set response.headers from controller.

## Type of Change

<!-- Uncomment all that apply: -->

<!-- - ❌ Breaking change -->
✨ New feature or improvement
<!-- - 🛠️ Bug fix -->
<!-- - 🧹 Code refactor -->
<!-- - 📝 Documentation -->
<!-- - 🗑️ Chore -->

## Ready Checklist

- [x] I've read the [Contribution Guide](https://github.com/schultek/jaspr/blob/main/CONTRIBUTING.md).
- [x] In case this PR changes one of the core packages, I've modified the respective **CHANGELOG.md** file using
      the [semantic_changelog](https://github.com/rrousselGit/semantic_changelog) format.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added myself to the AUTHORS file (optional, if you want to).

<!-- 
  Feel free to expand this list if you have additional todos before your PR is ready. 
-->

<!--
  If you need help, consider asking for advice on the *#contribute* channel on [Discord](https://discord.gg/XGXrGEk4c6).
-->

## Related issues
- https://github.com/schultek/jaspr/issues/258