### PR TITLE
Add --extra-js-compiler-option/--extra-wasm-compiler-option

### DIFF
--- a/packages/jaspr/CHANGELOG.md
+++ b/packages/jaspr/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased patch
 
 - Added `onClick` override to `a` html tag. Fixing issues with default action handling.
+- Added `--extra-js-compiler-option` and `--extra-wasm-compiler-option` to `jaspr build` command.
 
 ## 0.18.0
 

--- a/packages/jaspr_cli/lib/src/commands/build_command.dart
+++ b/packages/jaspr_cli/lib/src/commands/build_command.dart
@@ -256,11 +256,11 @@ class BuildCommand extends BaseCommand with ProxyHelper, FlutterHelper {
     final args = [
       '-Djaspr.flags.release=true',
       '-O${argResults!['optimize']}',
-      if (useWasm)
+      if (useWasm) //
         ...argResults!['extra-wasm-compiler-option']
       else
         ...argResults!['extra-js-compiler-option'],
-      for (final entry in getClientDartDefines().entries)
+      for (final entry in getClientDartDefines().entries) //
         '-D${entry.key}=${entry.value}',
     ];
 


### PR DESCRIPTION
This allows jaspr users to pass any arguments to the
  * `dart compile js`
  * `dart compile wasm` compilers.

For example if one wants an `-O4` optimized build but symbols for profiling one may run

  * `jaspr build -O4 --extra-js-compiler-option=--no-minify`
  * `jaspr build -O4 --experimental-wasm --extra-wasm-compiler-option=--no-strip-wasm`

✨ New feature or improvement