### PR TITLE
fix: dart process not able to find tailwindcss in path

### DIFF
--- a/packages/jaspr_tailwind/CHANGELOG.md
+++ b/packages/jaspr_tailwind/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased patch
+
+- Fixed execution of tailwind cli by adding `runInShell: true`.
+
 ## 0.3.0
 
 - Added minify option to tailwind in release mode.

--- a/packages/jaspr_tailwind/lib/builder.dart
+++ b/packages/jaspr_tailwind/lib/builder.dart
@@ -53,6 +53,7 @@ class TailwindBuilder implements Builder {
           p.join(Directory.current.path, '{lib,web}', '**', '*.dart').toPosix(true),
         ],
       ],
+      runInShell: true,
     );
 
     await scratchSpace.copyOutput(outputId, buildStep);


### PR DESCRIPTION
<!--
  Thanks for contributing! 💙

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

When running jaspr serve on some devices, the dart process isn't able to find `tailwindcss` command in the path.

## Type of Change

<!-- Uncomment all that apply: -->

<!-- - ❌ Breaking change -->
<!-- - ✨ New feature or improvement -->
🛠️ Bug fix
<!-- - 🧹 Code refactor -->
<!-- - 📝 Documentation -->
<!-- - 🗑️ Chore -->

## Ready Checklist

- [x] I've read the [Contribution Guide](https://github.com/schultek/jaspr/blob/main/CONTRIBUTING.md).
- [ ] In case this PR changes one of the core packages, I've modified the respective **CHANGELOG.md** file using
      the [semantic_changelog](https://github.com/rrousselGit/semantic_changelog) format.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added myself to the AUTHORS file (optional, if you want to).

<!-- 
  Feel free to expand this list if you have additional todos before your PR is ready. 
-->

<!--
  If you need help, consider asking for advice on the *#contribute* channel on [Discord](https://discord.gg/XGXrGEk4c6).
-->
