### PR TITLE
added missing `s` for file import doc in annotations.dart file

### DIFF
--- a/packages/jaspr/lib/src/foundation/annotations.dart
+++ b/packages/jaspr/lib/src/foundation/annotations.dart
@@ -29,13 +29,13 @@ class DecoderAnnotation {
 ///
 /// ```
 /// @Import.onWeb('dart:html', show: [#window])
-/// import 'file.import.dart';
+/// import 'file.imports.dart';
 /// ```
 ///
 /// 1. Put the actual import in the annotation.
 /// 3. Define what elements or types to 'show' as symbols (prefixed by #).
 ///   - This is required to reduce the amount of stubbing needed.
-/// 2. Import the file '<current filename>.import.dart'.
+/// 2. Import the file '<current filename>.imports.dart'.
 ///
 /// The associated file will be generated the next time you run `jaspr serve`.
 ///


### PR DESCRIPTION
> annotations.dart
```dart
/// import 'file.imports.dart';
.....
/// 2. Import the file '<current filename>.imports.dart'.
```

## Description

This pull request addresses a minor typo in the documentation. The import statement in the docs was missing an `s`. The change is as follows:

```dart
/// import 'file.import.dart';

2. Import the file '<current filename>.imports.dart'.
```


## Type of Change



 📝 Documentation 

## Ready Checklist

- [ ] I've read the [Contribution Guide](https://github.com/schultek/jaspr/blob/main/CONTRIBUTING.md).
- [ ] In case this PR changes one of the core packages, I've modified the respective **CHANGELOG.md** file using
      the [semantic_changelog](https://github.com/rrousselGit/semantic_changelog) format.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added myself to the AUTHORS file (optional, if you want to).

<!-- 
  Feel free to expand this list if you have additional todos before your PR is ready. 
-->

<!--
  If you need help, consider asking for advice on the *#contribute* channel on [Discord](https://discord.gg/XGXrGEk4c6).
-->
