### PR TITLE
chore: update Serverpod dependency upper version constraint to <2.5.0

### DIFF
--- a/packages/jaspr_serverpod/CHANGELOG.md
+++ b/packages/jaspr_serverpod/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased patch
+
+- Loosen `serverpod` dependency constraint to `>=2.3.0 <2.5.0`.
+
 ## 0.5.3
 
 - Loosen `serverpod` dependency constraint to `>=2.3.0 <2.4.0`.

--- a/packages/jaspr_serverpod/pubspec.yaml
+++ b/packages/jaspr_serverpod/pubspec.yaml
@@ -17,8 +17,8 @@ environment:
 
 dependencies:
   jaspr: ^0.18.0
-  serverpod: '>=2.3.0 <2.4.0'
-  serverpod_client: '>=2.3.0 <2.4.0'
+  serverpod: '>=2.3.0 <2.5.0'
+  serverpod_client: '>=2.3.0 <2.5.0'
   shelf: ^1.4.0
   web: ^1.0.0
 

--- a/packages/jaspr_test/lib/src/testers/component_tester.dart
+++ b/packages/jaspr_test/lib/src/testers/component_tester.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:jaspr/jaspr.dart';
 // ignore: implementation_imports
@@ -128,6 +129,11 @@ class TestComponentsBinding extends AppBinding with ComponentsBinding {
       return AsyncBuildOwner();
     }
     return super.createRootBuildOwner();
+  }
+
+  @override
+  void reportBuildError(Element element, Object error, StackTrace stackTrace) {
+    stderr.writeln('Error while building ${element.component.runtimeType}:\n$error\n\n$stackTrace');
   }
 }
 


### PR DESCRIPTION
<!--
  Thanks for contributing! 💙

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

This PR updates the Serverpod and Serverpod client dependency upper bounds from <2.4.0 to <2.5.0 in the jaspr_serverpod package to support newer versions.

## Type of Change

- 🗑️ Chore

## Ready Checklist

- [x] I've read the [Contribution Guide](https://github.com/schultek/jaspr/blob/main/CONTRIBUTING.md).
- [x] In case this PR changes one of the core packages, I've modified the respective **CHANGELOG.md** file using
      the [semantic_changelog](https://github.com/rrousselGit/semantic_changelog) format.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added myself to the AUTHORS file (optional, if you want to).

<!-- 
  Feel free to expand this list if you have additional todos before your PR is ready. 
-->

<!--
  If you need help, consider asking for advice on the *#contribute* channel on [Discord](https://discord.gg/XGXrGEk4c6).
-->
