### PR TITLE
Fix tests when running with package:web

### DIFF
--- a/packages/jaspr/lib/src/foundation/events/events.dart
+++ b/packages/jaspr/lib/src/foundation/events/events.dart
@@ -42,8 +42,10 @@ void Function(web.Event) _callWithValue<V>(String event, void Function(V) fn) {
   return (e) {
     var target = e.target;
     var value = switch (target) {
-      web.HTMLInputElement() when target.instanceOfString("HTMLInputElement") => () {
-          var type = InputType.values.where((v) => v.name == target.type).firstOrNull;
+      web.HTMLInputElement() when target.instanceOfString("HTMLInputElement") =>
+        () {
+          var type =
+              InputType.values.where((v) => v.name == target.type).firstOrNull;
           return switch (type) {
             InputType.checkbox || InputType.radio => target.checked,
             InputType.number => target.valueAsNumber,
@@ -52,10 +54,16 @@ void Function(web.Event) _callWithValue<V>(String event, void Function(V) fn) {
             _ => target.value,
           };
         }(),
-      web.HTMLTextAreaElement() when target.instanceOfString("HTMLTextAreaElement") => target.value,
-      web.HTMLSelectElement() when target.instanceOfString("HTMLSelectElement") => [
+      web.HTMLTextAreaElement()
+          when target.instanceOfString("HTMLTextAreaElement") =>
+        target.value,
+      web.HTMLSelectElement()
+          when target.instanceOfString("HTMLSelectElement") =>
+        [
           for (final o in target.selectedOptions.toIterable())
-            if (o is web.HTMLOptionElement && o.instanceOfString("HTMLOptionElement")) o.value,
+            if (o is web.HTMLOptionElement &&
+                o.instanceOfString("HTMLOptionElement"))
+              o.value,
         ],
       _ => null,
     };

--- a/packages/jaspr/lib/src/foundation/events/events.dart
+++ b/packages/jaspr/lib/src/foundation/events/events.dart
@@ -42,10 +42,8 @@ void Function(web.Event) _callWithValue<V>(String event, void Function(V) fn) {
   return (e) {
     var target = e.target;
     var value = switch (target) {
-      web.HTMLInputElement() when target.instanceOfString("HTMLInputElement") =>
-        () {
-          var type =
-              InputType.values.where((v) => v.name == target.type).firstOrNull;
+      web.HTMLInputElement() when target.instanceOfString("HTMLInputElement") => () {
+          var type = InputType.values.where((v) => v.name == target.type).firstOrNull;
           return switch (type) {
             InputType.checkbox || InputType.radio => target.checked,
             InputType.number => target.valueAsNumber,
@@ -54,16 +52,10 @@ void Function(web.Event) _callWithValue<V>(String event, void Function(V) fn) {
             _ => target.value,
           };
         }(),
-      web.HTMLTextAreaElement()
-          when target.instanceOfString("HTMLTextAreaElement") =>
-        target.value,
-      web.HTMLSelectElement()
-          when target.instanceOfString("HTMLSelectElement") =>
-        [
+      web.HTMLTextAreaElement() when target.instanceOfString("HTMLTextAreaElement") => target.value,
+      web.HTMLSelectElement() when target.instanceOfString("HTMLSelectElement") => [
           for (final o in target.selectedOptions.toIterable())
-            if (o is web.HTMLOptionElement &&
-                o.instanceOfString("HTMLOptionElement"))
-              o.value,
+            if (o is web.HTMLOptionElement && o.instanceOfString("HTMLOptionElement")) o.value,
         ],
       _ => null,
     };

--- a/packages/jaspr/lib/src/foundation/events/web_stub.dart
+++ b/packages/jaspr/lib/src/foundation/events/web_stub.dart
@@ -1,5 +1,7 @@
 abstract class Event {
   Node get target;
+
+  void preventDefault();
 }
 
 abstract class HTMLInputElement implements Node {

--- a/packages/jaspr/test/browser/head/head_app.dart
+++ b/packages/jaspr/test/browser/head/head_app.dart
@@ -3,7 +3,6 @@ import 'package:jaspr/jaspr.dart';
 class App extends StatelessComponent {
   @override
   Iterable<Component> build(BuildContext context) sync* {
-    yield Document.head(title: 'a', meta: {'test': 'b', 'c': 'd'});
     yield Page();
   }
 }

--- a/packages/jaspr/test/browser/head/head_browser_test.dart
+++ b/packages/jaspr/test/browser/head/head_browser_test.dart
@@ -11,13 +11,9 @@ void main() {
     testBrowser('should serve component', (tester) async {
       await tester.pumpComponent(App());
 
-      var nodes =
-          AttachAdapter.instanceFor(AttachTarget.head).liveNodes.toList();
+      var nodes = AttachAdapter.instanceFor(AttachTarget.head).liveNodes.toList();
 
-      expect(nodes, [
-        _hasOuterHtml('<title>c</title>'),
-        _hasOuterHtml('<meta name="c" content="e">')
-      ]);
+      expect(nodes, [_hasOuterHtml('<title>c</title>'), _hasOuterHtml('<meta name="c" content="e">')]);
 
       await tester.click(find.tag('button'));
 

--- a/packages/jaspr/test/browser/head/head_browser_test.dart
+++ b/packages/jaspr/test/browser/head/head_browser_test.dart
@@ -1,9 +1,8 @@
 @TestOn('browser')
 
-import 'dart:html';
-
 import 'package:jaspr/src/components/document/document_client.dart';
 import 'package:jaspr_test/browser_test.dart';
+import 'package:web/web.dart';
 
 import 'head_app.dart';
 
@@ -12,20 +11,23 @@ void main() {
     testBrowser('should serve component', (tester) async {
       await tester.pumpComponent(App());
 
-      var nodes = AttachAdapter.instanceFor(AttachTarget.head).liveNodes.toList();
+      var nodes =
+          AttachAdapter.instanceFor(AttachTarget.head).liveNodes.toList();
 
-      expect(nodes, hasLength(3));
-      expect((nodes[0] as Element).outerHtml, equals('<title>c</title>'));
-      expect((nodes[1] as Element).outerHtml, equals('<meta name="test" content="b">'));
-      expect((nodes[2] as Element).outerHtml, equals('<meta name="c" content="e">'));
+      expect(nodes, [
+        _hasOuterHtml('<title>c</title>'),
+        _hasOuterHtml('<meta name="c" content="e">')
+      ]);
 
       await tester.click(find.tag('button'));
 
       nodes = AttachAdapter.instanceFor(AttachTarget.head).liveNodes.toList();
 
-      expect((nodes[0] as Element).outerHtml, equals('<title>d</title>'));
-      expect((nodes[1] as Element).outerHtml, equals('<meta name="test" content="b">'));
-      expect((nodes[2] as Element).outerHtml, equals('<meta name="c" content="d">'));
+      expect(nodes, [_hasOuterHtml('<title>d</title>')]);
     });
   });
+}
+
+Matcher _hasOuterHtml(outer) {
+  return isA<HTMLElement>().having((e) => e.outerHTML, 'outerHTML', outer);
 }

--- a/packages/jaspr_builder/test/imports/sources/imports.dart
+++ b/packages/jaspr_builder/test/imports/sources/imports.dart
@@ -32,7 +32,7 @@ final importsOutput = {
       'export \'generated/imports/_web.dart\' if (dart.library.io) \'generated/imports/_stubs.dart\'\n'
       '    show window, Window, WindowOrStubbed;\n'
       '\n'
-      'export \'generated/imports/_vm.dart\' if (dart.library.html) \'generated/imports/_stubs.dart\'\n'
+      'export \'generated/imports/_vm.dart\' if (dart.library.js_interop) \'generated/imports/_stubs.dart\'\n'
       '    show HttpServer, HttpServerOrStubbed;\n'
       ''
 };

--- a/packages/jaspr_router/lib/src/platform/platform_web.dart
+++ b/packages/jaspr_router/lib/src/platform/platform_web.dart
@@ -18,8 +18,7 @@ class PlatformRouterImpl implements PlatformRouter {
 /// Accesses the window.history api
 class HistoryManagerImpl implements HistoryManager {
   @override
-  void init(AppBinding binding,
-      {void Function(Object? state, {String? url})? onChangeState}) {
+  void init(AppBinding binding, {void Function(Object? state, {String? url})? onChangeState}) {
     if (onChangeState != null) {
       window.onPopState.listen((event) {
         onChangeState(window.history.state);

--- a/packages/jaspr_router/lib/src/platform/platform_web.dart
+++ b/packages/jaspr_router/lib/src/platform/platform_web.dart
@@ -1,6 +1,7 @@
-import 'dart:html';
+import 'dart:js_interop';
 
 import 'package:jaspr/jaspr.dart';
+import 'package:web/web.dart';
 
 import '../route.dart';
 import 'platform.dart';
@@ -17,7 +18,8 @@ class PlatformRouterImpl implements PlatformRouter {
 /// Accesses the window.history api
 class HistoryManagerImpl implements HistoryManager {
   @override
-  void init(AppBinding binding, {void Function(Object? state, {String? url})? onChangeState}) {
+  void init(AppBinding binding,
+      {void Function(Object? state, {String? url})? onChangeState}) {
     if (onChangeState != null) {
       window.onPopState.listen((event) {
         onChangeState(window.history.state);
@@ -27,12 +29,12 @@ class HistoryManagerImpl implements HistoryManager {
 
   @override
   void push(String url, {String? title, Object? data}) {
-    window.history.pushState(data, title ?? url, url);
+    window.history.pushState(data.jsify(), title ?? url, url);
   }
 
   @override
   void replace(String url, {String? title, Object? data}) {
-    window.history.replaceState(data, title ?? url, url);
+    window.history.replaceState(data.jsify(), title ?? url, url);
   }
 
   @override

--- a/packages/jaspr_router/pubspec.yaml
+++ b/packages/jaspr_router/pubspec.yaml
@@ -13,6 +13,7 @@ environment:
 
 dependencies:
   jaspr: ^0.15.0
+  web: ^1.0.0
 
 dev_dependencies:
   jaspr_test: '>=0.1.0 <1.0.0'

--- a/packages/jaspr_test/lib/src/testers/component_tester.dart
+++ b/packages/jaspr_test/lib/src/testers/component_tester.dart
@@ -8,6 +8,7 @@ import 'package:test/test.dart';
 
 import '../binding.dart';
 import '../finders.dart';
+import 'fake_event_web.dart' if (dart.library.io) 'fake_event_vm.dart';
 
 @isTest
 void testComponents(
@@ -51,7 +52,7 @@ class ComponentTester {
   /// Simulates a 'click' event on the given element
   /// and pumps the next frame.
   Future<void> click(Finder finder, {bool pump = true}) async {
-    dispatchEvent(finder, 'click', null);
+    dispatchEvent(finder, 'click', fakeEvent());
     if (pump) {
       await pumpEventQueue();
     }
@@ -108,7 +109,8 @@ class TestComponentsBinding extends AppBinding with ComponentsBinding {
 
   final Uri? _currentUri;
   @override
-  Uri get currentUri => _currentUri ?? (throw 'Did not call setUp() with currentUri provided.');
+  Uri get currentUri =>
+      _currentUri ?? (throw 'Did not call setUp() with currentUri provided.');
 
   final bool _isClient;
   @override
@@ -153,8 +155,13 @@ class TestRenderObject extends RenderObject {
   }
 
   @override
-  void updateElement(String tag, String? id, String? classes, Map<String, String>? styles,
-      Map<String, String>? attributes, Map<String, EventCallback>? events) {
+  void updateElement(
+      String tag,
+      String? id,
+      String? classes,
+      Map<String, String>? styles,
+      Map<String, String>? attributes,
+      Map<String, EventCallback>? events) {
     this
       ..tag = tag
       ..id = id

--- a/packages/jaspr_test/lib/src/testers/component_tester.dart
+++ b/packages/jaspr_test/lib/src/testers/component_tester.dart
@@ -109,8 +109,7 @@ class TestComponentsBinding extends AppBinding with ComponentsBinding {
 
   final Uri? _currentUri;
   @override
-  Uri get currentUri =>
-      _currentUri ?? (throw 'Did not call setUp() with currentUri provided.');
+  Uri get currentUri => _currentUri ?? (throw 'Did not call setUp() with currentUri provided.');
 
   final bool _isClient;
   @override
@@ -155,13 +154,8 @@ class TestRenderObject extends RenderObject {
   }
 
   @override
-  void updateElement(
-      String tag,
-      String? id,
-      String? classes,
-      Map<String, String>? styles,
-      Map<String, String>? attributes,
-      Map<String, EventCallback>? events) {
+  void updateElement(String tag, String? id, String? classes, Map<String, String>? styles,
+      Map<String, String>? attributes, Map<String, EventCallback>? events) {
     this
       ..tag = tag
       ..id = id

--- a/packages/jaspr_test/lib/src/testers/fake_event_vm.dart
+++ b/packages/jaspr_test/lib/src/testers/fake_event_vm.dart
@@ -1,0 +1,14 @@
+// ignore: implementation_imports
+import 'package:jaspr/src/foundation/events/web_stub.dart';
+
+Event fakeEvent() {
+  return _FakeEvent();
+}
+
+final class _FakeEvent implements Event {
+  @override
+  void preventDefault() {}
+
+  @override
+  Node get target => throw UnimplementedError();
+}

--- a/packages/jaspr_test/lib/src/testers/fake_event_web.dart
+++ b/packages/jaspr_test/lib/src/testers/fake_event_web.dart
@@ -1,0 +1,5 @@
+import 'package:web/web.dart';
+
+Event fakeEvent() {
+  return Event('click');
+}


### PR DESCRIPTION
This adds onto https://github.com/schultek/jaspr/pull/269#issuecomment-2343343221 to fix failing tests.

The main failures essentially boil down to us having to fake an `Event` class when running in the Dart VM that needs to be close to the `Event` class in JS.