### PR TITLE
Fix an issue where resolution of webDir would hang.

### DIFF
--- a/packages/jaspr/CHANGELOG.md
+++ b/packages/jaspr/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased patch
+
+- Fixed an issue where webDir would never resolve during tests.
+
 ## 0.15.1
 
 - Include and setup `jaspr_lints` in newly created projects.

--- a/packages/jaspr/pubspec.yaml
+++ b/packages/jaspr/pubspec.yaml
@@ -34,3 +34,4 @@ dev_dependencies:
   build_web_compilers: ^4.0.0
   jaspr_test: '>=0.1.0 <1.0.0'
   lints: ^3.0.0
+  test: ^1.25.8

--- a/packages/jaspr/test/server/without_jaspr_testing_library/without_jaspr_testing_library_app.dart
+++ b/packages/jaspr/test/server/without_jaspr_testing_library/without_jaspr_testing_library_app.dart
@@ -1,0 +1,10 @@
+import 'package:jaspr/jaspr.dart';
+
+class App extends StatelessComponent {
+  @override
+  Iterable<Component> build(BuildContext context) sync* {
+    yield DomComponent(tag: 'div', children: [
+      Text('Hello'),
+    ]);
+  }
+}

--- a/packages/jaspr/test/server/without_jaspr_testing_library/without_jaspr_testing_library_test.dart
+++ b/packages/jaspr/test/server/without_jaspr_testing_library/without_jaspr_testing_library_test.dart
@@ -1,0 +1,17 @@
+@TestOn('vm')
+
+import 'package:jaspr/jaspr.dart';
+import 'package:jaspr/src/server/run_app.dart';
+import 'package:test/test.dart';
+
+import 'without_jaspr_testing_library_app.dart';
+
+void main() {
+  group('without jaspr testing library', () {
+    test('should resolve the project root and render', () async {
+      Jaspr.initializeApp();
+      final rendered = await renderComponent(App());
+      expect(rendered.contains('Hello'), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
This solves issues when running the backend server during tests on a Windows machines where the existing solution would infinitely loop in search of the directory.

<!--
  Thanks for contributing! 💙

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Previous implementation would look for the `pubspec.yaml` based on the location of the executable. When running tests on my Windows machine, that location is some random temporary directory. I added a fallback resolution based on the working directory (which is the project directory during tests).

I also made sure we would throw an exception if we could not actually resolve the directory, this informs the user and lets them set an environment variable instead.

The previous implementation would never resolve any directory on Windows machines during tests because the root dir would not satisfy the exit condition of the loop.

## Type of Change

🛠️ Bug fix 

## Ready Checklist

- [x] I've read the [Contribution Guide](https://github.com/schultek/jaspr/blob/main/CONTRIBUTING.md).
- [x] In case this PR changes one of the core packages, I've modified the respective **CHANGELOG.md** file using
      the [semantic_changelog](https://github.com/rrousselGit/semantic_changelog) format.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added myself to the AUTHORS file (optional, if you want to).

