### PR TITLE
fix: Adjust contribution link

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
   web framework written completely in Dart.
 
 > Want to contribute to Jaspr? Join our open [Discord Community](https://discord.gg/XGXrGEk4c6) of
-> developers around Jaspr and check out the [Contributing Guide](https://docs.page/schultek/jaspr/eco/contributing).
+> developers around Jaspr and check out the [Contributing Guide](https://docs.page/schultek/jaspr/going_further/contributing).
 
 ### Core Features
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -38,7 +38,7 @@ description: Documentation for the jaspr web framework.
 
 <Info>
 Want to contribute to Jaspr? Join our open [Discord Community](https://discord.gg/XGXrGEk4c6) 
-of developers around Jaspr and check out the [Contributing Guide](/eco/contributing).
+of developers around Jaspr and check out the [Contributing Guide](/going_further/contributing).
 </Info>
 
 ## 🎡 Online Editor & Playground


### PR DESCRIPTION
## Description

The contribution link was still linked to the old page.

## Type of Change

📝 Documentation

## Ready Checklist

- [x] I've read the [Contribution Guide](https://github.com/schultek/jaspr/blob/main/CONTRIBUTING.md).
- [x] In case this PR changes one of the core packages, I've modified the respective **CHANGELOG.md** file using
      the [semantic_changelog](https://github.com/rrousselGit/semantic_changelog) format.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added myself to the AUTHORS file (optional, if you want to). 