### PR TITLE
Add variable support

### DIFF
--- a/packages/jaspr/CHANGELOG.md
+++ b/packages/jaspr/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 0.16.0
-- Added css variable for Unit, Color and Angle.
+- Added css variable for Unit, Color, Angle and FontFamily.
 
 ## 0.15.0
 

--- a/packages/jaspr/CHANGELOG.md
+++ b/packages/jaspr/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.16.0
+- Added css variable for Unit, Color and Angle.
+
 ## 0.15.0
 
 - Added support for using `@css` and `@encoder`/`@decoder` across other packages.

--- a/packages/jaspr/CHANGELOG.md
+++ b/packages/jaspr/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.16.0
+## Unreleased minor
 - Added css variable for Unit, Color, Angle and FontFamily.
 
 ## 0.15.0

--- a/packages/jaspr/lib/src/foundation/styles/properties/angle.dart
+++ b/packages/jaspr/lib/src/foundation/styles/properties/angle.dart
@@ -18,6 +18,9 @@ abstract class Angle {
   /// Constructs an [Angle] in the form '1turn'
   const factory Angle.turn(double value) = _TurnAngle;
 
+  /// Represents a css variable
+  const factory Angle.variable(String value) = _VariableAngle;
+
   /// The css value
   String get value;
 }
@@ -33,6 +36,21 @@ class _ZeroAngle implements Angle {
 
   @override
   int get hashCode => 0;
+}
+
+class _VariableAngle implements Angle {
+  final String _value;
+
+  const _VariableAngle(this._value);
+
+  @override
+  String get value => 'var($_value)';
+
+  @override
+  bool operator ==(Object other) => identical(this, other) || other is _VariableAngle && other._value == _value;
+
+  @override
+  int get hashCode => _value.hashCode;
 }
 
 class _Angle implements Angle {

--- a/packages/jaspr/lib/src/foundation/styles/properties/color.dart
+++ b/packages/jaspr/lib/src/foundation/styles/properties/color.dart
@@ -99,12 +99,12 @@ class _HSLAColor extends _HSLColor {
 }
 
 class _VariableColor implements Color {
-  final String _variable;
+  final String _value;
 
-  const _VariableColor(this._variable);
+  const _VariableColor(this._value);
 
   @override
-  String get value => 'var($_variable)';
+  String get value => 'var($_value)';
 }
 
 class Colors {

--- a/packages/jaspr/lib/src/foundation/styles/properties/color.dart
+++ b/packages/jaspr/lib/src/foundation/styles/properties/color.dart
@@ -20,6 +20,9 @@ abstract class Color {
   /// Constructs a [Color] from hue, saturation, lightness and alpha values
   const factory Color.hsla(int hue, int saturation, int lightness, double alpha) = _HSLAColor;
 
+  /// Constructs a variable containing color.
+  const factory Color.variable(String value) = _VariableColor;
+
   static const Color inherit = Color.named('inherit');
   static const Color initial = Color.named('initial');
   static const Color revert = Color.named('revert');
@@ -93,6 +96,15 @@ class _HSLAColor extends _HSLColor {
 
   @override
   String get value => 'hsla($hue, $saturation%, $lightness%, $alpha)';
+}
+
+class _VariableColor implements Color {
+  final String _variable;
+
+  const _VariableColor(this._variable);
+
+  @override
+  String get value => 'var($_variable)';
 }
 
 class Colors {

--- a/packages/jaspr/lib/src/foundation/styles/properties/text.dart
+++ b/packages/jaspr/lib/src/foundation/styles/properties/text.dart
@@ -33,6 +33,9 @@ class FontFamily {
   /// Constructs a [FontFamily] value from a list of families
   const factory FontFamily.list(List<FontFamily> families) = _ListFontFamily;
 
+  /// Constructs a css variable with FontFamily
+  const factory FontFamily.variable(String value) = _VariableFontFamily;
+
   static const FontFamily inherit = FontFamily._generic('inherit');
   static const FontFamily initial = FontFamily._generic('initial');
   static const FontFamily revert = FontFamily._generic('revert');
@@ -46,6 +49,14 @@ class _ListFontFamily implements FontFamily {
 
   @override
   String get value => families.map((f) => f.value).join(', ');
+}
+
+class _VariableFontFamily implements FontFamily {
+  final String _value;
+  const _VariableFontFamily(this._value);
+
+  @override
+  String get value => 'var($_value)';
 }
 
 class FontFamilies {

--- a/packages/jaspr/lib/src/foundation/styles/properties/text.dart
+++ b/packages/jaspr/lib/src/foundation/styles/properties/text.dart
@@ -53,6 +53,7 @@ class _ListFontFamily implements FontFamily {
 
 class _VariableFontFamily implements FontFamily {
   final String _value;
+
   const _VariableFontFamily(this._value);
 
   @override

--- a/packages/jaspr/lib/src/foundation/styles/properties/unit.dart
+++ b/packages/jaspr/lib/src/foundation/styles/properties/unit.dart
@@ -51,6 +51,9 @@ abstract class Unit {
   ///auto represents the style attribute unit 'auto'
   static const Unit auto = _AutoUnit();
 
+  /// Represents a css variable
+  const factory Unit.variable(String value) = _VariableUnit;
+
   /// Constructs a [Unit] in the form '100%'
   const factory Unit.percent(double value) = _PercentUnit;
 
@@ -101,6 +104,21 @@ class _AutoUnit implements Unit {
 
   @override
   int get hashCode => 0;
+}
+
+class _VariableUnit implements Unit {
+  final String _value;
+
+  const _VariableUnit(this._value);
+
+  @override
+  String get value => 'var($_value)';
+
+  @override
+  bool operator ==(Object other) => identical(this, other) || other is _VariableUnit && other._value == _value;
+
+  @override
+  int get hashCode => _value.hashCode;
 }
 
 class _Unit implements Unit {


### PR DESCRIPTION
<!--
  Thanks for contributing! 💙

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Hello I added support variables for colors and units. https://github.com/schultek/jaspr/issues/279
Right now you can define variables in your html:
```
      .raw({
        '--background-color': '#fff',
        '--text-color': Colors.blue.value,
        '--text-size': 14.pt.value,
        // other values...
      }),

```
and use it as: `Color.variable('--text-color')` or `Unit.variable('--text-size')`

## Type of Change

<!-- Uncomment all that apply: -->

<!-- - ❌ Breaking change -->
✨ New feature or improvement
<!-- - 🛠️ Bug fix -->
<!-- - 🧹 Code refactor -->
<!-- - 📝 Documentation -->
<!-- - 🗑️ Chore -->

## Ready Checklist

- [ ] I've read the [Contribution Guide](https://github.com/schultek/jaspr/blob/main/CONTRIBUTING.md).
- [x] In case this PR changes one of the core packages, I've modified the respective **CHANGELOG.md** file using
      the [semantic_changelog](https://github.com/rrousselGit/semantic_changelog) format.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added myself to the AUTHORS file (optional, if you want to).

<!-- 
  Feel free to expand this list if you have additional todos before your PR is ready. 
-->

<!--
  If you need help, consider asking for advice on the *#contribute* channel on [Discord](https://discord.gg/XGXrGEk4c6).
-->
