### PR TITLE
Some performance optimizations in the jaspr framework

### DIFF
--- a/packages/jaspr/lib/src/components/html/forms.dart
+++ b/packages/jaspr/lib/src/components/html/forms.dart
@@ -168,7 +168,7 @@ Component input(List<Component> children,
     classes: classes,
     styles: styles,
     attributes: {
-      ...attributes ?? {},
+      ...?attributes,
       if (type != null) 'type': type.value,
       if (name != null) 'name': name,
       if (value != null) 'value': value,

--- a/packages/jaspr/lib/src/foundation/events.dart
+++ b/packages/jaspr/lib/src/foundation/events.dart
@@ -53,7 +53,8 @@ void Function(web.Event) _callWithValue<V>(String event, void Function(V) fn) {
     var target = e.target;
     var value = switch (target) {
       web.HTMLInputElement() when target.instanceOfString("HTMLInputElement") => () {
-          var type = InputType.values.where((v) => v.name == target.type).firstOrNull;
+          final targetType = target.type;
+          final type = InputType.values.where((v) => v.name == targetType).firstOrNull;
           return switch (type) {
             InputType.checkbox || InputType.radio => target.checked,
             InputType.number => target.valueAsNumber,

--- a/packages/jaspr/lib/src/framework/dom_component.dart
+++ b/packages/jaspr/lib/src/framework/dom_component.dart
@@ -79,10 +79,10 @@ class DomElement extends ProxyRenderObjectElement {
       renderObject.updateElement(
         component.tag,
         component.id ?? wrappingComponent.id,
-        _join(wrappingComponent.classes, component.classes, (a, b) => '$a $b'),
-        _join(wrappingComponent.styles?.properties, component.styles?.properties, (a, b) => {...a, ...b}),
-        _join(wrappingComponent.attributes, component.attributes, (a, b) => {...a, ...b}),
-        _join(wrappingComponent.events, component.events, (a, b) => {...a, ...b}),
+        _joinString(wrappingComponent.classes, component.classes),
+        _joinMap(wrappingComponent.styles?.properties, component.styles?.properties),
+        _joinMap(wrappingComponent.attributes, component.attributes),
+        _joinMap(wrappingComponent.events, component.events),
       );
 
       return;
@@ -98,8 +98,18 @@ class DomElement extends ProxyRenderObjectElement {
     );
   }
 
-  T? _join<T>(T? a, T? b, T Function(T a, T b) joiner) {
-    return a != null && b != null ? joiner(a, b) : a ?? b;
+  static String? _joinString(String? a, String? b) {
+    if (a == null) return b;
+    if (b == null) return null;
+    return '$a $b';
+  }
+
+  static Map<K, V>? _joinMap<K, V>(Map<K, V>? a, Map<K, V>? b) {
+    if (a == null) return b;
+    if (b == null) return null;
+    if (a.isEmpty) return b;
+    if (b.isEmpty) return a;
+    return {...a, ...b};
   }
 }
 


### PR DESCRIPTION
* Avoid repeatedly accessing the same `target.type` JS interop field
* Avoid unnecessary map allocation in map literal
* Avoid unnecessary closure allocation in joining maps/strings
* Avoid unnecessary map allocations in joining maps and one is empty