### PR TITLE
rx, ry attributes for svg rect

### DIFF
--- a/packages/jaspr/CHANGELOG.md
+++ b/packages/jaspr/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.19.1
+  
+- Added `rx:`, `ry:` attributes for svg rect().
+
 ## 0.19.0
 
 - **BREAKING** `JasprOptions.useIsolates` is now `false` by default (was `true`).

--- a/packages/jaspr/lib/src/components/html/svg.dart
+++ b/packages/jaspr/lib/src/components/html/svg.dart
@@ -36,6 +36,8 @@ Component svg(List<Component> children,
 ///
 /// - [x]: The x coordinate of the rect.
 /// - [y]: The y coordinate of the rect.
+/// - [rx]: The rx coordinate of the rect.
+/// - [ry]: The ry coordinate of the rect.
 /// - [width]: The width of the rect.
 /// - [height]: The height of the rect.
 /// - [fill]: The color (or gradient or pattern) used to paint the shape.
@@ -44,6 +46,8 @@ Component svg(List<Component> children,
 Component rect(List<Component> children,
     {String? x,
     String? y,
+    String? rx,
+    String? ry,
     String? width,
     String? height,
     Color? fill,
@@ -65,6 +69,8 @@ Component rect(List<Component> children,
       ...attributes ?? {},
       if (x != null) 'x': x,
       if (y != null) 'y': y,
+      if (rx != null) 'rx': rx,
+      if (ry != null) 'ry': ry,
       if (width != null) 'width': width,
       if (height != null) 'height': height,
       if (fill != null) 'fill': fill.value,

--- a/packages/jaspr/tool/data/html.json
+++ b/packages/jaspr/tool/data/html.json
@@ -1098,6 +1098,14 @@
           "doc": "The y coordinate of the rect.",
           "type": "string"
         },
+        "rx": {
+          "doc": "The rx coordinate of the rect.",
+          "type": "string"
+        },
+        "ry": {
+          "doc": "The ry coordinate of the rect.",
+          "type": "string"
+        },
         "width": {
           "doc": "The width of the rect.",
           "type": "string"

--- a/packages/jaspr/tool/data/html.json
+++ b/packages/jaspr/tool/data/html.json
@@ -1099,7 +1099,7 @@
           "type": "string"
         },
         "rx": {
-          "doc": "The rx coordinate of the rect.",
+          "doc": "The horizontal corner radius of the rect.",
           "type": "string"
         },
         "ry": {

--- a/packages/jaspr/tool/data/html.json
+++ b/packages/jaspr/tool/data/html.json
@@ -1103,7 +1103,7 @@
           "type": "string"
         },
         "ry": {
-          "doc": "The ry coordinate of the rect.",
+          "doc": "The vertical corner radius of the rect.",
           "type": "string"
         },
         "width": {


### PR DESCRIPTION
## Description

Defines the x-axis/y-axis radius for SVG rect rounded corners. 

## Type of Change

<!-- Uncomment all that apply: -->

<!-- - ❌ Breaking change -->
<!-- - ✨ New feature or improvement -->
<!-- - 🛠️ Bug fix -->
<!-- - 🧹 Code refactor -->
<!-- - 📝 Documentation -->
<!-- - 🗑️ Chore -->

## Ready Checklist

- [X] I've read the [Contribution Guide](https://github.com/schultek/jaspr/blob/main/CONTRIBUTING.md).
- [X] In case this PR changes one of the core packages, I've modified the respective **CHANGELOG.md** file using
      the [semantic_changelog](https://github.com/rrousselGit/semantic_changelog) format.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added myself to the AUTHORS file (optional, if you want to).

<!--
  If you need help, consider asking for advice on the *#contribute* channel on [Discord](https://discord.gg/XGXrGEk4c6).
-->
