### PR TITLE
fix: Spelling mistake for space evenly

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,3 +9,4 @@ Jeff Ward (fuzzybinary) - Contributor
 Matthew Jaoudi (gadfly361) - Contributor
 Rishabh Singh (cybertheory), UC Berkeley/Pagefelt - Contributor
 Wahab Alshahin (walsha2) - Contributor
+Lucas Goldner (lucas-goldner) - Contributor

--- a/packages/jaspr/CHANGELOG.md
+++ b/packages/jaspr/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased patch
 
-- **BREAKING** Fixed spelling mistake from `spaceRvenly` to `spaceEvenly`
+- Fixed spelling mistake from `spaceRvenly` to `spaceEvenly`
 
 ## 0.14.0
 

--- a/packages/jaspr/CHANGELOG.md
+++ b/packages/jaspr/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased patch
+
+- **BREAKING** Fixed spelling mistake from `spaceRvenly` to `spaceEvenly`
+
 ## 0.14.0
 
 - **BREAKING** Calling `Jaspr.initializeApp()` is now required in static and server mode.

--- a/packages/jaspr/lib/src/foundation/styles/properties/flexbox.dart
+++ b/packages/jaspr/lib/src/foundation/styles/properties/flexbox.dart
@@ -39,7 +39,7 @@ enum JustifyContent {
   normal('normal'),
   spaceBetween('space-between'),
   spaceAround('space-around'),
-  spaceRvenly('space-evenly'),
+  spaceEvenly('space-evenly'),
   stretch('stretch'),
   inherit('inherit'),
   initial('initial'),


### PR DESCRIPTION
## Description

I just fixed a minor spelling mistake I noticed. Hope the Changelog part is correct like that ^^ 

## Type of Change

🧹 Code refactor

## Ready Checklist

- [x] I've read the [Contribution Guide](https://github.com/schultek/jaspr/blob/main/CONTRIBUTING.md).
- [x] In case this PR changes one of the core packages, I've modified the respective **CHANGELOG.md** file using
      the [semantic_changelog](https://github.com/rrousselGit/semantic_changelog) format.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added myself to the AUTHORS file (optional, if you want to). 
