### PR TITLE
Fix: CTA in copy button to be same as text itself

### DIFF
--- a/apps/website/lib/pages/home/0_hero/components/install_command.dart
+++ b/apps/website/lib/pages/home/0_hero/components/install_command.dart
@@ -20,7 +20,7 @@ class InstallCommandState extends State<InstallCommand> {
   @override
   Iterable<Component> build(BuildContext context) sync* {
     yield div(classes: 'install-jaspr', events: events(onClick: () {
-      window.navigator.clipboard.writeText('dart pub global activate jaspr');
+      window.navigator.clipboard.writeText('dart pub global activate jaspr_cli');
       setState(() {
         copied = true;
       });


### PR DESCRIPTION
## Description

Fixes installation command. I clicked copy button, and pasted into CLI. Then I went to get started docs, scrolled down to CLI setup, and ran `jaspr create my_website`, which didnt work.

That's when I noticed command in docs is different than one I ran. I compared with homepage, and it was same. I as confused where I got the wrong command, but when looking through source-code, I noticed wrong command is placed in copy action of the command on homepage.

I checked rest of repository too, and this was the only place with wrong command

## Type of Change

📝 Documentation

## Ready Checklist

- [ ] I've read the [Contribution Guide](https://github.com/schultek/jaspr/blob/main/CONTRIBUTING.md).
- [x] In case this PR changes one of the core packages, I've modified the respective **CHANGELOG.md** file using
      the [semantic_changelog](https://github.com/rrousselGit/semantic_changelog) format.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added myself to the AUTHORS file (optional, if you want to).

