### PR TITLE
[chore] Serverpod 2.5.0 support

### DIFF
--- a/packages/jaspr_serverpod/pubspec.yaml
+++ b/packages/jaspr_serverpod/pubspec.yaml
@@ -16,9 +16,9 @@ environment:
   sdk: ">=3.6.0 <4.0.0"
 
 dependencies:
-  jaspr: ^0.18.1
-  serverpod: '>=2.3.0 <2.5.0'
-  serverpod_client: '>=2.3.0 <2.5.0'
+  jaspr: ^0.18.2
+  serverpod: '>=2.3.0 <2.6.0'
+  serverpod_client: '>=2.3.0 <2.6.0'
   shelf: ^1.4.0
   web: ^1.0.0
 


### PR DESCRIPTION
## Description

updated serverpod version constrains to 2.6.0 and jaspr to 0.18.2

## Type of Change
- 🗑️ Chore 
