### PR TITLE
fix(docs): Clarify `pub get` command and correct typo in `analysis_options.yaml` example

### DIFF
--- a/packages/jaspr_lints/README.md
+++ b/packages/jaspr_lints/README.md
@@ -31,10 +31,10 @@ dart pub add jaspr_lints --dev
 ```yaml
 analyzer:
   plugins:
-    - custom_lints
+    - custom_lint
 ```
 
-After running `pub get` you now see additional Jaspr lints 
+After running `dart pub get` you now see additional Jaspr lints 
 when invoking code assist on a component function like `div()` or `p()` files.
 
 ## Usage


### PR DESCRIPTION
## Description

- Replaced `pub get` with `dart pub get` to reflect the correct Dart command.
- Corrected typo in the `analysis_options.yaml` example by replacing `custom_lints` with `custom_lint`.

## Type of Change

📝 Documentation

## Ready Checklist

- [x] I've read the [Contribution Guide](https://github.com/schultek/jaspr/blob/main/CONTRIBUTING.md).
- [ ] In case this PR changes one of the core packages, I've modified the respective **CHANGELOG.md** file using the [semantic_changelog](https://github.com/rrousselGit/semantic_changelog) format.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added myself to the AUTHORS file (optional, if you want to).