### PR TITLE
[content] Support `.yml` extension as well as `.yaml`

### DIFF
--- a/packages/jaspr_content/lib/src/data_loader/data_loader.dart
+++ b/packages/jaspr_content/lib/src/data_loader/data_loader.dart
@@ -24,7 +24,7 @@ abstract class DataLoader {
   static Object? parseData(String name, String data) {
     if (name.endsWith('.json')) {
       return jsonDecode(data);
-    } else if (name.endsWith('.yaml')) {
+    } else if (name.endsWith('.yaml') || name.endsWith('.yml')) {
       return yaml.loadYamlNode(data).normalize();
     } else {
       return data;

--- a/packages/jaspr_content/lib/src/page.dart
+++ b/packages/jaspr_content/lib/src/page.dart
@@ -282,7 +282,7 @@ extension PageHandlersExtension on Page {
       return 'text/markdown';
     } else if (this.path.endsWith('.json')) {
       return 'application/json';
-    } else if (this.path.endsWith('.yaml')) {
+    } else if (this.path.endsWith('.yaml') || this.path.endsWith('.yml')) {
       return 'application/yaml';
     } else {
       return 'text/plain';


### PR DESCRIPTION
While the `.yaml` extension is preferred and recommended, there's many usages of `.yml` in the wild that this will make support for easier.