### PR TITLE
 - add isDark for MediaQuery

### DIFF
--- a/packages/jaspr/CHANGELOG.md
+++ b/packages/jaspr/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased patch
+
+- Added `prefersColorScheme` parameter to `MediaQuery`.
+
 ## 0.16.4
 
 - Added `--dart-define`, `--dart-define-client` and `--dart-define-server` to `serve` and `build` commands.

--- a/packages/jaspr/lib/src/foundation/styles/rules.dart
+++ b/packages/jaspr/lib/src/foundation/styles/rules.dart
@@ -110,6 +110,7 @@ abstract class MediaQuery {
     Orientation? orientation,
     bool? canHover,
     String? aspectRatio,
+    ColorScheme? prefersColorScheme,
   }) = _MediaRuleQuery.all;
 
   const factory MediaQuery.screen({
@@ -120,6 +121,7 @@ abstract class MediaQuery {
     Orientation? orientation,
     bool? canHover,
     String? aspectRatio,
+    ColorScheme? prefersColorScheme,
   }) = _MediaRuleQuery.screen;
 
   const factory MediaQuery.print({
@@ -130,6 +132,7 @@ abstract class MediaQuery {
     Orientation? orientation,
     bool? canHover,
     String? aspectRatio,
+    ColorScheme? prefersColorScheme,
   }) = _MediaRuleQuery.print;
 
   const factory MediaQuery.not(MediaQuery query) = _NotMediaRuleQuery;
@@ -137,6 +140,8 @@ abstract class MediaQuery {
 }
 
 enum Orientation { portrait, landscape }
+
+enum ColorScheme { light, dark }
 
 class _MediaRuleQuery implements MediaQuery {
   const _MediaRuleQuery.all({
@@ -147,7 +152,7 @@ class _MediaRuleQuery implements MediaQuery {
     this.orientation,
     this.canHover,
     this.aspectRatio,
-    this.isDark,
+    this.prefersColorScheme,
   }) : target = 'all';
 
   const _MediaRuleQuery.screen({
@@ -158,7 +163,7 @@ class _MediaRuleQuery implements MediaQuery {
     this.orientation,
     this.canHover,
     this.aspectRatio,
-    this.isDark,
+    this.prefersColorScheme,
   }) : target = 'screen';
 
   const _MediaRuleQuery.print({
@@ -169,7 +174,7 @@ class _MediaRuleQuery implements MediaQuery {
     this.orientation,
     this.canHover,
     this.aspectRatio,
-    this.isDark,
+    this.prefersColorScheme,
   }) : target = 'print';
 
   final String target;
@@ -180,7 +185,7 @@ class _MediaRuleQuery implements MediaQuery {
   final Orientation? orientation;
   final bool? canHover;
   final String? aspectRatio;
-  final bool? isDark;
+  final ColorScheme? prefersColorScheme;
 
   @override
   String get _value => '$target'
@@ -190,7 +195,7 @@ class _MediaRuleQuery implements MediaQuery {
       '${maxHeight != null ? ' and (max-height: ${maxHeight!.value})' : ''}'
       '${orientation != null ? ' and (orientation: ${orientation!.name})' : ''}'
       '${canHover != null ? ' and (hover: ${canHover! ? 'hover' : 'none'})' : ''}'
-      '${isDark != null ? ' and (prefers-color-scheme: ${isDark! ? 'dark' : 'light'})' : ''}'
+      '${prefersColorScheme != null ? ' and (prefers-color-scheme: ${prefersColorScheme!.name})' : ''}'
       '${aspectRatio != null ? ' and (aspect-ratio: ${aspectRatio!})' : ''}';
 }
 

--- a/packages/jaspr/lib/src/foundation/styles/rules.dart
+++ b/packages/jaspr/lib/src/foundation/styles/rules.dart
@@ -4,25 +4,44 @@ import 'styles.dart';
 
 abstract class StyleRule {
   /// Renders a css rule with the given selector and styles.
-  const factory StyleRule({required Selector selector, required Styles styles}) = BlockStyleRule;
+  const factory StyleRule({
+    required Selector selector,
+    required Styles styles,
+  }) = BlockStyleRule;
 
   /// Renders a `@import url(...)` css rule.
   const factory StyleRule.import(String url) = ImportStyleRule;
 
   /// Renders a `@font-face` css rule.
-  const factory StyleRule.fontFace({required String family, FontStyle? style, required String url}) = FontFaceStyleRule;
+  const factory StyleRule.fontFace({
+    required String family,
+    FontStyle? style,
+    required String url,
+  }) = FontFaceStyleRule;
 
   /// Renders a `@media` css rule.
-  const factory StyleRule.media({required MediaQuery query, required List<StyleRule> styles}) = MediaStyleRule;
+  const factory StyleRule.media({
+    required MediaQuery query,
+    required List<StyleRule> styles,
+  }) = MediaStyleRule;
 
   /// Renders a `@layer` css rule.
-  const factory StyleRule.layer({String? name, required List<StyleRule> styles}) = LayerStyleRule;
+  const factory StyleRule.layer({
+    String? name,
+    required List<StyleRule> styles,
+  }) = LayerStyleRule;
 
   /// Renders a `@supports` css rule.
-  const factory StyleRule.supports({required String condition, required List<StyleRule> styles}) = SupportsStyleRule;
+  const factory StyleRule.supports({
+    required String condition,
+    required List<StyleRule> styles,
+  }) = SupportsStyleRule;
 
   /// Renders a `@keyframes` css rule.
-  const factory StyleRule.keyframes({required String name, required Map<String, Styles> styles}) = KeyframesStyleRule;
+  const factory StyleRule.keyframes({
+    required String name,
+    required Map<String, Styles> styles,
+  }) = KeyframesStyleRule;
 
   /// Returns the rendered css for this rule.
   String toCss([String indent]);
@@ -128,7 +147,9 @@ class _MediaRuleQuery implements MediaQuery {
     this.orientation,
     this.canHover,
     this.aspectRatio,
+    this.isDark,
   }) : target = 'all';
+
   const _MediaRuleQuery.screen({
     this.minWidth,
     this.maxWidth,
@@ -137,7 +158,9 @@ class _MediaRuleQuery implements MediaQuery {
     this.orientation,
     this.canHover,
     this.aspectRatio,
+    this.isDark,
   }) : target = 'screen';
+
   const _MediaRuleQuery.print({
     this.minWidth,
     this.maxWidth,
@@ -146,6 +169,7 @@ class _MediaRuleQuery implements MediaQuery {
     this.orientation,
     this.canHover,
     this.aspectRatio,
+    this.isDark,
   }) : target = 'print';
 
   final String target;
@@ -156,6 +180,7 @@ class _MediaRuleQuery implements MediaQuery {
   final Orientation? orientation;
   final bool? canHover;
   final String? aspectRatio;
+  final bool? isDark;
 
   @override
   String get _value => '$target'
@@ -165,6 +190,7 @@ class _MediaRuleQuery implements MediaQuery {
       '${maxHeight != null ? ' and (max-height: ${maxHeight!.value})' : ''}'
       '${orientation != null ? ' and (orientation: ${orientation!.name})' : ''}'
       '${canHover != null ? ' and (hover: ${canHover! ? 'hover' : 'none'})' : ''}'
+      '${isDark != null ? ' and (prefers-color-scheme: ${isDark! ? 'dark' : 'light'})' : ''}'
       '${aspectRatio != null ? ' and (aspect-ratio: ${aspectRatio!})' : ''}';
 }
 
@@ -208,7 +234,11 @@ class ImportStyleRule implements StyleRule {
 }
 
 class FontFaceStyleRule implements StyleRule {
-  const FontFaceStyleRule({required this.family, this.style, required this.url});
+  const FontFaceStyleRule({
+    required this.family,
+    this.style,
+    required this.url,
+  });
 
   final String family;
   final FontStyle? style;


### PR DESCRIPTION
## Description

Adds parameter for MediaQuery defining dark theme.
Also follows suggestion of linter.

## Type of Change

 - ✨ New feature or improvement
 - 🗑️ Chore

## Ready Checklist

- [ ] I've read the [Contribution Guide](https://github.com/schultek/jaspr/blob/main/CONTRIBUTING.md).
- [ ] In case this PR changes one of the core packages, I've modified the respective **CHANGELOG.md** file using
      the [semantic_changelog](https://github.com/rrousselGit/semantic_changelog) format.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added myself to the AUTHORS file (optional, if you want to).
