### PR TITLE
[content] Don't assume layout of `page.data['site']` in `PageLayoutBase`

### DIFF
--- a/packages/jaspr_content/lib/src/layouts/page_layout.dart
+++ b/packages/jaspr_content/lib/src/layouts/page_layout.dart
@@ -94,10 +94,11 @@ abstract class PageLayoutBase implements PageLayout {
 
   @override
   Component buildLayout(Page page, Component child) {
-    final pageData = page.data['page'] ?? {};
-    final siteData = page.data['site'] ?? {};
-
-    final lang = pageData['lang'] ?? siteData['lang'];
+    final lang = switch (page.data) {
+      {'page': {'lang': String lang}} => lang,
+      {'site': {'lang': String lang}} => lang,
+      _ => null,
+    };
 
     return Document(
       lang: lang,


### PR DESCRIPTION
When building the layout in `PageLayoutBase`, don't assume the layout of `page.data['site']` as if it's not a `Map` or `page.data['site']['lang']` is otherwise not a `String`, there'll be a runtime error.
