### PR TITLE
Add instructions for tailwindcss v4 in the docs

### DIFF
--- a/docs/eco/tailwind.mdx
+++ b/docs/eco/tailwind.mdx
@@ -15,7 +15,7 @@ Jaspr can be integrated with Tailwind using the [`jaspr_tailwind`](https://pub.d
 This package expects tailwind to be installed through the `tailwindcss` command. The recommended way is to use
 the [standalone tailwind cli](https://tailwindcss.com/blog/standalone-cli).
 
-To install it, download the executable for your platform from the [latest release](https://github.com/tailwindlabs/tailwindcss/releases/latest)
+To install it, download the executable for your platform, preferably the [latest release](https://github.com/tailwindlabs/tailwindcss/releases/latest)
 on GitHub and give it executable permissions:
 
 ```shell
@@ -44,10 +44,18 @@ Simply add `jaspr_tailwind` as a dev dependency to your project:
 
 Next add a `styles.tw.css` file inside the `web` directory with the following content:
 
+If you are using tailwindcss v4, then:
+
+```css title="styles.tw.css"
+@import "tailwindcss";
+```
+
+Or else, if you are using tailwindcss v3, then:
+
 ```css title="styles.tw.css"
 @tailwind base;
 @tailwind components;
-@tailwind utilities;
+@tailwind utilities
 ```
 
 Finally, link the generated `styles.css` in your document, or otherwise add it to your website:


### PR DESCRIPTION
Closes https://github.com/dinko7/jaspr_tailwind/issues/2. The issue was that tailwindcss v4 had some breaking changes whereas the docs, even though it suggested to use the _latest version of tailwindcss_, had the instructions for v3 only.

<!--
  Thanks for contributing! 💙

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!-- Describe your changes in detail -->

## Type of Change

<!-- Uncomment all that apply: -->

<!-- - ❌ Breaking change -->
<!-- - ✨ New feature or improvement -->
- 🛠️ Bug fix
<!-- - 🧹 Code refactor -->
- 📝 Documentation
<!-- - 🗑️ Chore -->

## Ready Checklist

- [x] I've read the [Contribution Guide](https://github.com/schultek/jaspr/blob/main/CONTRIBUTING.md).
- [ ] In case this PR changes one of the core packages, I've modified the respective **CHANGELOG.md** file using
      the [semantic_changelog](https://github.com/rrousselGit/semantic_changelog) format.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added myself to the AUTHORS file (optional, if you want to).

<!-- 
  Feel free to expand this list if you have additional todos before your PR is ready. 
-->

<!--
  If you need help, consider asking for advice on the *#contribute* channel on [Discord](https://discord.gg/XGXrGEk4c6).
-->
