### PR TITLE
chore: update Serverpod dependency upper version constraint to <3.0.0

### DIFF
--- a/packages/jaspr_serverpod/CHANGELOG.md
+++ b/packages/jaspr_serverpod/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased patch
 
-- Loosen `serverpod` dependency constraint to `>=2.3.0 <2.6.0`.
+- Loosen `serverpod` dependency constraint to `>=2.3.0 <3.0.0`.
 
 ## 0.5.4
 

--- a/packages/jaspr_serverpod/pubspec.yaml
+++ b/packages/jaspr_serverpod/pubspec.yaml
@@ -17,8 +17,8 @@ environment:
 
 dependencies:
   jaspr: ^0.18.0
-  serverpod: '>=2.3.0 <2.6.0'
-  serverpod_client: '>=2.3.0 <2.6.0'
+  serverpod: '>=2.3.0 <3.0.0'
+  serverpod_client: '>=2.3.0 <3.0.0'
   shelf: ^1.4.0
   web: ^1.0.0
 


### PR DESCRIPTION
## Description
This PR expands the version constraints for Serverpod and Serverpod client dependencies in the jaspr_serverpod package. The upper version constraint has been changed from <2.5.0 to <3.0.0 to ensure compatibility with a wider range of Serverpod versions.

## Type of Change
<!-- Uncomment all that apply: -->
<!-- - ❌ Breaking change -->
<!-- - ✨ New feature or improvement -->
<!-- - 🛠️ Bug fix -->
<!-- - 🧹 Code refactor -->
<!-- - 📝 Documentation -->
🗑️ Chore

## Ready Checklist
[x] I've read the Contribution Guide.
[x] In case this PR changes one of the core packages, I've modified the respective CHANGELOG.md file using
the semantic_changelog format.
[x] I updated/added relevant documentation (doc comments with ///).
[ ] I added myself to the AUTHORS file (optional, if you want to).
<!--
Feel free to expand this list if you have additional todos before your PR is ready.
-->
<!--
If you need help, consider asking for advice on the #contribute channel on Discord.
--