### PR TITLE
Use faster mechanism for type checks against DOM nodes

### DIFF
--- a/packages/jaspr/lib/src/browser/dom_render_object.dart
+++ b/packages/jaspr/lib/src/browser/dom_render_object.dart
@@ -5,6 +5,7 @@ import 'package:universal_web/web.dart' as web;
 
 import '../foundation/constants.dart';
 import '../foundation/events.dart';
+import '../foundation/type_checks.dart';
 import '../framework/framework.dart';
 import 'utils.dart';
 
@@ -51,7 +52,7 @@ class DomRenderObject extends RenderObject {
     late web.Element elem;
 
     var namespace = xmlns[tag];
-    if (namespace == null && (parent?.node?.instanceOfString("Element") ?? false)) {
+    if (namespace == null && (parent?.node?.isElement ?? false)) {
       namespace = (parent?.node as web.Element).namespaceURI;
     }
 
@@ -59,7 +60,7 @@ class DomRenderObject extends RenderObject {
     if (node == null) {
       if (parent!.toHydrate.isNotEmpty) {
         for (final e in parent!.toHydrate) {
-          if (e.instanceOfString('Element') && (e as web.Element).tagName.toLowerCase() == tag) {
+          if (e.isElement && (e as web.Element).tagName.toLowerCase() == tag) {
             if (kVerboseMode) {
               print("Hydrate html node: $e");
             }
@@ -81,7 +82,7 @@ class DomRenderObject extends RenderObject {
         web.console.log("Create html node: $elem".toJS);
       }
     } else {
-      if (!node.instanceOfString('Element') || (node as web.Element).tagName.toLowerCase() != tag) {
+      if (!node.isElement || (node as web.Element).tagName.toLowerCase() != tag) {
         elem = _createElement(tag, namespace);
         final old = node!;
         node!.parentNode!.replaceChild(elem, old);
@@ -112,7 +113,7 @@ class DomRenderObject extends RenderObject {
     if (attributes != null && attributes.isNotEmpty) {
       for (final attr in attributes.entries) {
         if (attr.key == 'value' &&
-            elem.instanceOfString('HTMLInputElement') &&
+            elem.isHtmlInputElement  &&
             (elem as web.HTMLInputElement).value != attr.value) {
           if (kVerboseMode) {
             print("Set input value: ${attr.value}");
@@ -122,7 +123,7 @@ class DomRenderObject extends RenderObject {
         }
 
         if (attr.key == 'value' &&
-            elem.instanceOfString('HTMLSelectElement') &&
+            elem.isHtmlSelectElement &&
             (elem as web.HTMLSelectElement).value != attr.value) {
           if (kVerboseMode) {
             print("Set select value: ${attr.value}");
@@ -173,7 +174,7 @@ class DomRenderObject extends RenderObject {
       final toHydrate = parent!.toHydrate;
       if (toHydrate.isNotEmpty) {
         for (final e in toHydrate) {
-          if (e.instanceOfString('Text')) {
+          if (e.isText) {
             if (kVerboseMode) {
               print("Hydrate text node: $e");
             }
@@ -195,7 +196,7 @@ class DomRenderObject extends RenderObject {
         print("Create text node: $text");
       }
     } else {
-      if (!node.instanceOfString('Text')) {
+      if (!node.isText) {
         final elem = web.Text(text);
         (node as web.Element).replaceWith(elem as dynamic);
         node = elem;
@@ -227,7 +228,7 @@ class DomRenderObject extends RenderObject {
       final parentNode = node;
       final childNode = child.node;
 
-      assert(parentNode.instanceOfString('Element'));
+      assert(parentNode.isElement);
       if (childNode == null) return;
 
       final afterNode = after?.node;

--- a/packages/jaspr/lib/src/components/document/document_client.dart
+++ b/packages/jaspr/lib/src/components/document/document_client.dart
@@ -1,9 +1,8 @@
-import 'dart:js_interop';
-
 import 'package:universal_web/web.dart' as web;
 
 import '../../../browser.dart';
 import '../../browser/utils.dart';
+import '../../foundation/type_checks.dart';
 
 abstract class Document implements Component {
   /// Attaches a set of attributes to the `<html>` element.
@@ -271,7 +270,7 @@ class AttachAdapter {
   };
 
   String? keyFor(web.Node node) {
-    if (!node.instanceOfString('Element')) return null;
+    if (!node.isElement) return null;
     return switch (node as web.Element) {
       web.Element(id: String id) when id.isNotEmpty => id,
       web.Element(tagName: "TITLE" || "BASE") => '__${node.tagName}',

--- a/packages/jaspr/lib/src/components/raw_text/raw_text_web.dart
+++ b/packages/jaspr/lib/src/components/raw_text/raw_text_web.dart
@@ -4,6 +4,7 @@ import 'package:universal_web/web.dart' as web;
 
 import '../../../browser.dart';
 import '../../browser/utils.dart';
+import '../../foundation/type_checks.dart';
 
 /// Renders its input as raw HTML.
 ///
@@ -32,8 +33,8 @@ class RawNode extends Component {
     return RawNode(
       node,
       key: switch (node) {
-        web.Text() when node.instanceOfString("Text") => ValueKey('text'),
-        web.Element() when node.instanceOfString("Element") => ValueKey('element:${node.tagName}'),
+        web.Text() when node.isText => ValueKey('text'),
+        web.Element() when node.isElement => ValueKey('element:${node.tagName}'),
         _ => null,
       },
     );
@@ -61,9 +62,10 @@ class RawNodeElement extends BuildableRenderObjectElement {
   @override
   void updateRenderObject() {
     var next = component.node;
-    if (next.instanceOfString("Text") && next is web.Text) {
-      renderObject.updateText(next.textContent ?? '');
-    } else if (next.instanceOfString("Element") && next is web.Element) {
+    if (next.isText) {
+      renderObject.updateText((next as web.Text).textContent ?? '');
+    } else if (next.isElement) {
+      next as web.Element;
       renderObject.updateElement(
           next.tagName.toLowerCase(), next.id, next.className, null, next.attributes.toMap(), null);
     } else {

--- a/packages/jaspr/lib/src/foundation/events.dart
+++ b/packages/jaspr/lib/src/foundation/events.dart
@@ -1,9 +1,9 @@
-import 'package:universal_web/js_interop.dart';
 import 'package:universal_web/web.dart' as web;
 
 import '../components/html/html.dart';
 import 'basic_types.dart';
 import 'constants.dart';
+import 'type_checks.dart';
 
 typedef EventCallback = void Function(web.Event event);
 typedef EventCallbacks = Map<String, EventCallback>;
@@ -39,7 +39,7 @@ EventCallbacks events<V1, V2>({
     {
       if (onClick != null)
         'click': (event) {
-          if (kIsWeb && event.target is web.HTMLAnchorElement && event.target.instanceOfString("HTMLAnchorElement")) {
+          if (kIsWeb && (event.target.isHtmlAnchorElement)) {
             event.preventDefault();
           }
           onClick();
@@ -52,9 +52,10 @@ void Function(web.Event) _callWithValue<V>(String event, void Function(V) fn) {
   return (e) {
     var target = e.target;
     var value = switch (target) {
-      web.HTMLInputElement() when target.instanceOfString("HTMLInputElement") => () {
+      web.HTMLInputElement() when target.isHtmlInputElement => () {
           final targetType = target.type;
-          final type = InputType.values.where((v) => v.name == targetType).firstOrNull;
+          final type =
+              InputType.values.where((v) => v.name == targetType).firstOrNull;
           return switch (type) {
             InputType.checkbox || InputType.radio => target.checked,
             InputType.number => target.valueAsNumber,
@@ -63,10 +64,10 @@ void Function(web.Event) _callWithValue<V>(String event, void Function(V) fn) {
             _ => target.value,
           };
         }(),
-      web.HTMLTextAreaElement() when target.instanceOfString("HTMLTextAreaElement") => target.value,
-      web.HTMLSelectElement() when target.instanceOfString("HTMLSelectElement") => [
+      web.HTMLTextAreaElement() when target.isTextAreaElement => target.value,
+      web.HTMLSelectElement() when target.isHtmlSelectElement => [
           for (final o in target.selectedOptions.toIterable())
-            if (o is web.HTMLOptionElement && o.instanceOfString("HTMLOptionElement")) o.value,
+            if (o.isHtmlOptionElement) (o as web.HTMLOptionElement).value,
         ],
       _ => null,
     };

--- a/packages/jaspr/lib/src/foundation/sync/sync_web.dart
+++ b/packages/jaspr/lib/src/foundation/sync/sync_web.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:js_interop';
 
 import '../../../browser.dart';
+import '../../foundation/type_checks.dart';
 import '../marker_utils.dart';
 
 final _syncRegex = RegExp('^$syncMarkerPrefixRegex(.*)\$');
@@ -10,7 +11,7 @@ void initSyncState(SyncStateMixin sync) {
   var r = (sync.context as Element).parentRenderObjectElement?.renderObject as DomRenderObject?;
   if (r == null) return;
   for (var node in r.toHydrate) {
-    if (node.instanceOfString("Text")) {
+    if (node.isText) {
       continue;
     }
     if (node.instanceOfString("Comment")) {

--- a/packages/jaspr/lib/src/foundation/type_checks.dart
+++ b/packages/jaspr/lib/src/foundation/type_checks.dart
@@ -1,0 +1,46 @@
+import 'package:universal_web/js_interop.dart';
+
+// For type checks against DOM types we're looking up the constructor
+// functions of those DOM types *once* and cache them.
+//
+// That allows for much faster type checking via
+// `JSObject.instanceof(constructor)` as it avoids re-resolving the names
+// repeatedly.
+//
+// See also https://github.com/dart-lang/sdk/issues/60344
+extension DomTypeTests on JSAny? {
+  bool get isElement => this == null ? false : instanceof(_cachedElementConstructor);
+  bool get isHtmlInputElement => this == null ? false : instanceof(_cachedHtmlInputElementConstructor);
+  bool get isHtmlAnchorElement => this == null ? false : instanceof(_cachedHtmlAnchorElementConstructor);
+  bool get isHtmlSelectElement => this == null ? false : instanceof(_cachedHtmlSelectElementConstructor);
+  bool get isTextAreaElement => this == null ? false : instanceof(_cachedHtmlTextAreaElementConstructor);
+  bool get isHtmlOptionElement => this == null ? false : instanceof(_cachedHtmlOptionElementConstructor);
+  bool get isText => this == null ? false : instanceof(_cachedTextConstructor);
+  bool get isComment => this == null ? false : instanceof(_cachedCommentConstructor);
+}
+
+final _cachedElementConstructor = _elementConstructor;
+final _cachedHtmlInputElementConstructor = _htmlInputElementConstructor;
+final _cachedHtmlAnchorElementConstructor = _htmlAnchorElementConstructor;
+final _cachedHtmlSelectElementConstructor = _htmlSelectElementConstructor;
+final _cachedHtmlTextAreaElementConstructor = _htmlTextAreaElementConstructor;
+final _cachedHtmlOptionElementConstructor = _htmlOptionElementConstructor;
+final _cachedTextConstructor = _textConstructor;
+final _cachedCommentConstructor = _commentConstructor;
+
+@JS('Element')
+external JSFunction get _elementConstructor;
+@JS('HTMLInputElement')
+external JSFunction get _htmlInputElementConstructor;
+@JS('HTMLAnchorElement')
+external JSFunction get _htmlAnchorElementConstructor;
+@JS('HTMLSelectElement')
+external JSFunction get _htmlSelectElementConstructor;
+@JS('HTMLTextAreaElement')
+external JSFunction get _htmlTextAreaElementConstructor;
+@JS('HTMLOptionElement')
+external JSFunction get _htmlOptionElementConstructor;
+@JS('Text')
+external JSFunction get _textConstructor;
+@JS('Comment')
+external JSFunction get _commentConstructor;


### PR DESCRIPTION
The

  * `<node>.isA<HTMLInputElement>()` and
  * `<node>.instanceOfString('HTMLInputElement')`

APIs are currently performing poorly, see [0].

Instead we use `<node>.instanceof(<constructor>)` with a cached value of the looked up constructor.
=> This results in 5-10x faster type checks in dart2wasm.

[0] https://github.com/dart-lang/sdk/issues/60344
