### PR TITLE
[content] Require Dart 3.8, format, and update lints

### DIFF
--- a/packages/jaspr_content/CHANGELOG.md
+++ b/packages/jaspr_content/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0-wip
+
+- Require Dart 3.8 or later.
+
 ## 0.1.1
 
 - `jaspr` upgraded to `0.19.0`

--- a/packages/jaspr_content/analysis_options.yaml
+++ b/packages/jaspr_content/analysis_options.yaml
@@ -5,3 +5,6 @@ linter:
     sort_pub_dependencies: true
     prefer_relative_imports: true
     directives_ordering: true
+
+formatter:
+  trailing_commas: preserve

--- a/packages/jaspr_content/example/jaspr_content_example.dart
+++ b/packages/jaspr_content/example/jaspr_content_example.dart
@@ -5,17 +5,19 @@ import 'package:jaspr_content/jaspr_content.dart';
 void main() {
   Jaspr.initializeApp();
 
-  runApp(ContentApp(
-    templateEngine: MustacheTemplateEngine(),
-    parsers: [
-      MarkdownParser(),
-    ],
-    components: [
-      // Enables using custom components like '<Info>Hello</Info>'.
-      Callout(),
-    ],
-    layouts: [
-      EmptyLayout(),
-    ],
-  ));
+  runApp(
+    ContentApp(
+      templateEngine: MustacheTemplateEngine(),
+      parsers: [
+        MarkdownParser(),
+      ],
+      components: [
+        // Enables using custom components like '<Info>Hello</Info>'.
+        Callout(),
+      ],
+      layouts: [
+        EmptyLayout(),
+      ],
+    ),
+  );
 }

--- a/packages/jaspr_content/lib/components/_internal/code_block_copy_button.dart
+++ b/packages/jaspr_content/lib/components/_internal/code_block_copy_button.dart
@@ -20,25 +20,30 @@ class _CodeBlockCopyButtonState extends State<CodeBlockCopyButton> {
 
   @override
   Iterable<Component> build(BuildContext context) sync* {
-    yield button(events: {
-      'click': (event) {
-        final target = event.currentTarget as web.Element;
-        final content = target.parentElement?.querySelector('pre code')?.textContent;
-        if (content == null) {
-          return;
-        }
-        web.window.navigator.clipboard.writeText(content);
-        setState(() {
-          copied = true;
-        });
-        Timer(const Duration(seconds: 2), () {
+    yield button(
+      events: {
+        'click': (event) {
+          final target = event.currentTarget as web.Element;
+          final content = target.parentElement
+              ?.querySelector('pre code')
+              ?.textContent;
+          if (content == null) {
+            return;
+          }
+          web.window.navigator.clipboard.writeText(content);
           setState(() {
-            copied = false;
+            copied = true;
           });
-        });
-      }
-    }, [
-      copied ? CheckIcon(size: 18) : CopyIcon(size: 18),
-    ]);
+          Timer(const Duration(seconds: 2), () {
+            setState(() {
+              copied = false;
+            });
+          });
+        },
+      },
+      [
+        copied ? CheckIcon(size: 18) : CopyIcon(size: 18),
+      ],
+    );
   }
 }

--- a/packages/jaspr_content/lib/components/_internal/icon.dart
+++ b/packages/jaspr_content/lib/components/_internal/icon.dart
@@ -13,10 +13,13 @@ class CloseIcon extends StatelessComponent {
 
   @override
   Iterable<Component> build(BuildContext context) sync* {
-    yield _Icon(size: size, children: [
-      path(d: "M18 6 6 18", []),
-      path(d: "m6 6 12 12", []),
-    ]);
+    yield _Icon(
+      size: size,
+      children: [
+        path(d: "M18 6 6 18", []),
+        path(d: "m6 6 12 12", []),
+      ],
+    );
   }
 }
 
@@ -28,9 +31,12 @@ class MoonIcon extends StatelessComponent {
 
   @override
   Iterable<Component> build(BuildContext context) sync* {
-    yield _Icon(size: size, children: [
-      path(d: 'M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z', []),
-    ]);
+    yield _Icon(
+      size: size,
+      children: [
+        path(d: 'M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z', []),
+      ],
+    );
   }
 }
 
@@ -42,17 +48,20 @@ class SunIcon extends StatelessComponent {
 
   @override
   Iterable<Component> build(BuildContext context) sync* {
-    yield _Icon(size: size, children: [
-      circle(cx: '12', cy: '12', r: '4', []),
-      path(d: 'M12 4h.01', []),
-      path(d: 'M20 12h.01', []),
-      path(d: 'M12 20h.01', []),
-      path(d: 'M4 12h.01', []),
-      path(d: 'M17.657 6.343h.01', []),
-      path(d: 'M17.657 17.657h.01', []),
-      path(d: 'M6.343 17.657h.01', []),
-      path(d: 'M6.343 6.343h.01', []),
-    ]);
+    yield _Icon(
+      size: size,
+      children: [
+        circle(cx: '12', cy: '12', r: '4', []),
+        path(d: 'M12 4h.01', []),
+        path(d: 'M20 12h.01', []),
+        path(d: 'M12 20h.01', []),
+        path(d: 'M4 12h.01', []),
+        path(d: 'M17.657 6.343h.01', []),
+        path(d: 'M17.657 17.657h.01', []),
+        path(d: 'M6.343 17.657h.01', []),
+        path(d: 'M6.343 6.343h.01', []),
+      ],
+    );
   }
 }
 
@@ -64,11 +73,14 @@ class InfoIcon extends StatelessComponent {
 
   @override
   Iterable<Component> build(BuildContext context) sync* {
-    yield _Icon(size: size, children: [
-      circle(cx: '12', cy: '12', r: '10', []),
-      path(d: 'M12 16v-4', []),
-      path(d: 'M12 8h.01', []),
-    ]);
+    yield _Icon(
+      size: size,
+      children: [
+        circle(cx: '12', cy: '12', r: '10', []),
+        path(d: 'M12 16v-4', []),
+        path(d: 'M12 8h.01', []),
+      ],
+    );
   }
 }
 
@@ -80,11 +92,17 @@ class AlertIcon extends StatelessComponent {
 
   @override
   Iterable<Component> build(BuildContext context) sync* {
-    yield _Icon(size: size, children: [
-      path(d: 'm21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3', []),
-      path(d: 'M12 9v4', []),
-      path(d: 'M12 17h.01', []),
-    ]);
+    yield _Icon(
+      size: size,
+      children: [
+        path(
+          d: 'm21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3',
+          [],
+        ),
+        path(d: 'M12 9v4', []),
+        path(d: 'M12 17h.01', []),
+      ],
+    );
   }
 }
 
@@ -95,11 +113,14 @@ class CircleXIcon extends StatelessComponent {
 
   @override
   Iterable<Component> build(BuildContext context) sync* {
-    yield _Icon(size: size, children: [
-      circle(cx: '12', cy: '12', r: '10', []),
-      path(d: 'm15 9-6 6', []),
-      path(d: 'm9 9 6 6', []),
-    ]);
+    yield _Icon(
+      size: size,
+      children: [
+        circle(cx: '12', cy: '12', r: '10', []),
+        path(d: 'm15 9-6 6', []),
+        path(d: 'm9 9 6 6', []),
+      ],
+    );
   }
 }
 
@@ -110,10 +131,13 @@ class CircleCheckIcon extends StatelessComponent {
 
   @override
   Iterable<Component> build(BuildContext context) sync* {
-    yield _Icon(size: size, children: [
-      circle(cx: '12', cy: '12', r: '10', []),
-      path(d: 'm9 12 2 2 4-4', []),
-    ]);
+    yield _Icon(
+      size: size,
+      children: [
+        circle(cx: '12', cy: '12', r: '10', []),
+        path(d: 'm9 12 2 2 4-4', []),
+      ],
+    );
   }
 }
 
@@ -124,10 +148,20 @@ class CopyIcon extends StatelessComponent {
 
   @override
   Iterable<Component> build(BuildContext context) sync* {
-    yield _Icon(size: size, children: [
-      rect(width: "14", height: "14", x: "8", y: "8", attributes: {'rx': "2", 'ry': "2"}, []),
-      path(d: "M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2", []),
-    ]);
+    yield _Icon(
+      size: size,
+      children: [
+        rect(
+          width: "14",
+          height: "14",
+          x: "8",
+          y: "8",
+          attributes: {'rx': "2", 'ry': "2"},
+          [],
+        ),
+        path(d: "M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2", []),
+      ],
+    );
   }
 }
 
@@ -138,9 +172,12 @@ class CheckIcon extends StatelessComponent {
 
   @override
   Iterable<Component> build(BuildContext context) sync* {
-    yield _Icon(size: size, children: [
-      path(d: 'M20 6 9 17l-5-5', []),
-    ]);
+    yield _Icon(
+      size: size,
+      children: [
+        path(d: 'M20 6 9 17l-5-5', []),
+      ],
+    );
   }
 }
 
@@ -156,16 +193,17 @@ class _Icon extends StatelessComponent {
   @override
   Iterable<Component> build(BuildContext context) sync* {
     yield svg(
-        width: size?.px,
-        height: size?.px,
-        viewBox: "0 0 24 24",
-        attributes: {
-          'fill': 'none',
-          'stroke': 'currentColor',
-          'stroke-width': '2',
-          'stroke-linecap': 'round',
-          'stroke-linejoin': 'round',
-        },
-        children);
+      width: size?.px,
+      height: size?.px,
+      viewBox: "0 0 24 24",
+      attributes: {
+        'fill': 'none',
+        'stroke': 'currentColor',
+        'stroke-width': '2',
+        'stroke-linecap': 'round',
+        'stroke-linejoin': 'round',
+      },
+      children,
+    );
   }
 }

--- a/packages/jaspr_content/lib/components/_internal/tab_bar.dart
+++ b/packages/jaspr_content/lib/components/_internal/tab_bar.dart
@@ -18,26 +18,35 @@ class TabBar extends StatefulComponent {
 
   @css
   static List<StyleRule> get styles => [
-        css('.tab-bar', [
-          css('&').styles(
-            display: Display.flex,
-            alignItems: AlignItems.center,
-            gap: Gap(column: 1.25.rem),
-            border: Border.only(bottom: BorderSide(width: 1.px, color: ContentColors.hr)),
-          ),
-          css('button').styles(
-            padding: Padding.symmetric(vertical: 0.75.rem),
-            fontWeight: FontWeight.w700,
-            border: Border.only(bottom: BorderSide(width: 2.px, color: Colors.transparent)),
-          ),
-          css('button:hover').styles(raw: {
-            'border-bottom-color': ContentColors.hr.value,
-          }),
-          css('button[active]').styles(color: ContentColors.primary, raw: {
-            'border-bottom-color': ContentColors.primary.value,
-          }),
-        ]),
-      ];
+    css('.tab-bar', [
+      css('&').styles(
+        display: Display.flex,
+        alignItems: AlignItems.center,
+        gap: Gap(column: 1.25.rem),
+        border: Border.only(
+          bottom: BorderSide(width: 1.px, color: ContentColors.hr),
+        ),
+      ),
+      css('button').styles(
+        padding: Padding.symmetric(vertical: 0.75.rem),
+        fontWeight: FontWeight.w700,
+        border: Border.only(
+          bottom: BorderSide(width: 2.px, color: Colors.transparent),
+        ),
+      ),
+      css('button:hover').styles(
+        raw: {
+          'border-bottom-color': ContentColors.hr.value,
+        },
+      ),
+      css('button[active]').styles(
+        color: ContentColors.primary,
+        raw: {
+          'border-bottom-color': ContentColors.primary.value,
+        },
+      ),
+    ]),
+  ];
 }
 
 class _TabBarState extends State<TabBar> {
@@ -53,25 +62,27 @@ class _TabBarState extends State<TabBar> {
   Iterable<Component> build(BuildContext context) sync* {
     yield div(classes: 'tab-bar', [
       for (var item in component.items.entries)
-        button(attributes: {
-          if (item.key == value) 'active': ''
-        }, events: {
-          'click': (e) {
-            setState(() {
-              value = item.key;
-            });
+        button(
+          attributes: {if (item.key == value) 'active': ''},
+          events: {
+            'click': (e) {
+              setState(() {
+                value = item.key;
+              });
 
-            final target = e.currentTarget as web.Element;
+              final target = e.currentTarget as web.Element;
 
-            final currentTabView = target.parentElement?.nextElementSibling?.querySelector('div[active]');
-            final nexttabView = target.parentElement?.nextElementSibling?.querySelector('div[data-tab="${item.key}"]');
+              final currentTabView = target.parentElement?.nextElementSibling
+                  ?.querySelector('div[active]');
+              final nexttabView = target.parentElement?.nextElementSibling
+                  ?.querySelector('div[data-tab="${item.key}"]');
 
-            currentTabView?.removeAttribute('active');
-            nexttabView?.setAttribute('active', '');
-          }
-        }, [
-          text(item.value)
-        ]),
+              currentTabView?.removeAttribute('active');
+              nexttabView?.setAttribute('active', '');
+            },
+          },
+          [text(item.value)],
+        ),
     ]);
   }
 }

--- a/packages/jaspr_content/lib/components/_internal/zoomable_image.dart
+++ b/packages/jaspr_content/lib/components/_internal/zoomable_image.dart
@@ -23,43 +23,44 @@ class ZoomableImage extends StatefulComponent {
 
   @css
   static List<StyleRule> get styles => [
-        css('figure.image', [
-          css('&.zoomable img').styles(
-            cursor: Cursor.zoomIn,
-          ),
-        ]),
-        css('dialog.zoom-modal', [
-          css('&').styles(
-            width: 100.vw,
-            height: 100.vh,
-            maxWidth: Unit.initial,
-            maxHeight: Unit.initial,
-            margin: Margin.zero,
-            padding: Padding.zero,
-            border: Border.none,
-            backgroundColor: Colors.transparent,
-            overflow: Overflow.hidden,
-            outline: Outline(style: OutlineStyle.none),
-          ),
-          css('.image-wrapper').styles(
-            position: Position.relative(),
-            width: 100.percent,
-            height: 100.percent,
-            backgroundColor: ContentColors.background,
-          ),
-          css('img').styles(
-            position: Position.absolute(),
-            cursor: Cursor.zoomOut,
-            transition: Transition('transform', duration: 300),
-            raw: {
-              'transform-origin': 'top left',
-            },
-          ),
-        ]),
-      ];
+    css('figure.image', [
+      css('&.zoomable img').styles(
+        cursor: Cursor.zoomIn,
+      ),
+    ]),
+    css('dialog.zoom-modal', [
+      css('&').styles(
+        width: 100.vw,
+        height: 100.vh,
+        maxWidth: Unit.initial,
+        maxHeight: Unit.initial,
+        margin: Margin.zero,
+        padding: Padding.zero,
+        border: Border.none,
+        backgroundColor: Colors.transparent,
+        overflow: Overflow.hidden,
+        outline: Outline(style: OutlineStyle.none),
+      ),
+      css('.image-wrapper').styles(
+        position: Position.relative(),
+        width: 100.percent,
+        height: 100.percent,
+        backgroundColor: ContentColors.background,
+      ),
+      css('img').styles(
+        position: Position.absolute(),
+        cursor: Cursor.zoomOut,
+        transition: Transition('transform', duration: 300),
+        raw: {
+          'transform-origin': 'top left',
+        },
+      ),
+    ]),
+  ];
 }
 
-class _ZoomableImageState extends State<ZoomableImage> with ViewTransitionMixin {
+class _ZoomableImageState extends State<ZoomableImage>
+    with ViewTransitionMixin {
   static int _dialogCount = 0;
 
   late final HTMLDialogElement dialog;
@@ -86,20 +87,29 @@ class _ZoomableImageState extends State<ZoomableImage> with ViewTransitionMixin 
           ..className = 'zoom-modal';
         window.document.body!.appendChild(dialog);
 
-        _cancelSub = EventStreamProviders.cancelEvent.forTarget(dialog).listen((e) {
+        _cancelSub = EventStreamProviders.cancelEvent.forTarget(dialog).listen((
+          e,
+        ) {
           e.preventDefault();
           zoomOut();
         });
 
         updateImageOffset(false);
 
-        (runApp as dynamic)(StatefulBuilder(builder: (context, setState) {
-          dialogSetState = setState;
-          return _buildDialog(context);
-        }), attachTo: '#${dialog.id}');
+        (runApp as dynamic)(
+          StatefulBuilder(
+            builder: (context, setState) {
+              dialogSetState = setState;
+              return _buildDialog(context);
+            },
+          ),
+          attachTo: '#${dialog.id}',
+        );
       });
 
-      _resizeSub = EventStreamProviders.resizeEvent.forTarget(window).listen((_) {
+      _resizeSub = EventStreamProviders.resizeEvent.forTarget(window).listen((
+        _,
+      ) {
         updateImageOffset(true);
       });
     }
@@ -112,21 +122,30 @@ class _ZoomableImageState extends State<ZoomableImage> with ViewTransitionMixin 
     var sourceAspect = sourceRect.width / sourceRect.height;
     var windowAspect = window.innerWidth / window.innerHeight;
 
-    final sourceScale = windowAspect > sourceAspect //
+    final sourceScale =
+        windowAspect >
+            sourceAspect //
         ? sourceRect.height / window.innerHeight
         : sourceRect.width / window.innerWidth;
 
-    final targetOffsetX = windowAspect > sourceAspect ? (window.innerWidth - sourceRect.width / sourceScale) / 2 : 0.0;
-    final targetOffsetY =
-        windowAspect > sourceAspect ? 0.0 : (window.innerHeight - sourceRect.height / sourceScale) / 2;
+    final targetOffsetX = windowAspect > sourceAspect
+        ? (window.innerWidth - sourceRect.width / sourceScale) / 2
+        : 0.0;
+    final targetOffsetY = windowAspect > sourceAspect
+        ? 0.0
+        : (window.innerHeight - sourceRect.height / sourceScale) / 2;
 
     setState(() {
-      sourceOffset = (x: sourceRect.left, y: sourceRect.top, scale: sourceScale);
+      sourceOffset = (
+        x: sourceRect.left,
+        y: sourceRect.top,
+        scale: sourceScale,
+      );
       targetOffset = (
         x: targetOffsetX,
         y: targetOffsetY,
         width: sourceRect.width / sourceScale,
-        height: sourceRect.height / sourceScale
+        height: sourceRect.height / sourceScale,
       );
       this.isResize = isResize;
     });
@@ -165,51 +184,67 @@ class _ZoomableImageState extends State<ZoomableImage> with ViewTransitionMixin 
 
   @override
   Iterable<Component> build(BuildContext context) sync* {
-    yield DomComponent(tag: 'figure', classes: 'image zoomable', children: [
-      img(
-        key: imageKey,
-        src: component.src,
-        alt: component.alt ?? component.caption,
-        styles: zoomed ? Styles(visibility: Visibility.hidden) : null,
-        events: events(onClick: () {
-          zoomIn();
-        }),
-      ),
-      if (component.caption != null) DomComponent(tag: 'figcaption', children: [text(component.caption!)]),
-    ]);
+    yield DomComponent(
+      tag: 'figure',
+      classes: 'image zoomable',
+      children: [
+        img(
+          key: imageKey,
+          src: component.src,
+          alt: component.alt ?? component.caption,
+          styles: zoomed ? Styles(visibility: Visibility.hidden) : null,
+          events: events(
+            onClick: () {
+              zoomIn();
+            },
+          ),
+        ),
+        if (component.caption != null)
+          DomComponent(tag: 'figcaption', children: [text(component.caption!)]),
+      ],
+    );
   }
 
   Iterable<Component> _buildDialog(BuildContext context) sync* {
-    yield div(classes: 'image-wrapper', events: {
-      'click': (_) {
-        zoomOut();
+    yield div(
+      classes: 'image-wrapper',
+      events: {
+        'click': (_) {
+          zoomOut();
+        },
+        'wheel': (_) {
+          zoomOut();
+        },
       },
-      'wheel': (_) {
-        zoomOut();
-      },
-    }, [
-      img(
-        src: component.src,
-        alt: component.alt ?? component.caption,
-        styles: Styles(
-          position: Position.absolute(top: sourceOffset.y.px, left: sourceOffset.x.px),
-          width: targetOffset.width.px,
-          height: targetOffset.height.px,
-          transform: Transform.combine(zoomed
-              ? [
-                  Transform.translate(
-                    x: (-sourceOffset.x + targetOffset.x).px,
-                    y: (-sourceOffset.y + targetOffset.y).px,
-                  ),
-                  Transform.scale(1),
-                ]
-              : [
-                  Transform.translate(x: 0.px, y: 0.px),
-                  Transform.scale(sourceOffset.scale),
-                ]),
-          raw: {if (isResize) 'transition': 'none'},
+      [
+        img(
+          src: component.src,
+          alt: component.alt ?? component.caption,
+          styles: Styles(
+            position: Position.absolute(
+              top: sourceOffset.y.px,
+              left: sourceOffset.x.px,
+            ),
+            width: targetOffset.width.px,
+            height: targetOffset.height.px,
+            transform: Transform.combine(
+              zoomed
+                  ? [
+                      Transform.translate(
+                        x: (-sourceOffset.x + targetOffset.x).px,
+                        y: (-sourceOffset.y + targetOffset.y).px,
+                      ),
+                      Transform.scale(1),
+                    ]
+                  : [
+                      Transform.translate(x: 0.px, y: 0.px),
+                      Transform.scale(sourceOffset.scale),
+                    ],
+            ),
+            raw: {if (isResize) 'transition': 'none'},
+          ),
         ),
-      ),
-    ]);
+      ],
+    );
   }
 }

--- a/packages/jaspr_content/lib/components/callout.dart
+++ b/packages/jaspr_content/lib/components/callout.dart
@@ -25,7 +25,11 @@ class Callout extends CustomComponentBase {
   final Pattern pattern = RegExp(r'Info|Warning|Error|Success');
 
   @override
-  Component apply(String name, Map<String, String> attributes, Component? child) {
+  Component apply(
+    String name,
+    Map<String, String> attributes,
+    Component? child,
+  ) {
     return _Callout(
       type: name.toLowerCase(),
       child: child!,
@@ -34,66 +38,66 @@ class Callout extends CustomComponentBase {
 
   @css
   static List<StyleRule> get styles => [
-        css('.callout', [
-          css('&').styles(
-            display: Display.flex,
-            padding: Padding.symmetric(vertical: 1.rem, horizontal: 1.25.rem),
-            margin: Margin.only(bottom: 0.75.rem),
-            radius: BorderRadius.circular(0.75.rem),
-            border: Border(width: 1.px),
-            gap: Gap(column: 1.rem),
-          ),
-          css('span:first-child').styles(
-            padding: Padding.only(top: 0.25.rem),
-            flex: Flex(shrink: 0),
-          ),
-          css('span:last-child > p').styles(
-            margin: Margin.all(Unit.zero),
-          ),
-          css('&.callout-info').styles(
-            color: Color('rgb(3 105 161)'),
-            backgroundColor: Color('rgba(186, 230, 253, .1)'),
-            border: Border(color: Color('rgba(14,165,233,.2)')),
-          ),
-          css('&.callout-warning').styles(
-            color: Color('rgb(161 98 7)'),
-            backgroundColor: Color('hsla(53,98%,77%,.1)'),
-            border: Border(color: Color('rgba(234,179,8,.2)')),
-          ),
-          css('&.callout-error').styles(
-            color: Color('rgb(185 28 28)'),
-            backgroundColor: Color('hsla(0,96%,89%,.1)'),
-            border: Border(color: Color('rgba(239,68,68,.2)')),
-          ),
-          css('&.callout-success').styles(
-            color: Color('oklch(0.527 0.154 150.069)'),
-            backgroundColor: Color('rgba(187,247,208,.1)'),
-            border: Border(color: Color('rgba(34,197,94,.2)')),
-          ),
-        ]),
-        css('[data-theme="dark"] .callout', [
-          css('&.callout-info').styles(
-            color: Color.inherit,
-            backgroundColor: Color('rgba(14,165,233,.1)'),
-            border: Border(color: Color('rgba(14,165,233,.5)')),
-          ),
-          css('&.callout-warning').styles(
-            color: Color.inherit,
-            backgroundColor: Color('rgba(234,179,8,.1)'),
-            border: Border(color: Color('rgba(234,179,8,.5)')),
-          ),
-          css('&.callout-error').styles(
-            color: Color.inherit,
-            backgroundColor: Color('rgba(239,68,68,.1)'),
-            border: Border(color: Color('rgba(239,68,68,.5)')),
-          ),
-          css('&.callout-success').styles(
-            color: Color.inherit,
-            backgroundColor: Color('rgba(34,197,94,.1)'),
-            border: Border(color: Color('rgba(34,197,94,.5)')),
-          ),
-        ])
-      ];
+    css('.callout', [
+      css('&').styles(
+        display: Display.flex,
+        padding: Padding.symmetric(vertical: 1.rem, horizontal: 1.25.rem),
+        margin: Margin.only(bottom: 0.75.rem),
+        radius: BorderRadius.circular(0.75.rem),
+        border: Border(width: 1.px),
+        gap: Gap(column: 1.rem),
+      ),
+      css('span:first-child').styles(
+        padding: Padding.only(top: 0.25.rem),
+        flex: Flex(shrink: 0),
+      ),
+      css('span:last-child > p').styles(
+        margin: Margin.all(Unit.zero),
+      ),
+      css('&.callout-info').styles(
+        color: Color('rgb(3 105 161)'),
+        backgroundColor: Color('rgba(186, 230, 253, .1)'),
+        border: Border(color: Color('rgba(14,165,233,.2)')),
+      ),
+      css('&.callout-warning').styles(
+        color: Color('rgb(161 98 7)'),
+        backgroundColor: Color('hsla(53,98%,77%,.1)'),
+        border: Border(color: Color('rgba(234,179,8,.2)')),
+      ),
+      css('&.callout-error').styles(
+        color: Color('rgb(185 28 28)'),
+        backgroundColor: Color('hsla(0,96%,89%,.1)'),
+        border: Border(color: Color('rgba(239,68,68,.2)')),
+      ),
+      css('&.callout-success').styles(
+        color: Color('oklch(0.527 0.154 150.069)'),
+        backgroundColor: Color('rgba(187,247,208,.1)'),
+        border: Border(color: Color('rgba(34,197,94,.2)')),
+      ),
+    ]),
+    css('[data-theme="dark"] .callout', [
+      css('&.callout-info').styles(
+        color: Color.inherit,
+        backgroundColor: Color('rgba(14,165,233,.1)'),
+        border: Border(color: Color('rgba(14,165,233,.5)')),
+      ),
+      css('&.callout-warning').styles(
+        color: Color.inherit,
+        backgroundColor: Color('rgba(234,179,8,.1)'),
+        border: Border(color: Color('rgba(234,179,8,.5)')),
+      ),
+      css('&.callout-error').styles(
+        color: Color.inherit,
+        backgroundColor: Color('rgba(239,68,68,.1)'),
+        border: Border(color: Color('rgba(239,68,68,.5)')),
+      ),
+      css('&.callout-success').styles(
+        color: Color.inherit,
+        backgroundColor: Color('rgba(34,197,94,.1)'),
+        border: Border(color: Color('rgba(34,197,94,.5)')),
+      ),
+    ]),
+  ];
 }
 
 /// A callout component.
@@ -119,9 +123,9 @@ class _Callout extends StatelessComponent {
           'error' => CircleXIcon(size: 20),
           'success' => CircleCheckIcon(size: 20),
           _ => InfoIcon(size: 20),
-        }
+        },
       ]),
-      span([child])
+      span([child]),
     ]);
   }
 }

--- a/packages/jaspr_content/lib/components/code_block.dart
+++ b/packages/jaspr_content/lib/components/code_block.dart
@@ -42,10 +42,20 @@ class CodeBlock implements CustomComponent {
   @override
   Component? create(Node node, NodesBuilder builder) {
     if (node
-        case ElementNode(tag: 'Code' || 'CodeBlock', :final children, :final attributes) ||
-            ElementNode(tag: 'pre', children: [ElementNode(tag: 'code', :final children, :final attributes)])) {
+        case ElementNode(
+              tag: 'Code' || 'CodeBlock',
+              :final children,
+              :final attributes,
+            ) ||
+            ElementNode(
+              tag: 'pre',
+              children: [
+                ElementNode(tag: 'code', :final children, :final attributes),
+              ],
+            )) {
       var language = attributes['language'];
-      if (language == null && (attributes['class']?.startsWith('language-') ?? false)) {
+      if (language == null &&
+          (attributes['class']?.startsWith('language-') ?? false)) {
         language = attributes['class']!.substring('language-'.length);
       }
 
@@ -57,36 +67,40 @@ class CodeBlock implements CustomComponent {
         _initialized = true;
       }
 
-      return AsyncBuilder(builder: (context) async* {
-        final highlighter = Highlighter(
-          language: language ?? defaultLanguage,
-          theme: theme ?? (_defaultTheme ??= await HighlighterTheme.loadDarkTheme()),
-        );
+      return AsyncBuilder(
+        builder: (context) async* {
+          final highlighter = Highlighter(
+            language: language ?? defaultLanguage,
+            theme:
+                theme ??
+                (_defaultTheme ??= await HighlighterTheme.loadDarkTheme()),
+          );
 
-        yield _CodeBlock(
-          source: children?.map((c) => c.innerText).join(' ') ?? '',
-          highlighter: highlighter,
-        );
-      });
+          yield _CodeBlock(
+            source: children?.map((c) => c.innerText).join(' ') ?? '',
+            highlighter: highlighter,
+          );
+        },
+      );
     }
     return null;
   }
 
   @css
   static List<StyleRule> get styles => [
-        css('.code-block', [
-          css('&').styles(position: Position.relative()),
-          css('button').styles(
-            position: Position.absolute(top: 1.rem, right: 1.rem),
-            opacity: 0,
-            color: Colors.white,
-            width: 1.25.rem,
-            height: 1.25.rem,
-            zIndex: ZIndex(10),
-          ),
-          css('&:hover button').styles(opacity: 0.75),
-        ]),
-      ];
+    css('.code-block', [
+      css('&').styles(position: Position.relative()),
+      css('button').styles(
+        position: Position.absolute(top: 1.rem, right: 1.rem),
+        opacity: 0,
+        color: Colors.white,
+        width: 1.25.rem,
+        height: 1.25.rem,
+        zIndex: ZIndex(10),
+      ),
+      css('&:hover button').styles(opacity: 0.75),
+    ]),
+  ];
 }
 
 /// A code block component with syntax highlighting.
@@ -107,8 +121,11 @@ class _CodeBlock extends StatelessComponent {
   Iterable<Component> build(BuildContext context) sync* {
     final codeblock = pre([
       code([
-        if (highlighter != null) buildSpan(highlighter!.highlight(source)) else text(source),
-      ])
+        if (highlighter != null)
+          buildSpan(highlighter!.highlight(source))
+        else
+          text(source),
+      ]),
     ]);
 
     yield div(classes: 'code-block', [
@@ -125,7 +142,9 @@ class _CodeBlock extends StatelessComponent {
         color: Color.value(style.foreground.argb & 0x00FFFFFF),
         fontWeight: style.bold ? FontWeight.bold : null,
         fontStyle: style.italic ? FontStyle.italic : null,
-        textDecoration: style.underline ? TextDecoration(line: TextDecorationLine.underline) : null,
+        textDecoration: style.underline
+            ? TextDecoration(line: TextDecorationLine.underline)
+            : null,
       );
     }
 

--- a/packages/jaspr_content/lib/components/drop_cap.dart
+++ b/packages/jaspr_content/lib/components/drop_cap.dart
@@ -10,7 +10,11 @@ class DropCap extends StatelessComponent with CustomComponentBase {
   final Pattern pattern = 'DropCap';
 
   @override
-  Component apply(String name, Map<String, String> attributes, Component? child) {
+  Component apply(
+    String name,
+    Map<String, String> attributes,
+    Component? child,
+  ) {
     return this;
   }
 
@@ -21,13 +25,13 @@ class DropCap extends StatelessComponent with CustomComponentBase {
 
   @css
   static List<StyleRule> get styles => [
-        css('.dropcap + p:first-letter').styles(
-          fontSize: 5.em,
-          lineHeight: 0.85.em,
-          margin: Margin.only(right: 0.1.em, bottom: 0.1.em),
-          raw: {
-            'float': 'left',
-          },
-        ),
-      ];
+    css('.dropcap + p:first-letter').styles(
+      fontSize: 5.em,
+      lineHeight: 0.85.em,
+      margin: Margin.only(right: 0.1.em, bottom: 0.1.em),
+      raw: {
+        'float': 'left',
+      },
+    ),
+  ];
 }

--- a/packages/jaspr_content/lib/components/github_button.dart
+++ b/packages/jaspr_content/lib/components/github_button.dart
@@ -17,7 +17,8 @@ class GithubButton extends StatefulComponent {
   State createState() => GithubButtonState();
 }
 
-class GithubButtonState extends State<GithubButton> with PreloadStateMixin<GithubButton> {
+class GithubButtonState extends State<GithubButton>
+    with PreloadStateMixin<GithubButton> {
   int? stars;
   int? forks;
 
@@ -42,7 +43,9 @@ class GithubButtonState extends State<GithubButton> with PreloadStateMixin<Githu
   }
 
   Future<void> loadRepositoryData() async {
-    final response = await http.get(Uri.parse('https://api.github.com/repos/${component.repo}'));
+    final response = await http.get(
+      Uri.parse('https://api.github.com/repos/${component.repo}'),
+    );
     if (response.statusCode != 200) {
       return;
     }
@@ -55,90 +58,108 @@ class GithubButtonState extends State<GithubButton> with PreloadStateMixin<Githu
 
   @override
   Iterable<Component> build(BuildContext context) sync* {
-    yield a(href: 'https://github.com/${component.repo}', target: Target.blank, classes: 'github-button not-content', [
-      div(classes: 'github-icon', [
-        GithubIcon(),
-      ]),
-      div(classes: 'github-info', [
-        span([text('schultek/jaspr')]),
-        span([
-          text('★'),
-          span(styles: !loaded ? Styles(opacity: 0) : null, [text('${stars ?? 9999}')]),
-          span([]),
-          text('⑂'),
-          span(styles: !loaded ? Styles(opacity: 0) : null, [text('${forks ?? 99}')])
-        ])
-      ])
-    ]);
+    yield a(
+      href: 'https://github.com/${component.repo}',
+      target: Target.blank,
+      classes: 'github-button not-content',
+      [
+        div(classes: 'github-icon', [
+          GithubIcon(),
+        ]),
+        div(classes: 'github-info', [
+          span([text('schultek/jaspr')]),
+          span([
+            text('★'),
+            span(styles: !loaded ? Styles(opacity: 0) : null, [
+              text('${stars ?? 9999}'),
+            ]),
+            span([]),
+            text('⑂'),
+            span(styles: !loaded ? Styles(opacity: 0) : null, [
+              text('${forks ?? 99}'),
+            ]),
+          ]),
+        ]),
+      ],
+    );
   }
 
   @css
   static List<StyleRule> get styles => [
-        css('.github-button', [
+    css('.github-button', [
+      css('&').styles(
+        display: Display.flex,
+        padding: Padding.symmetric(horizontal: 0.7.rem, vertical: 0.4.rem),
+        radius: BorderRadius.circular(8.px),
+        alignItems: AlignItems.center,
+        gap: Gap(column: .5.rem),
+        fontSize: 0.7.rem,
+        textDecoration: TextDecoration.none,
+        lineHeight: 1.2.em,
+      ),
+      css('&:hover').styles(
+        backgroundColor: Color(
+          'color-mix(in srgb, currentColor 5%, transparent)',
+        ),
+      ),
+      css('& *').styles(
+        transition: Transition(
+          'opacity',
+          duration: 200,
+          curve: Curve.easeInOut,
+        ),
+      ),
+      css('&:hover *').styles(
+        raw: {'opacity': '1 !important'},
+      ),
+      css('.github-icon').styles(
+        width: 1.2.rem,
+      ),
+      css('.github-info', [
+        css('&').styles(
+          display: Display.flex,
+          flexDirection: FlexDirection.column,
+        ),
+        css('& > span:first-child').styles(
+          margin: Margin.only(bottom: 2.px),
+          opacity: 0.9,
+          fontFamily: FontFamily.list([FontFamilies.monospace]),
+        ),
+        css('& > span:last-child', [
           css('&').styles(
             display: Display.flex,
-            padding: Padding.symmetric(horizontal: 0.7.rem, vertical: 0.4.rem),
-            radius: BorderRadius.circular(8.px),
+            opacity: 0.7,
             alignItems: AlignItems.center,
-            gap: Gap(column: .5.rem),
-            fontSize: 0.7.rem,
-            textDecoration: TextDecoration.none,
-            lineHeight: 1.2.em,
+            gap: Gap(column: .3.em),
+            fontSize: 0.9.em,
+            fontWeight: FontWeight.w800,
           ),
-          css('&:hover').styles(
-            backgroundColor: Color('color-mix(in srgb, currentColor 5%, transparent)'),
-          ),
-          css('& *').styles(
-            transition: Transition('opacity', duration: 200, curve: Curve.easeInOut),
-          ),
-          css('&:hover *').styles(
-            raw: {'opacity': '1 !important'},
-          ),
-          css('.github-icon').styles(
-            width: 1.2.rem,
-          ),
-          css('.github-info', [
-            css('&').styles(
-              display: Display.flex,
-              flexDirection: FlexDirection.column,
-            ),
-            css('& > span:first-child').styles(
-              margin: Margin.only(bottom: 2.px),
-              opacity: 0.9,
-              fontFamily: FontFamily.list([FontFamilies.monospace]),
-            ),
-            css('& > span:last-child', [
-              css('&').styles(
-                display: Display.flex,
-                opacity: 0.7,
-                alignItems: AlignItems.center,
-                gap: Gap(column: .3.em),
-                fontSize: 0.9.em,
-                fontWeight: FontWeight.w800,
-              ),
-              css('span').styles(fontWeight: FontWeight.w500)
-            ]),
-          ]),
+          css('span').styles(fontWeight: FontWeight.w500),
         ]),
-      ];
+      ]),
+    ]),
+  ];
 }
 
 class GithubIcon extends StatelessComponent {
   @override
   Iterable<Component> build(BuildContext context) sync* {
-    yield svg(viewBox: '0 0 24 24', attributes: {
-      'fill': 'currentColor'
-    }, [
-      path(
-        d: r"M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.0"
-            "15-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.2"
-            "05.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-"
-            "1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1"
-            ".98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.8"
-            "4 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 "
-            ".315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12",
-        [],
-      ),
-    ]);
+    yield svg(
+      viewBox: '0 0 24 24',
+      attributes: {'fill': 'currentColor'},
+      [
+        path(
+          d:
+              r"M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.0"
+              "15-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.2"
+              "05.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-"
+              "1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1"
+              ".98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.8"
+              "4 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 "
+              ".315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12",
+          [],
+        ),
+      ],
+    );
   }
 }

--- a/packages/jaspr_content/lib/components/image.dart
+++ b/packages/jaspr_content/lib/components/image.dart
@@ -33,8 +33,14 @@ class Image implements CustomComponent {
   Component? create(Node node, NodesBuilder builder) {
     if (node
         case ElementNode(tag: 'img' || 'Image', :final attributes) ||
-            ElementNode(tag: 'p', children: [ElementNode(tag: 'img' || 'Image', :final attributes)])) {
-      assert(attributes.containsKey('src'), 'Image must have a "src" argument. Found $attributes');
+            ElementNode(
+              tag: 'p',
+              children: [ElementNode(tag: 'img' || 'Image', :final attributes)],
+            )) {
+      assert(
+        attributes.containsKey('src'),
+        'Image must have a "src" argument. Found $attributes',
+      );
       return from(
         src: attributes['src']!,
         alt: attributes['alt'],
@@ -47,14 +53,14 @@ class Image implements CustomComponent {
 
   @css
   static List<StyleRule> get styles => [
-        css('figure.image', [
-          css('&').styles(
-            display: Display.flex,
-            flexDirection: FlexDirection.column,
-            alignItems: AlignItems.center,
-          ),
-        ]),
-      ];
+    css('figure.image', [
+      css('&').styles(
+        display: Display.flex,
+        flexDirection: FlexDirection.column,
+        alignItems: AlignItems.center,
+      ),
+    ]),
+  ];
 }
 
 /// An image component with an optional caption.
@@ -77,9 +83,14 @@ class _Image extends StatelessComponent {
 
   @override
   Iterable<Component> build(BuildContext context) sync* {
-    yield DomComponent(tag: 'figure', classes: 'image', children: [
-      img(src: src, alt: alt ?? caption),
-      if (caption != null) DomComponent(tag: 'figcaption', children: [text(caption!)]),
-    ]);
+    yield DomComponent(
+      tag: 'figure',
+      classes: 'image',
+      children: [
+        img(src: src, alt: alt ?? caption),
+        if (caption != null)
+          DomComponent(tag: 'figcaption', children: [text(caption!)]),
+      ],
+    );
   }
 }

--- a/packages/jaspr_content/lib/components/post_break.dart
+++ b/packages/jaspr_content/lib/components/post_break.dart
@@ -11,7 +11,11 @@ class PostBreak extends StatelessComponent with CustomComponentBase {
   final Pattern pattern = 'PostBreak';
 
   @override
-  Component apply(String name, Map<String, String> attributes, Component? child) {
+  Component apply(
+    String name,
+    Map<String, String> attributes,
+    Component? child,
+  ) {
     return this;
   }
 
@@ -26,19 +30,19 @@ class PostBreak extends StatelessComponent with CustomComponentBase {
 
   @css
   static List<StyleRule> get styles => [
-        css('.postbreak', [
-          css('&').styles(
-            margin: Margin.only(top: 3.rem, bottom: 3.rem),
-            display: Display.flex,
-            justifyContent: JustifyContent.center,
-            gap: Gap(column: 1.25.rem),
-          ),
-          css('span').styles(
-            width: 4.px,
-            height: 4.px,
-            backgroundColor: ContentColors.headings,
-            radius: BorderRadius.circular(4.px),
-          ),
-        ])
-      ];
+    css('.postbreak', [
+      css('&').styles(
+        margin: Margin.only(top: 3.rem, bottom: 3.rem),
+        display: Display.flex,
+        justifyContent: JustifyContent.center,
+        gap: Gap(column: 1.25.rem),
+      ),
+      css('span').styles(
+        width: 4.px,
+        height: 4.px,
+        backgroundColor: ContentColors.headings,
+        radius: BorderRadius.circular(4.px),
+      ),
+    ]),
+  ];
 }

--- a/packages/jaspr_content/lib/components/sidebar_toggle_button.dart
+++ b/packages/jaspr_content/lib/components/sidebar_toggle_button.dart
@@ -11,43 +11,63 @@ class SidebarToggleButton extends StatelessComponent {
   @override
   Iterable<Component> build(BuildContext context) sync* {
     if (!kIsWeb) {
-      yield Document.head(children: [
-        Style(styles: styles),
-      ]);
+      yield Document.head(
+        children: [
+          Style(styles: styles),
+        ],
+      );
     }
 
-    yield button(classes: 'sidebar-toggle-button', onClick: () {
-      StreamSubscription? closeSub, barrierSub;
-      void close() {
-        closeSub?.cancel();
-        barrierSub?.cancel();
-        window.document.querySelector('.sidebar-container')?.classList.remove('open');
-      }
+    yield button(
+      classes: 'sidebar-toggle-button',
+      onClick: () {
+        StreamSubscription? closeSub, barrierSub;
+        void close() {
+          closeSub?.cancel();
+          barrierSub?.cancel();
+          window.document
+              .querySelector('.sidebar-container')
+              ?.classList
+              .remove('open');
+        }
 
-      closeSub = window.document.querySelector('.sidebar-close')?.onClick.listen((_) {
-        close();
-      });
-      barrierSub = window.document.querySelector('.sidebar-barrier')?.onClick.listen((_) {
-        close();
-      });
-      window.document.querySelector('.sidebar-container')?.classList.add('open');
-    }, [
-      raw(menuIcon),
-    ]);
+        closeSub = window.document
+            .querySelector('.sidebar-close')
+            ?.onClick
+            .listen((_) {
+              close();
+            });
+        barrierSub = window.document
+            .querySelector('.sidebar-barrier')
+            ?.onClick
+            .listen((_) {
+              close();
+            });
+        window.document
+            .querySelector('.sidebar-container')
+            ?.classList
+            .add('open');
+      },
+      [
+        raw(menuIcon),
+      ],
+    );
   }
 
   List<StyleRule> get styles => [
-        css('.sidebar-toggle-button').styles(
-          display: Display.none,
-          justifyContent: JustifyContent.center,
-          alignItems: AlignItems.center,
-          width: 2.rem,
-          height: 2.rem,
-        ),
-        css.media(MediaQuery.all(maxWidth: 1024.px), [
-          css('[data-has-sidebar] .sidebar-toggle-button').styles(display: Display.flex),
-        ]),
-      ];
+    css('.sidebar-toggle-button').styles(
+      display: Display.none,
+      justifyContent: JustifyContent.center,
+      alignItems: AlignItems.center,
+      width: 2.rem,
+      height: 2.rem,
+    ),
+    css.media(MediaQuery.all(maxWidth: 1024.px), [
+      css(
+        '[data-has-sidebar] .sidebar-toggle-button',
+      ).styles(display: Display.flex),
+    ]),
+  ];
 }
 
 const menuIcon = '''

--- a/packages/jaspr_content/lib/components/tabs.dart
+++ b/packages/jaspr_content/lib/components/tabs.dart
@@ -18,7 +18,11 @@ class Tabs implements CustomComponent {
   @override
   Component? create(Node node, NodesBuilder builder) {
     if (node is ElementNode && node.tag == 'Tabs') {
-      var tabs = node.children?.whereType<ElementNode>().where((n) => n.tag == 'TabItem') ?? [];
+      var tabs =
+          node.children?.whereType<ElementNode>().where(
+            (n) => n.tag == 'TabItem',
+          ) ??
+          [];
       if (tabs.isEmpty) {
         print("[WARNING] Tabs component requires at least one TabItem child.");
       }
@@ -40,13 +44,13 @@ class Tabs implements CustomComponent {
 
   @css
   static List<StyleRule> get styles => [
-        css('.tabs', [
-          css('.tab-content', [
-            css('&').styles(display: Display.none),
-            css('&[active]').styles(display: Display.initial),
-          ])
-        ]),
-      ];
+    css('.tabs', [
+      css('.tab-content', [
+        css('&').styles(display: Display.none),
+        css('&[active]').styles(display: Display.initial),
+      ]),
+    ]),
+  ];
 }
 
 class _Tabs extends StatelessComponent {
@@ -62,12 +66,19 @@ class _Tabs extends StatelessComponent {
   Iterable<Component> build(BuildContext context) sync* {
     final initialValue = defaultValue ?? items.first.value;
     yield div(classes: 'tabs', [
-      TabBar(initialValue: initialValue, items: {for (var item in items) item.value: item.label}),
+      TabBar(
+        initialValue: initialValue,
+        items: {for (var item in items) item.value: item.label},
+      ),
       div([
         for (var item in items)
           div(
             classes: 'tab-content',
-            attributes: {'data-tab': item.value, 'label': item.label, if (item.value == initialValue) 'active': ''},
+            attributes: {
+              'data-tab': item.value,
+              'label': item.label,
+              if (item.value == initialValue) 'active': '',
+            },
             [item.child],
           ),
       ]),

--- a/packages/jaspr_content/lib/components/theme_toggle.dart
+++ b/packages/jaspr_content/lib/components/theme_toggle.dart
@@ -26,10 +26,14 @@ class ThemeToggleState extends State<ThemeToggle> {
   @override
   Iterable<Component> build(BuildContext context) sync* {
     if (!kIsWeb) {
-      yield Document.head(children: [
-        // ignore: prefer_html_methods
-        DomComponent(id: 'theme-script', tag: 'script', children: [
-          raw('''
+      yield Document.head(
+        children: [
+          // ignore: prefer_html_methods
+          DomComponent(
+            id: 'theme-script',
+            tag: 'script',
+            children: [
+              raw('''
           let userTheme = window.localStorage.getItem('jaspr:theme');
           if (userTheme != null) {
             document.documentElement.setAttribute('data-theme', userTheme);
@@ -38,13 +42,17 @@ class ThemeToggleState extends State<ThemeToggle> {
           } else {
             document.documentElement.setAttribute('data-theme', 'light');
           }
-        ''')
-        ]),
-      ]);
+        '''),
+            ],
+          ),
+        ],
+      );
     }
 
     if (kIsWeb) {
-      yield Document.html(attributes: {'data-theme': isDark ? 'dark' : 'light'});
+      yield Document.html(
+        attributes: {'data-theme': isDark ? 'dark' : 'light'},
+      );
     }
 
     yield button(
@@ -54,12 +62,19 @@ class ThemeToggleState extends State<ThemeToggle> {
         setState(() {
           isDark = !isDark;
         });
-        web.window.localStorage.setItem('jaspr:theme', isDark ? 'dark' : 'light');
+        web.window.localStorage.setItem(
+          'jaspr:theme',
+          isDark ? 'dark' : 'light',
+        );
       },
       styles: !kIsWeb ? Styles(visibility: Visibility.hidden) : null,
       [
-        span(styles: Styles(display: isDark ? Display.none : null), [MoonIcon(size: 20)]),
-        span(styles: Styles(display: isDark ? null : Display.none), [SunIcon(size: 20)]),
+        span(styles: Styles(display: isDark ? Display.none : null), [
+          MoonIcon(size: 20),
+        ]),
+        span(styles: Styles(display: isDark ? null : Display.none), [
+          SunIcon(size: 20),
+        ]),
       ],
     );
   }
@@ -77,7 +92,9 @@ class ThemeToggleState extends State<ThemeToggle> {
         backgroundColor: Colors.transparent,
       ),
       css('&:hover').styles(
-        backgroundColor: Color('color-mix(in srgb, currentColor 5%, transparent)'),
+        backgroundColor: Color(
+          'color-mix(in srgb, currentColor 5%, transparent)',
+        ),
       ),
     ]),
   ];

--- a/packages/jaspr_content/lib/src/components/header.dart
+++ b/packages/jaspr_content/lib/src/components/header.dart
@@ -17,9 +17,11 @@ class Header extends StatelessComponent {
 
   @override
   Iterable<Component> build(BuildContext context) sync* {
-    yield Document.head(children: [
-      Style(styles: _styles),
-    ]);
+    yield Document.head(
+      children: [
+        Style(styles: _styles),
+      ],
+    );
 
     yield header(classes: 'header', [
       SidebarToggleButton(),
@@ -32,41 +34,43 @@ class Header extends StatelessComponent {
   }
 
   static List<StyleRule> get _styles => [
-        css('.header', [
-          css('&').styles(
-            height: 4.rem,
-            display: Display.flex,
-            alignItems: AlignItems.center,
-            gap: Gap(column: 1.rem),
-            maxWidth: 90.rem,
-            padding: Padding.symmetric(horizontal: 1.rem, vertical: .25.rem),
-            margin: Margin.symmetric(horizontal: Unit.auto),
-            border: Border.only(bottom: BorderSide(color: Color('#0000000d'), width: 1.px)),
-          ),
-          css.media(MediaQuery.all(minWidth: 768.px), [
-            css('&').styles(padding: Padding.symmetric(horizontal: 2.5.rem)),
-          ]),
-          css('.header-title', [
-            css('&').styles(
-              flex: Flex(grow: 1),
-              display: Display.inlineFlex,
-              alignItems: AlignItems.center,
-              gap: Gap(column: .75.rem),
-            ),
-            css('img').styles(
-              height: 1.5.rem,
-              width: Unit.auto,
-            ),
-            css('span').styles(
-              fontWeight: FontWeight.w700,
-            ),
-          ]),
-          css('.header-items', [
-            css('&').styles(
-              display: Display.flex,
-              gap: Gap(column: 0.25.rem),
-            ),
-          ]),
-        ]),
-      ];
+    css('.header', [
+      css('&').styles(
+        height: 4.rem,
+        display: Display.flex,
+        alignItems: AlignItems.center,
+        gap: Gap(column: 1.rem),
+        maxWidth: 90.rem,
+        padding: Padding.symmetric(horizontal: 1.rem, vertical: .25.rem),
+        margin: Margin.symmetric(horizontal: Unit.auto),
+        border: Border.only(
+          bottom: BorderSide(color: Color('#0000000d'), width: 1.px),
+        ),
+      ),
+      css.media(MediaQuery.all(minWidth: 768.px), [
+        css('&').styles(padding: Padding.symmetric(horizontal: 2.5.rem)),
+      ]),
+      css('.header-title', [
+        css('&').styles(
+          flex: Flex(grow: 1),
+          display: Display.inlineFlex,
+          alignItems: AlignItems.center,
+          gap: Gap(column: .75.rem),
+        ),
+        css('img').styles(
+          height: 1.5.rem,
+          width: Unit.auto,
+        ),
+        css('span').styles(
+          fontWeight: FontWeight.w700,
+        ),
+      ]),
+      css('.header-items', [
+        css('&').styles(
+          display: Display.flex,
+          gap: Gap(column: 0.25.rem),
+        ),
+      ]),
+    ]),
+  ];
 }

--- a/packages/jaspr_content/lib/src/components/sidebar.dart
+++ b/packages/jaspr_content/lib/src/components/sidebar.dart
@@ -34,9 +34,11 @@ class Sidebar extends StatelessComponent {
   Iterable<Component> build(BuildContext context) sync* {
     var currentRoute = context.page.url;
 
-    yield Document.head(children: [
-      Style(styles: _styles),
-    ]);
+    yield Document.head(
+      children: [
+        Style(styles: _styles),
+      ],
+    );
 
     yield nav(classes: 'sidebar', [
       button(classes: 'sidebar-close', [
@@ -62,71 +64,77 @@ class Sidebar extends StatelessComponent {
   }
 
   static List<StyleRule> get _styles => [
-        css('.sidebar', [
-          css('&').styles(
-            position: Position.relative(),
-            fontSize: 0.875.rem,
-            lineHeight: 1.25.rem,
-            padding: Padding.only(left: 0.5.rem, bottom: 1.25.rem, top: 0.75.rem),
-          ),
-          css.media(MediaQuery.all(minWidth: 1024.px), [
-            css('&').styles(
-              padding: Padding.only(top: Unit.zero),
-            ),
-          ]),
-          css('.sidebar-close', [
-            css('&').styles(
-              position: Position.absolute(top: 0.75.rem, right: 0.75.rem),
-            ),
-            css.media(MediaQuery.all(minWidth: 1024.px), [
-              css('&').styles(display: Display.none),
-            ]),
-          ]),
-          css('.sidebar-group', [
-            css('&').styles(
-              padding: Padding.only(top: 1.5.rem, right: 0.75.rem),
-            ),
-            css('h3').styles(
-              fontWeight: FontWeight.w600,
-              fontSize: 14.px,
-              padding: Padding.only(left: 0.75.rem),
-              margin: Margin.only(bottom: 1.rem, top: Unit.zero),
-            ),
-            css('ul').styles(
-              listStyle: ListStyle.none,
-              margin: Margin.zero,
-              padding: Padding.zero,
-            ),
-            css('li', [
-              css('div', [
-                css('&').styles(
-                  opacity: 0.75,
-                  margin: Margin.only(bottom: 1.px),
-                  whiteSpace: WhiteSpace.noWrap,
-                  overflow: Overflow.hidden,
-                  textOverflow: TextOverflow.ellipsis,
-                  radius: BorderRadius.circular(.375.rem),
-                  display: Display.flex,
-                  transition: Transition('all', duration: 150, curve: Curve.easeInOut),
-                ),
-                css('&:hover').styles(
-                  opacity: 1,
-                  backgroundColor: Color('#0000000d'),
-                ),
-                css('&.active').styles(
-                  opacity: 1,
-                  color: ContentColors.primary,
-                  fontWeight: FontWeight.w700,
-                  backgroundColor: Color('color-mix(in srgb, currentColor 15%, transparent)'),
-                ),
-              ]),
-              css('a').styles(
-                padding: Padding.only(left: 12.px, top: .5.rem, bottom: .5.rem),
-                display: Display.inlineFlex,
-                flex: Flex(grow: 1),
-              ),
-            ]),
-          ]),
+    css('.sidebar', [
+      css('&').styles(
+        position: Position.relative(),
+        fontSize: 0.875.rem,
+        lineHeight: 1.25.rem,
+        padding: Padding.only(left: 0.5.rem, bottom: 1.25.rem, top: 0.75.rem),
+      ),
+      css.media(MediaQuery.all(minWidth: 1024.px), [
+        css('&').styles(
+          padding: Padding.only(top: Unit.zero),
+        ),
+      ]),
+      css('.sidebar-close', [
+        css('&').styles(
+          position: Position.absolute(top: 0.75.rem, right: 0.75.rem),
+        ),
+        css.media(MediaQuery.all(minWidth: 1024.px), [
+          css('&').styles(display: Display.none),
         ]),
-      ];
+      ]),
+      css('.sidebar-group', [
+        css('&').styles(
+          padding: Padding.only(top: 1.5.rem, right: 0.75.rem),
+        ),
+        css('h3').styles(
+          fontWeight: FontWeight.w600,
+          fontSize: 14.px,
+          padding: Padding.only(left: 0.75.rem),
+          margin: Margin.only(bottom: 1.rem, top: Unit.zero),
+        ),
+        css('ul').styles(
+          listStyle: ListStyle.none,
+          margin: Margin.zero,
+          padding: Padding.zero,
+        ),
+        css('li', [
+          css('div', [
+            css('&').styles(
+              opacity: 0.75,
+              margin: Margin.only(bottom: 1.px),
+              whiteSpace: WhiteSpace.noWrap,
+              overflow: Overflow.hidden,
+              textOverflow: TextOverflow.ellipsis,
+              radius: BorderRadius.circular(.375.rem),
+              display: Display.flex,
+              transition: Transition(
+                'all',
+                duration: 150,
+                curve: Curve.easeInOut,
+              ),
+            ),
+            css('&:hover').styles(
+              opacity: 1,
+              backgroundColor: Color('#0000000d'),
+            ),
+            css('&.active').styles(
+              opacity: 1,
+              color: ContentColors.primary,
+              fontWeight: FontWeight.w700,
+              backgroundColor: Color(
+                'color-mix(in srgb, currentColor 15%, transparent)',
+              ),
+            ),
+          ]),
+          css('a').styles(
+            padding: Padding.only(left: 12.px, top: .5.rem, bottom: .5.rem),
+            display: Display.inlineFlex,
+            flex: Flex(grow: 1),
+          ),
+        ]),
+      ]),
+    ]),
+  ];
 }

--- a/packages/jaspr_content/lib/src/content.dart
+++ b/packages/jaspr_content/lib/src/content.dart
@@ -16,16 +16,21 @@ class Content extends StatelessComponent {
   }
 
   static ContentTheme themeOf(BuildContext context) {
-    return context.dependOnInheritedComponentOfExactType<_InheritedContentTheme>()?.theme ?? ContentTheme();
+    return context
+            .dependOnInheritedComponentOfExactType<_InheritedContentTheme>()
+            ?.theme ??
+        ContentTheme();
   }
 
   @override
   Iterable<Component> build(BuildContext context) sync* {
     if (!kIsWeb) {
       final theme = themeOf(context);
-      yield Document.head(children: [
-        Style(styles: theme.styles),
-      ]);
+      yield Document.head(
+        children: [
+          Style(styles: theme.styles),
+        ],
+      );
     }
 
     yield section(classes: 'content', [child]);

--- a/packages/jaspr_content/lib/src/content_app.dart
+++ b/packages/jaspr_content/lib/src/content_app.dart
@@ -89,20 +89,20 @@ class ContentApp extends AsyncStatelessComponent {
     /// The [ContentTheme] to use for the pages.
     ContentTheme? theme,
     bool debugPrint = false,
-  })  : loaders = [FilesystemLoader(directory, debugPrint: debugPrint)],
-        configResolver = PageConfig.all(
-          enableFrontmatter: enableFrontmatter,
-          dataLoaders: [
-            FilesystemDataLoader(dataDirectory),
-          ],
-          templateEngine: templateEngine,
-          parsers: parsers,
-          extensions: extensions,
-          components: components,
-          layouts: layouts,
-          theme: theme,
-        ),
-        routerBuilder = _defaultRouterBuilder {
+  }) : loaders = [FilesystemLoader(directory, debugPrint: debugPrint)],
+       configResolver = PageConfig.all(
+         enableFrontmatter: enableFrontmatter,
+         dataLoaders: [
+           FilesystemDataLoader(dataDirectory),
+         ],
+         templateEngine: templateEngine,
+         parsers: parsers,
+         extensions: extensions,
+         components: components,
+         layouts: layouts,
+         theme: theme,
+       ),
+       routerBuilder = _defaultRouterBuilder {
     _overrideGlobalOptions();
   }
 
@@ -129,7 +129,9 @@ class ContentApp extends AsyncStatelessComponent {
 
   void _overrideGlobalOptions() {
     if (Jaspr.useIsolates) {
-      print("[Warning] ContentApp only supports non-isolate rendering. Disabling isolate rendering.");
+      print(
+        "[Warning] ContentApp only supports non-isolate rendering. Disabling isolate rendering.",
+      );
       // For caching to work correctly we need to disable isolate rendering.
       Jaspr.initializeApp(options: Jaspr.options, useIsolates: false);
     }
@@ -142,7 +144,9 @@ class ContentApp extends AsyncStatelessComponent {
 
   @override
   Stream<Component> build(BuildContext context) async* {
-    final routes = await Future.wait(loaders.map((l) => l.loadRoutes(configResolver, eagerlyLoadAllPages)));
+    final routes = await Future.wait(
+      loaders.map((l) => l.loadRoutes(configResolver, eagerlyLoadAllPages)),
+    );
     _ensureAllowedSuffixes(routes);
     yield routerBuilder(routes);
   }
@@ -151,7 +155,8 @@ class ContentApp extends AsyncStatelessComponent {
     List<String> getSuffixes(RouteBase route) {
       if (route is Route) {
         return [
-          if (route.path.split('/').last.split('.') case [_, ..., final suffix]) suffix,
+          if (route.path.split('/').last.split('.') case [_, ..., final suffix])
+            suffix,
           ...route.routes.expand((r) => getSuffixes(r)),
         ];
       } else if (route is ShellRoute) {
@@ -161,7 +166,10 @@ class ContentApp extends AsyncStatelessComponent {
       }
     }
 
-    final suffixes = routes.expand((r) => r).expand((r) => getSuffixes(r)).toSet();
+    final suffixes = routes
+        .expand((r) => r)
+        .expand((r) => getSuffixes(r))
+        .toSet();
     final missing = suffixes.difference(Jaspr.allowedPathSuffixes.toSet());
     if (missing.isNotEmpty) {
       Jaspr.initializeApp(

--- a/packages/jaspr_content/lib/src/data_loader/data_loader.dart
+++ b/packages/jaspr_content/lib/src/data_loader/data_loader.dart
@@ -36,7 +36,8 @@ extension on yaml.YamlNode {
   Object normalize() {
     if (this case yaml.YamlMap(:final nodes)) {
       return {
-        for (final entry in nodes.entries) entry.key.toString(): entry.value.normalize(),
+        for (final entry in nodes.entries)
+          entry.key.toString(): entry.value.normalize(),
       };
     } else if (this case yaml.YamlList(:final nodes)) {
       return [

--- a/packages/jaspr_content/lib/src/layouts/blog_layout.dart
+++ b/packages/jaspr_content/lib/src/layouts/blog_layout.dart
@@ -40,18 +40,20 @@ class BlogLayout extends PageLayoutBase {
   @override
   Iterable<Component> buildHead(Page page) sync* {
     yield* super.buildHead(page);
-    yield Style(styles: [
-      ..._styles,
-      css('.blog .content', [
-        css('&').styles(
-          fontSize: 1.125.rem,
-          lineHeight: 2.rem,
-        ),
-        css('> :not(:is(h1,h2,h3,h4,h5,h6))').styles(
-          fontFamily: textFont,
-        ),
-      ])
-    ]);
+    yield Style(
+      styles: [
+        ..._styles,
+        css('.blog .content', [
+          css('&').styles(
+            fontSize: 1.125.rem,
+            lineHeight: 2.rem,
+          ),
+          css('> :not(:is(h1,h2,h3,h4,h5,h6))').styles(
+            fontFamily: textFont,
+          ),
+        ]),
+      ],
+    );
   }
 
   @override
@@ -69,14 +71,18 @@ class BlogLayout extends PageLayoutBase {
             div(classes: 'post-header', [
               if (pageData['title'] case String title) h1([text(title)]),
               div(classes: 'post-info', [
-                if (pageData['authorImage'] case String authorImage) img(src: authorImage, alt: 'Author image'),
+                if (pageData['authorImage'] case String authorImage)
+                  img(src: authorImage, alt: 'Author image'),
                 div([
                   span([text(pageData['author'] ?? 'Unknown')]),
                   span([
-                    text([
-                      if (pageData['readTime'] case String readTime) '$readTime read',
-                      if (pageData['date'] case String date) date,
-                    ].join(' • ')),
+                    text(
+                      [
+                        if (pageData['readTime'] case String readTime)
+                          '$readTime read',
+                        if (pageData['date'] case String date) date,
+                      ].join(' • '),
+                    ),
                   ]),
                 ]),
               ]),
@@ -94,79 +100,95 @@ class BlogLayout extends PageLayoutBase {
   }
 
   static List<StyleRule> get _styles => [
-        css('.blog', [
-          css('.header-container', [
-            css('&').styles(
-              position: Position.sticky(top: Unit.zero, left: Unit.zero, right: Unit.zero),
-              zIndex: ZIndex(10),
-              backgroundColor: ContentColors.background,
+    css('.blog', [
+      css('.header-container', [
+        css('&').styles(
+          position: Position.sticky(
+            top: Unit.zero,
+            left: Unit.zero,
+            right: Unit.zero,
+          ),
+          zIndex: ZIndex(10),
+          backgroundColor: ContentColors.background,
+        ),
+      ]),
+      css('.main-container', [
+        css('&').styles(
+          padding: Padding.zero,
+        ),
+        css.media(MediaQuery.all(minWidth: 768.px), [
+          css('&').styles(padding: Padding.symmetric(horizontal: 1.25.rem)),
+        ]),
+        css('main', [
+          css('&').styles(
+            padding: Padding.only(
+              top: 2.rem,
+              left: 1.rem,
+              right: 1.rem,
+              bottom: 4.rem,
             ),
-          ]),
-          css('.main-container', [
-            css('&').styles(
-              padding: Padding.zero,
-            ),
-            css.media(MediaQuery.all(minWidth: 768.px), [
-              css('&').styles(padding: Padding.symmetric(horizontal: 1.25.rem)),
-            ]),
-            css('main', [
+            margin: Margin.symmetric(horizontal: Unit.auto),
+            maxWidth: Unit.expression('75ch'),
+          ),
+          css('.content-container', [
+            css('.post-header', [
               css('&').styles(
-                padding: Padding.only(top: 2.rem, left: 1.rem, right: 1.rem, bottom: 4.rem),
-                margin: Margin.symmetric(horizontal: Unit.auto),
-                maxWidth: Unit.expression('75ch'),
+                margin: Margin.only(bottom: 2.rem),
               ),
-              css('.content-container', [
-                css('.post-header', [
-                  css('&').styles(
-                    margin: Margin.only(bottom: 2.rem),
-                  ),
-                  css('h1').styles(
-                    fontSize: 2.75.rem,
-                    lineHeight: 3.25.rem,
-                    color: ContentColors.headings,
-                  ),
-                  css('.post-info', [
-                    css('&').styles(
-                      margin: Margin.only(top: 2.rem),
-                      display: Display.flex,
-                      alignItems: AlignItems.center,
-                      gap: Gap(column: 1.rem),
-                    ),
-                    css('> img').styles(width: 42.px, height: 42.px, radius: BorderRadius.circular(10.rem)),
-                    css('> div', [
-                      css('&').styles(
-                        display: Display.flex,
-                        flexDirection: FlexDirection.column,
-                        color: ContentColors.text,
-                      ),
-                      css(':first-child').styles(
-                        fontSize: 1.125.rem,
-                      ),
-                      css(':last-child').styles(
-                        fontSize: 1.rem,
-                        opacity: 0.85,
-                      ),
-                    ])
-                  ]),
-                ]),
-                css('.post-tags', [
+              css('h1').styles(
+                fontSize: 2.75.rem,
+                lineHeight: 3.25.rem,
+                color: ContentColors.headings,
+              ),
+              css('.post-info', [
+                css('&').styles(
+                  margin: Margin.only(top: 2.rem),
+                  display: Display.flex,
+                  alignItems: AlignItems.center,
+                  gap: Gap(column: 1.rem),
+                ),
+                css('> img').styles(
+                  width: 42.px,
+                  height: 42.px,
+                  radius: BorderRadius.circular(10.rem),
+                ),
+                css('> div', [
                   css('&').styles(
                     display: Display.flex,
-                    flexDirection: FlexDirection.row,
-                    flexWrap: FlexWrap.wrap,
-                    gap: Gap.all(0.5.rem),
-                    margin: Margin.only(top: 2.rem, bottom: 0.5.rem),
+                    flexDirection: FlexDirection.column,
+                    color: ContentColors.text,
                   ),
-                  css('span').styles(
-                    padding: Padding.symmetric(horizontal: 0.75.rem, vertical: 0.25.rem),
-                    radius: BorderRadius.circular(10.rem),
-                    backgroundColor: ContentColors.hr,
-                    fontSize: 0.875.rem,
-                  )
-                ])
+                  css(':first-child').styles(
+                    fontSize: 1.125.rem,
+                  ),
+                  css(':last-child').styles(
+                    fontSize: 1.rem,
+                    opacity: 0.85,
+                  ),
+                ]),
               ]),
+            ]),
+            css('.post-tags', [
+              css('&').styles(
+                display: Display.flex,
+                flexDirection: FlexDirection.row,
+                flexWrap: FlexWrap.wrap,
+                gap: Gap.all(0.5.rem),
+                margin: Margin.only(top: 2.rem, bottom: 0.5.rem),
+              ),
+              css('span').styles(
+                padding: Padding.symmetric(
+                  horizontal: 0.75.rem,
+                  vertical: 0.25.rem,
+                ),
+                radius: BorderRadius.circular(10.rem),
+                backgroundColor: ContentColors.hr,
+                fontSize: 0.875.rem,
+              ),
             ]),
           ]),
         ]),
-      ];
+      ]),
+    ]),
+  ];
 }

--- a/packages/jaspr_content/lib/src/layouts/docs_layout.dart
+++ b/packages/jaspr_content/lib/src/layouts/docs_layout.dart
@@ -50,11 +50,13 @@ class DocsLayout extends PageLayoutBase {
 
     return div(classes: 'docs', [
       if (header case final header?)
-        div(classes: 'header-container', attributes: {
-          if (sidebar != null) 'data-has-sidebar': ''
-        }, [
-          header,
-        ]),
+        div(
+          classes: 'header-container',
+          attributes: {if (sidebar != null) 'data-has-sidebar': ''},
+          [
+            header,
+          ],
+        ),
       div(classes: 'main-container', [
         div(classes: 'sidebar-barrier', attributes: {'role': 'button'}, []),
         if (sidebar case final sidebar?)
@@ -66,8 +68,10 @@ class DocsLayout extends PageLayoutBase {
             div(classes: 'content-container', [
               div(classes: 'content-header', [
                 if (pageData['title'] case String title) h1([text(title)]),
-                if (pageData['description'] case String description) p([text(description)]),
-                if (pageData['image'] case String image) img(src: image, alt: pageData['imageAlt']),
+                if (pageData['description'] case String description)
+                  p([text(description)]),
+                if (pageData['image'] case String image)
+                  img(src: image, alt: pageData['imageAlt']),
               ]),
               child,
               if (footer case final footer?)
@@ -89,152 +93,162 @@ class DocsLayout extends PageLayoutBase {
   }
 
   static List<StyleRule> get _styles => [
-        css('.docs', [
-          css('.header-container', [
+    css('.docs', [
+      css('.header-container', [
+        css('&').styles(
+          position: Position.fixed(
+            top: Unit.zero,
+            left: Unit.zero,
+            right: Unit.zero,
+          ),
+          zIndex: ZIndex(10),
+          raw: {
+            'backdrop-filter': 'blur(8px)',
+          },
+        ),
+      ]),
+      css('.main-container', [
+        css('&').styles(
+          padding: Padding.zero,
+          margin: Margin.symmetric(horizontal: Unit.auto),
+          maxWidth: 90.rem,
+        ),
+        css.media(MediaQuery.all(minWidth: 768.px), [
+          css('&').styles(padding: Padding.symmetric(horizontal: 1.25.rem)),
+        ]),
+        css('.sidebar-barrier', [
+          css('&').styles(
+            position: Position.absolute(),
+            zIndex: ZIndex(9),
+            backgroundColor: ContentColors.background,
+            opacity: 0,
+            pointerEvents: PointerEvents.none,
+            raw: {'inset': '0'},
+          ),
+          css('&:has(+ .sidebar-container.open)').styles(
+            opacity: 0.5,
+            pointerEvents: PointerEvents.auto,
+          ),
+        ]),
+        css('.sidebar-container', [
+          css('&').styles(
+            position: Position.fixed(bottom: Unit.zero, top: 4.rem),
+            zIndex: ZIndex(10),
+            width: 17.rem,
+            overflow: Overflow.only(y: Overflow.auto),
+            transform: Transform.translate(x: (-100).percent),
+            transition: Transition(
+              'transform',
+              duration: 150,
+              curve: Curve.easeInOut,
+            ),
+          ),
+          css.media(MediaQuery.all(minWidth: 768.px), [
             css('&').styles(
-              position: Position.fixed(top: Unit.zero, left: Unit.zero, right: Unit.zero),
-              zIndex: ZIndex(10),
-              raw: {
-                'backdrop-filter': 'blur(8px)',
-              },
+              margin: Margin.only(left: (-1.25).rem),
             ),
           ]),
-          css('.main-container', [
+          css.media(MediaQuery.all(minWidth: 1024.px), [
             css('&').styles(
-              padding: Padding.zero,
-              margin: Margin.symmetric(horizontal: Unit.auto),
-              maxWidth: 90.rem,
+              margin: Margin.only(left: Unit.zero),
+              transform: Transform.translate(x: Unit.zero),
             ),
-            css.media(MediaQuery.all(minWidth: 768.px), [
-              css('&').styles(padding: Padding.symmetric(horizontal: 1.25.rem)),
+          ]),
+          css.media(MediaQuery.all(maxWidth: 1023.px), [
+            css('&').styles(
+              backgroundColor: ContentColors.background,
+              position: Position.fixed(top: Unit.zero),
+              border: Border.only(
+                right: BorderSide(width: 1.px, color: Color('#0000000d')),
+              ),
+            ),
+          ]),
+          css('&.open').styles(
+            transform: Transform.translate(x: Unit.zero),
+          ),
+        ]),
+        css('main', [
+          css('&').styles(
+            position: Position.relative(),
+            padding: Padding.only(top: 4.rem),
+          ),
+          css.media(MediaQuery.all(minWidth: 1024.px), [
+            css('&').styles(padding: Padding.only(left: 17.rem)),
+          ]),
+          css('> div', [
+            css('&').styles(
+              padding: Padding.only(top: 2.rem, left: 1.rem, right: 1.rem),
+              display: Display.flex,
+            ),
+            css.media(MediaQuery.all(minWidth: 1024.px), [
+              css('&').styles(padding: Padding.only(left: 4.rem)),
             ]),
-            css('.sidebar-barrier', [
+            css('.content-container', [
               css('&').styles(
-                position: Position.absolute(),
-                zIndex: ZIndex(9),
-                backgroundColor: ContentColors.background,
-                opacity: 0,
-                pointerEvents: PointerEvents.none,
-                raw: {'inset': '0'},
+                flex: Flex(grow: 1, shrink: 1, basis: 0.percent),
+                minWidth: Unit.zero,
+                padding: Padding.only(right: Unit.zero),
               ),
-              css('&:has(+ .sidebar-container.open)').styles(
-                opacity: 0.5,
-                pointerEvents: PointerEvents.auto,
-              ),
-            ]),
-            css('.sidebar-container', [
-              css('&').styles(
-                position: Position.fixed(bottom: Unit.zero, top: 4.rem),
-                zIndex: ZIndex(10),
-                width: 17.rem,
-                overflow: Overflow.only(y: Overflow.auto),
-                transform: Transform.translate(x: (-100).percent),
-                transition: Transition('transform', duration: 150, curve: Curve.easeInOut),
-              ),
-              css.media(MediaQuery.all(minWidth: 768.px), [
+              css.media(MediaQuery.all(minWidth: 1280.px), [
+                css('&').styles(padding: Padding.only(right: 3.rem)),
+              ]),
+              css('.content-header', [
                 css('&').styles(
-                  margin: Margin.only(left: (-1.25).rem),
+                  margin: Margin.only(bottom: 2.rem),
+                  color: ContentColors.headings,
+                ),
+                css('h1').styles(
+                  fontSize: 2.rem,
+                  lineHeight: 2.25.rem,
+                ),
+                css('p').styles(
+                  fontSize: 1.25.rem,
+                  lineHeight: 1.25.rem,
+                  margin: Margin.only(top: .75.rem),
+                ),
+                css('img').styles(
+                  margin: Margin.only(top: 1.rem),
+                  radius: BorderRadius.circular(0.375.rem),
                 ),
               ]),
-              css.media(MediaQuery.all(minWidth: 1024.px), [
+              css('.content-footer', [
                 css('&').styles(
-                  margin: Margin.only(left: Unit.zero),
-                  transform: Transform.translate(x: Unit.zero),
+                  margin: Margin.only(top: 2.rem),
                 ),
               ]),
-              css.media(MediaQuery.all(maxWidth: 1023.px), [
-                css('&').styles(
-                  backgroundColor: ContentColors.background,
-                  position: Position.fixed(top: Unit.zero),
-                  border: Border.only(right: BorderSide(width: 1.px, color: Color('#0000000d'))),
-                ),
-              ]),
-              css('&.open').styles(
-                transform: Transform.translate(x: Unit.zero),
-              ),
             ]),
-            css('main', [
+            css('aside.toc', [
               css('&').styles(
+                display: Display.none,
                 position: Position.relative(),
-                padding: Padding.only(top: 4.rem),
+                width: 17.rem,
               ),
-              css.media(MediaQuery.all(minWidth: 1024.px), [
-                css('&').styles(padding: Padding.only(left: 17.rem)),
+              css.media(MediaQuery.all(minWidth: 1280.px), [
+                css('&').styles(display: Display.block),
               ]),
               css('> div', [
                 css('&').styles(
-                  padding: Padding.only(top: 2.rem, left: 1.rem, right: 1.rem),
-                  display: Display.flex,
+                  position: Position.sticky(top: 6.rem),
                 ),
-                css.media(MediaQuery.all(minWidth: 1024.px), [
-                  css('&').styles(padding: Padding.only(left: 4.rem)),
-                ]),
-                css('.content-container', [
-                  css('&').styles(
-                    flex: Flex(grow: 1, shrink: 1, basis: 0.percent),
-                    minWidth: Unit.zero,
-                    padding: Padding.only(right: Unit.zero),
-                  ),
-                  css.media(MediaQuery.all(minWidth: 1280.px), [
-                    css('&').styles(padding: Padding.only(right: 3.rem)),
-                  ]),
-                  css('.content-header', [
-                    css('&').styles(
-                      margin: Margin.only(bottom: 2.rem),
-                      color: ContentColors.headings,
-                    ),
-                    css('h1').styles(
-                      fontSize: 2.rem,
-                      lineHeight: 2.25.rem,
-                    ),
-                    css('p').styles(
-                      fontSize: 1.25.rem,
-                      lineHeight: 1.25.rem,
-                      margin: Margin.only(top: .75.rem),
-                    ),
-                    css('img').styles(
-                      margin: Margin.only(top: 1.rem),
-                      radius: BorderRadius.circular(0.375.rem),
-                    )
-                  ]),
-                  css('.content-footer', [
-                    css('&').styles(
-                      margin: Margin.only(top: 2.rem),
-                    ),
-                  ]),
-                ]),
-                css('aside.toc', [
-                  css('&').styles(
-                    display: Display.none,
-                    position: Position.relative(),
-                    width: 17.rem,
-                  ),
-                  css.media(MediaQuery.all(minWidth: 1280.px), [
-                    css('&').styles(display: Display.block),
-                  ]),
-                  css('> div', [
-                    css('&').styles(
-                      position: Position.sticky(top: 6.rem),
-                    ),
-                  ]),
-                  css('h3').styles(
-                    opacity: 0.75,
-                    fontWeight: FontWeight.w600,
-                    fontSize: .875.rem,
-                    lineHeight: 1.25.rem,
-                    margin: Margin.only(bottom: .5.rem),
-                  ),
-                  css('ul').styles(
-                    margin: Margin.only(top: 1.rem),
-                  ),
-                  css('li').styles(
-                    margin: Margin.only(top: .5.rem),
-                    fontSize: 14.px,
-                  ),
-                ]),
-              ])
+              ]),
+              css('h3').styles(
+                opacity: 0.75,
+                fontWeight: FontWeight.w600,
+                fontSize: .875.rem,
+                lineHeight: 1.25.rem,
+                margin: Margin.only(bottom: .5.rem),
+              ),
+              css('ul').styles(
+                margin: Margin.only(top: 1.rem),
+              ),
+              css('li').styles(
+                margin: Margin.only(top: .5.rem),
+                fontSize: 14.px,
+              ),
             ]),
           ]),
         ]),
-      ];
+      ]),
+    ]),
+  ];
 }

--- a/packages/jaspr_content/lib/src/layouts/page_layout.dart
+++ b/packages/jaspr_content/lib/src/layouts/page_layout.dart
@@ -67,7 +67,10 @@ abstract class PageLayoutBase implements PageLayout {
       yield meta(name: 'description', content: desc.toString());
     }
     if (keywords case final keys?) {
-      yield meta(name: 'keywords', content: keys is List ? keys.join(', ') : keys.toString());
+      yield meta(
+        name: 'keywords',
+        content: keys is List ? keys.join(', ') : keys.toString(),
+      );
     }
     if (metaData case Map metaData?) {
       for (final key in metaData.keys) {
@@ -76,7 +79,10 @@ abstract class PageLayoutBase implements PageLayout {
     }
 
     if (description case final desc?) {
-      yield meta(attributes: {'property': 'og:description'}, content: desc.toString());
+      yield meta(
+        attributes: {'property': 'og:description'},
+        content: desc.toString(),
+      );
     }
     if (image case final img?) {
       yield meta(attributes: {'property': 'og:image'}, content: img.toString());

--- a/packages/jaspr_content/lib/src/page.dart
+++ b/packages/jaspr_content/lib/src/page.dart
@@ -54,7 +54,11 @@ class Page {
   final RouteLoader loader;
 
   /// Applies changes to the page content or data.
-  void apply({String? content, Map<String, dynamic>? data, bool mergeData = true}) {
+  void apply({
+    String? content,
+    Map<String, dynamic>? data,
+    bool mergeData = true,
+  }) {
     this.content = content ?? this.content;
     if (mergeData && data != null) {
       this.data = this.data.merge(data);
@@ -64,7 +68,14 @@ class Page {
   }
 
   Page copy() {
-    return Page(path: path, url: url, content: content, data: data, config: config, loader: loader);
+    return Page(
+      path: path,
+      url: url,
+      content: content,
+      data: data,
+      config: config,
+      loader: loader,
+    );
   }
 
   void markNeedsRebuild() {
@@ -99,32 +110,39 @@ class Page {
   Future<Component> render() async {
     parseFrontmatter();
     await loadData();
-    return AsyncBuilder(builder: (context) async* {
-      await renderTemplate(context.pages);
+    return AsyncBuilder(
+      builder: (context) async* {
+        await renderTemplate(context.pages);
 
-      if (kGenerateMode && data['page']['sitemap'] != null) {
-        context.setHeader('jaspr-sitemap-data', jsonEncode(data['page']['sitemap']));
-      }
+        if (kGenerateMode && data['page']['sitemap'] != null) {
+          context.setHeader(
+            'jaspr-sitemap-data',
+            jsonEncode(data['page']['sitemap']),
+          );
+        }
 
-      if (InheritedSecondaryOutput.of(context) case final secondaryOutput?) {
-        yield secondaryOutput.builder(this);
-        return;
-      }
+        if (InheritedSecondaryOutput.of(context) case final secondaryOutput?) {
+          yield secondaryOutput.builder(this);
+          return;
+        }
 
-      if (config.rawOutputPattern?.matchAsPrefix(path) != null) {
-        context.setHeader('Content-Type', getContentType());
-        context.setStatusCode(200, responseBody: content);
-        return;
-      }
+        if (config.rawOutputPattern?.matchAsPrefix(path) != null) {
+          context.setHeader('Content-Type', getContentType());
+          context.setStatusCode(200, responseBody: content);
+          return;
+        }
 
-      yield await build();
-    });
+        yield await build();
+      },
+    );
   }
 
   Future<Component> build() async {
     var nodes = parseNodes();
     nodes = await applyExtensions(nodes);
-    final component = Content(NodesBuilder(config.components).build(nodes) ?? const Text(''));
+    final component = Content(
+      NodesBuilder(config.components).build(nodes) ?? const Text(''),
+    );
     final layout = buildLayout(component);
     return wrapTheme(layout);
   }
@@ -250,7 +268,10 @@ extension PageHandlersExtension on Page {
   void parseFrontmatter() {
     if (config.enableFrontmatter) {
       final document = fm.parse(content);
-      apply(content: document.content, data: {'page': document.data.cast<String, dynamic>()});
+      apply(
+        content: document.content,
+        data: {'page': document.data.cast<String, dynamic>()},
+      );
     }
   }
 
@@ -313,9 +334,10 @@ extension PageHandlersExtension on Page {
   /// Returns [child] if no layout is provided.
   Component buildLayout(Component child) {
     final pageLayout = switch (data['page']?['layout']) {
-      final String layoutName => config.layouts
-          .where((l) => l.name.matchAsPrefix(layoutName) != null)
-          .firstOrNull,
+      final String layoutName =>
+        config.layouts
+            .where((l) => l.name.matchAsPrefix(layoutName) != null)
+            .firstOrNull,
       _ => config.layouts.firstOrNull,
     };
 
@@ -334,7 +356,8 @@ extension PageContext on BuildContext {
   /// Returns the current [Page] that this component is being built for.
   ///
   /// The page should not be modified, otherwise it could lead to unexpected behavior.
-  Page get page => dependOnInheritedComponentOfExactType<_InheritedPage>()!.page;
+  Page get page =>
+      dependOnInheritedComponentOfExactType<_InheritedPage>()!.page;
 
   /// Returns the list of all pages that are being built.
   ///
@@ -342,7 +365,8 @@ extension PageContext on BuildContext {
   /// Otherwise, it will only contain the pages that have been built so far.
   ///
   /// The list should not be modified, otherwise it could lead to unexpected behavior.
-  List<Page> get pages => dependOnInheritedComponentOfExactType<_InheritedPage>()!.pages;
+  List<Page> get pages =>
+      dependOnInheritedComponentOfExactType<_InheritedPage>()!.pages;
 }
 
 class _InheritedPage extends InheritedComponent {
@@ -363,8 +387,11 @@ extension DataMergeExtension on Map<String, dynamic> {
     var otherKeys = other.keys.toSet();
     for (var key in keys) {
       if (otherKeys.remove(key)) {
-        if (this[key] is Map<String, dynamic> && other[key] is Map<String, dynamic>) {
-          merged[key] = (this[key] as Map<String, dynamic>).merge(other[key] as Map<String, dynamic>);
+        if (this[key] is Map<String, dynamic> &&
+            other[key] is Map<String, dynamic>) {
+          merged[key] = (this[key] as Map<String, dynamic>).merge(
+            other[key] as Map<String, dynamic>,
+          );
         } else {
           merged[key] = other[key];
         }

--- a/packages/jaspr_content/lib/src/page_extension/heading_anchors_extension.dart
+++ b/packages/jaspr_content/lib/src/page_extension/heading_anchors_extension.dart
@@ -21,9 +21,13 @@ class HeadingAnchorsExtension implements PageExtension {
   @override
   Future<List<Node>> apply(Page page, List<Node> nodes) async {
     return [
-      ComponentNode(Document.head(children: [
-        Style(styles: _styles),
-      ])),
+      ComponentNode(
+        Document.head(
+          children: [
+            Style(styles: _styles),
+          ],
+        ),
+      ),
       for (final node in nodes) _processNode(node),
     ];
   }
@@ -46,44 +50,53 @@ class HeadingAnchorsExtension implements PageExtension {
 
     final children = node.children;
 
-    return ElementNode(node.tag, {
-      ...node.attributes,
-      'anchor': 'true'
-    }, [
-      ElementNode('span', {}, children),
-      ComponentNode(Builder(builder: (context) sync* {
-        var route = RouteState.of(context);
-        yield a(href: '${route.path}#$id', [text('#')]);
-      })),
-    ]);
+    return ElementNode(
+      node.tag,
+      {...node.attributes, 'anchor': 'true'},
+      [
+        ElementNode('span', {}, children),
+        ComponentNode(
+          Builder(
+            builder: (context) sync* {
+              var route = RouteState.of(context);
+              yield a(href: '${route.path}#$id', [text('#')]);
+            },
+          ),
+        ),
+      ],
+    );
   }
 
   Node _processChildren(Node node) {
     if (node is ElementNode) {
-      return ElementNode(node.tag, node.attributes, node.children?.map(_processNode).toList());
+      return ElementNode(
+        node.tag,
+        node.attributes,
+        node.children?.map(_processNode).toList(),
+      );
     }
     return node;
   }
 
   List<StyleRule> get _styles => [
-        css(':is(h1, h2, h3, h4, h5, h6)[anchor="true"]', [
-          css('&').styles(
-            display: Display.flex,
-            alignItems: AlignItems.baseline,
-            gap: Gap(column: 0.5.rem),
-          ),
-          css('> a').styles(
-            textDecoration: TextDecoration.none,
-            opacity: 0,
-            fontSize: 0.8.em,
-            transition: Transition('opacity', duration: 300),
-          ),
-          css('&:hover > a').styles(
-            opacity: 0.8,
-          ),
-          css('& > a:hover').styles(
-            opacity: 1,
-          ),
-        ]),
-      ];
+    css(':is(h1, h2, h3, h4, h5, h6)[anchor="true"]', [
+      css('&').styles(
+        display: Display.flex,
+        alignItems: AlignItems.baseline,
+        gap: Gap(column: 0.5.rem),
+      ),
+      css('> a').styles(
+        textDecoration: TextDecoration.none,
+        opacity: 0,
+        fontSize: 0.8.em,
+        transition: Transition('opacity', duration: 300),
+      ),
+      css('&:hover > a').styles(
+        opacity: 0.8,
+      ),
+      css('& > a:hover').styles(
+        opacity: 1,
+      ),
+    ]),
+  ];
 }

--- a/packages/jaspr_content/lib/src/page_extension/table_of_contents_extension.dart
+++ b/packages/jaspr_content/lib/src/page_extension/table_of_contents_extension.dart
@@ -74,12 +74,17 @@ class TableOfContents {
 
   Iterable<Component> _buildToc(List<TocEntry> toc, [int indent = 0]) sync* {
     for (final entry in toc) {
-      yield li(styles: Styles(padding: Padding.only(left: (0.75 * indent).em)), [
-        Builder(builder: (context) sync* {
-          var route = RouteState.of(context);
-          yield a(href: '${route.path}#${entry.id}', [text(entry.text)]);
-        }),
-      ]);
+      yield li(
+        styles: Styles(padding: Padding.only(left: (0.75 * indent).em)),
+        [
+          Builder(
+            builder: (context) sync* {
+              var route = RouteState.of(context);
+              yield a(href: '${route.path}#${entry.id}', [text(entry.text)]);
+            },
+          ),
+        ],
+      );
       if (entry.children.isNotEmpty) {
         yield* _buildToc(entry.children, indent + 1);
       }

--- a/packages/jaspr_content/lib/src/page_parser/html_parser.dart
+++ b/packages/jaspr_content/lib/src/page_parser/html_parser.dart
@@ -30,7 +30,9 @@ class HtmlParser implements PageParser {
         nodes.add(TextNode(node.text));
       } else if (node is html.Element) {
         final children = buildNodes(node.nodes);
-        nodes.add(ElementNode(node.localName ?? '', node.attributes.cast(), children));
+        nodes.add(
+          ElementNode(node.localName ?? '', node.attributes.cast(), children),
+        );
       }
     }
     return nodes;

--- a/packages/jaspr_content/lib/src/page_parser/markdown_parser.dart
+++ b/packages/jaspr_content/lib/src/page_parser/markdown_parser.dart
@@ -44,14 +44,21 @@ class MarkdownParser implements PageParser {
     final nodes = <Node>[];
     for (final node in markdownNodes) {
       if (node is md.Text) {
-        nodes.addAll(HtmlParser.buildNodes(html.parseFragment(node.text).nodes));
+        nodes.addAll(
+          HtmlParser.buildNodes(html.parseFragment(node.text).nodes),
+        );
       } else if (node is md.Element) {
         final children = _buildNodes(node.children ?? []);
-        nodes.add(ElementNode(
-          node.tag,
-          {if (node.generatedId != null) 'id': node.generatedId!, ...node.attributes},
-          children,
-        ));
+        nodes.add(
+          ElementNode(
+            node.tag,
+            {
+              if (node.generatedId != null) 'id': node.generatedId!,
+              ...node.attributes,
+            },
+            children,
+          ),
+        );
       }
     }
     return nodes;
@@ -62,9 +69,12 @@ class ComponentBlockSyntax extends md.BlockSyntax {
   const ComponentBlockSyntax();
 
   @override
-  RegExp get pattern => RegExp(r'^\s*<([A-Z][a-zA-Z]*)\s*([^>]*?)((/?)>(?:(.*)</([A-Z][a-zA-Z]*)>)?)?\s*$');
+  RegExp get pattern => RegExp(
+    r'^\s*<([A-Z][a-zA-Z]*)\s*([^>]*?)((/?)>(?:(.*)</([A-Z][a-zA-Z]*)>)?)?\s*$',
+  );
 
-  RegExp get closingPattern => RegExp(r'^([^>]*?)(/?)>(?:(.*)</([A-Z][a-zA-Z]*)>)?$');
+  RegExp get closingPattern =>
+      RegExp(r'^([^>]*?)(/?)>(?:(.*)</([A-Z][a-zA-Z]*)>)?$');
   RegExp get endPattern => RegExp(r'^\s*</([A-Z][a-zA-Z]*)>\s*$');
 
   @override
@@ -117,7 +127,9 @@ class ComponentBlockSyntax extends md.BlockSyntax {
   md.Node parse(md.BlockParser parser) {
     var match = pattern.firstMatch(parser.current.content);
 
-    if (match == null) throw AssertionError('Block syntax should match pattern.');
+    if (match == null) {
+      throw AssertionError('Block syntax should match pattern.');
+    }
 
     parser.advance();
 
@@ -157,7 +169,9 @@ class ComponentBlockSyntax extends md.BlockSyntax {
     var attributes = <MapEntry<String, String>>[];
 
     if (value.trim().isNotEmpty) {
-      final attributeRegex = RegExp(r'\s*([a-zA-Z][a-zA-Z0-9_-]*)(="((?:[^"]|\\")*)")?');
+      final attributeRegex = RegExp(
+        r'\s*([a-zA-Z][a-zA-Z0-9_-]*)(="((?:[^"]|\\")*)")?',
+      );
       final matches = attributeRegex.allMatches(value.trim());
 
       attributes = matches.map((m) {
@@ -181,7 +195,10 @@ class ComponentBlockSyntax extends md.BlockSyntax {
     final childLines = parseChildLines(parser, tag);
 
     // Recursively parse the contents of the component.
-    final children = md.BlockParser(childLines, parser.document).parseLines(parentSyntax: this);
+    final children = md.BlockParser(
+      childLines,
+      parser.document,
+    ).parseLines(parentSyntax: this);
 
     return md.Element(tag, children)..attributes.addEntries(attributes);
   }

--- a/packages/jaspr_content/lib/src/page_parser/page_parser.dart
+++ b/packages/jaspr_content/lib/src/page_parser/page_parser.dart
@@ -25,7 +25,9 @@ abstract class PageParser {
 extension PageBuilderExtension on Iterable<PageParser> {
   /// Parses the given [page] by selecting the matching parser and calling [PageParser.parsePage].
   List<Node> parsePage(Page page) {
-    final parser = where((parser) => parser.pattern.matchAsPrefix(page.path) != null).firstOrNull;
+    final parser = where(
+      (parser) => parser.pattern.matchAsPrefix(page.path) != null,
+    ).firstOrNull;
     if (parser == null) {
       throw Exception('No parser found for page: ${page.path}');
     }
@@ -85,7 +87,12 @@ abstract class CustomComponent {
 }
 
 /// A builder for creating components from a name, attributes, and child.
-typedef CustomComponentBuilder = Component Function(String name, Map<String, String> attributes, Component? child);
+typedef CustomComponentBuilder =
+    Component Function(
+      String name,
+      Map<String, String> attributes,
+      Component? child,
+    );
 
 /// Base class for creating components based on a name pattern.
 abstract mixin class CustomComponentBase implements CustomComponent {
@@ -95,12 +102,20 @@ abstract mixin class CustomComponentBase implements CustomComponent {
   Pattern get pattern;
 
   /// Builds a component with the given name, attributes, and child.
-  Component apply(String name, Map<String, String> attributes, Component? child);
+  Component apply(
+    String name,
+    Map<String, String> attributes,
+    Component? child,
+  );
 
   @override
   Component? create(Node node, NodesBuilder builder) {
     if (node is ElementNode && pattern.matchAsPrefix(node.tag) != null) {
-      return apply(node.tag, node.attributes, node.children != null ? builder.build(node.children!) : null);
+      return apply(
+        node.tag,
+        node.attributes,
+        node.children != null ? builder.build(node.children!) : null,
+      );
     }
     return null;
   }
@@ -117,7 +132,11 @@ class _CustomComponent extends CustomComponentBase {
   final CustomComponentBuilder _builder;
 
   @override
-  Component apply(String name, Map<String, String> attributes, Component? child) {
+  Component apply(
+    String name,
+    Map<String, String> attributes,
+    Component? child,
+  ) {
     return _builder(name, attributes, child);
   }
 }
@@ -157,11 +176,13 @@ class NodesBuilder {
           result.add(text(node.text));
         }
       } else if (node is ElementNode) {
-        result.add(DomComponent(
-          tag: node.tag,
-          attributes: node.attributes,
-          child: node.children != null ? build(node.children!) : null,
-        ));
+        result.add(
+          DomComponent(
+            tag: node.tag,
+            attributes: node.attributes,
+            child: node.children != null ? build(node.children!) : null,
+          ),
+        );
       } else if (node is ComponentNode) {
         result.add(node.component);
       }

--- a/packages/jaspr_content/lib/src/route_loader/filesystem_loader.dart
+++ b/packages/jaspr_content/lib/src/route_loader/filesystem_loader.dart
@@ -31,7 +31,10 @@ class FilesystemLoader extends RouteLoaderBase {
   StreamSubscription<WatchEvent>? _watcherSub;
 
   @override
-  Future<List<RouteBase>> loadRoutes(ConfigResolver resolver, bool eager) async {
+  Future<List<RouteBase>> loadRoutes(
+    ConfigResolver resolver,
+    bool eager,
+  ) async {
     if (kDebugMode) {
       _watcherSub ??= DirectoryWatcher(directory).events.listen((event) {
         var path = event.path;
@@ -77,16 +80,18 @@ class FilesystemLoader extends RouteLoaderBase {
     final root = Directory(directory);
 
     List<PageSource> loadFiles(Directory dir) {
-      List<PageSource> entities = [];
+      final entities = <PageSource>[];
       for (final entry in dir.listSync()) {
         final path = entry.path.substring(root.path.length + 1);
         if (entry is File) {
-          entities.add(FilePageSource(
-            path,
-            entry,
-            this,
-            keepSuffix: keeySuffixPattern?.matchAsPrefix(entry.path) != null,
-          ));
+          entities.add(
+            FilePageSource(
+              path,
+              entry,
+              this,
+              keepSuffix: keeySuffixPattern?.matchAsPrefix(entry.path) != null,
+            ),
+          );
         } else if (entry is Directory) {
           entities.addAll(loadFiles(entry));
         }
@@ -98,7 +103,9 @@ class FilesystemLoader extends RouteLoaderBase {
   }
 
   void invalidateFile(String path, {bool rebuild = true}) {
-    final source = sources.where((s) => (s as FilePageSource).file.path == path).firstOrNull;
+    final source = sources
+        .where((s) => (s as FilePageSource).file.path == path)
+        .firstOrNull;
     if (source != null) {
       invalidateSource(source, rebuild: rebuild);
     }

--- a/packages/jaspr_content/lib/src/route_loader/github_loader.dart
+++ b/packages/jaspr_content/lib/src/route_loader/github_loader.dart
@@ -41,7 +41,9 @@ class GithubLoader extends RouteLoaderBase {
 
   Future<List<dynamic>> _loadTree() async {
     var response = await http.get(
-      Uri.parse('https://api.github.com/repos/$repo/git/trees/$ref?recursive=true'),
+      Uri.parse(
+        'https://api.github.com/repos/$repo/git/trees/$ref?recursive=true',
+      ),
       headers: {
         'Accept': 'application/vnd.github+json',
         if (accessToken != null) 'Authorization': 'Bearer $accessToken',
@@ -49,7 +51,9 @@ class GithubLoader extends RouteLoaderBase {
       },
     );
     if (response.statusCode != 200) {
-      throw Exception('Failed to load tree: ${response.statusCode} - ${response.body}');
+      throw Exception(
+        'Failed to load tree: ${response.statusCode} - ${response.body}',
+      );
     }
     var files = jsonDecode(response.body)['tree'] as List;
     return files;
@@ -63,7 +67,7 @@ class GithubLoader extends RouteLoaderBase {
     }
     var files = await _loadTree();
 
-    List<PageSource> routes = [];
+    final routes = <PageSource>[];
 
     for (final file in files) {
       if (file['type'] != 'blob') continue;
@@ -74,13 +78,15 @@ class GithubLoader extends RouteLoaderBase {
       if (path.startsWith('/')) path = path.substring(1);
       if (path.isEmpty) continue;
 
-      routes.add(GithubPageSource(
-        path,
-        file['url'],
-        this,
-        accessToken: accessToken,
-        keepSuffix: keeySuffixPattern?.matchAsPrefix(path) != null,
-      ));
+      routes.add(
+        GithubPageSource(
+          path,
+          file['url'],
+          this,
+          accessToken: accessToken,
+          keepSuffix: keeySuffixPattern?.matchAsPrefix(path) != null,
+        ),
+      );
     }
 
     return routes;
@@ -88,18 +94,27 @@ class GithubLoader extends RouteLoaderBase {
 }
 
 class GithubPageSource extends PageSource {
-  GithubPageSource(super.path, this.blobUrl, super.loader, {this.accessToken, super.keepSuffix = false});
+  GithubPageSource(
+    super.path,
+    this.blobUrl,
+    super.loader, {
+    this.accessToken,
+    super.keepSuffix = false,
+  });
 
   final String blobUrl;
   final String? accessToken;
 
   @override
   Future<Page> buildPage() async {
-    final response = await http.get(Uri.parse(blobUrl), headers: {
-      'Accept': 'application/vnd.github.raw+json',
-      if (accessToken != null) 'Authorization': 'Bearer $accessToken',
-      'X-GitHub-Api-Version': '2022-11-28',
-    });
+    final response = await http.get(
+      Uri.parse(blobUrl),
+      headers: {
+        'Accept': 'application/vnd.github.raw+json',
+        if (accessToken != null) 'Authorization': 'Bearer $accessToken',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+    );
     final content = response.body;
 
     return Page(

--- a/packages/jaspr_content/lib/src/route_loader/memory_loader.dart
+++ b/packages/jaspr_content/lib/src/route_loader/memory_loader.dart
@@ -9,7 +9,8 @@ import 'route_loader.dart';
 ///
 /// Takes a list of [MemoryPage]s and creates routes from them.
 class MemoryLoader extends RouteLoaderBase {
-  MemoryLoader({required List<MemoryPage> pages, super.debugPrint}) : _pages = pages;
+  MemoryLoader({required List<MemoryPage> pages, super.debugPrint})
+    : _pages = pages;
 
   final List<MemoryPage> _pages;
 
@@ -17,7 +18,9 @@ class MemoryLoader extends RouteLoaderBase {
   Future<List<PageSource>> loadPageSources() async {
     final entities = <PageSource>[];
     for (final page in _pages) {
-      entities.add(MemoryPageSource(page, page.path, this, keepSuffix: page.keepSuffix));
+      entities.add(
+        MemoryPageSource(page, page.path, this, keepSuffix: page.keepSuffix),
+      );
     }
     return entities;
   }
@@ -38,8 +41,8 @@ class MemoryPage {
     this.keepSuffix = false,
     this.content,
     this.data = const {},
-  })  : builder = null,
-        applyLayout = true;
+  }) : builder = null,
+       applyLayout = true;
 
   /// Creates a new [MemoryPage] with the given [path] and builds it using the [builder].
   ///
@@ -76,7 +79,12 @@ class MemoryPage {
 }
 
 class MemoryPageSource extends PageSource {
-  MemoryPageSource(this._page, super.path, super.loader, {super.keepSuffix = false});
+  MemoryPageSource(
+    this._page,
+    super.path,
+    super.loader, {
+    super.keepSuffix = false,
+  });
 
   final MemoryPage _page;
 
@@ -134,19 +142,24 @@ class _BuilderPage extends Page {
   @override
   Future<Component> render() async {
     await loadData();
-    return Builder.single(builder: (context) {
-      if (kGenerateMode && data['page']['sitemap'] != null) {
-        context.setHeader('jaspr-sitemap-data', jsonEncode(data['page']['sitemap']));
-      }
+    return Builder.single(
+      builder: (context) {
+        if (kGenerateMode && data['page']['sitemap'] != null) {
+          context.setHeader(
+            'jaspr-sitemap-data',
+            jsonEncode(data['page']['sitemap']),
+          );
+        }
 
-      final child = builder(this);
+        final child = builder(this);
 
-      if (applyLayout) {
-        final layout = buildLayout(child);
-        return wrapTheme(layout);
-      }
+        if (applyLayout) {
+          final layout = buildLayout(child);
+          return wrapTheme(layout);
+        }
 
-      return child;
-    });
+        return child;
+      },
+    );
   }
 }

--- a/packages/jaspr_content/lib/src/route_loader/route_loader.dart
+++ b/packages/jaspr_content/lib/src/route_loader/route_loader.dart
@@ -66,12 +66,16 @@ abstract class RouteLoaderBase implements RouteLoader {
 
   @override
   Future<String> readPartial(String path, Page page) {
-    throw UnsupportedError('Reading partial files is not supported for $runtimeType');
+    throw UnsupportedError(
+      'Reading partial files is not supported for $runtimeType',
+    );
   }
 
   @override
   String readPartialSync(String path, Page page) {
-    throw UnsupportedError('Reading partial files is not supported for $runtimeType');
+    throw UnsupportedError(
+      'Reading partial files is not supported for $runtimeType',
+    );
   }
 
   PageSource? getSourceForPage(Page page) {
@@ -79,7 +83,10 @@ abstract class RouteLoaderBase implements RouteLoader {
   }
 
   @override
-  Future<List<RouteBase>> loadRoutes(ConfigResolver resolver, bool eager) async {
+  Future<List<RouteBase>> loadRoutes(
+    ConfigResolver resolver,
+    bool eager,
+  ) async {
     _reassembleSub ??= ServerApp.onReassemble.listen((_) {
       invalidateAll();
       onReassemble();
@@ -104,7 +111,7 @@ abstract class RouteLoaderBase implements RouteLoader {
   Future<List<RouteBase>> _buildRoutes() async {
     final sources = _sources ??= await loadPageSources();
 
-    List<RouteBase> routes = [];
+    final routes = <RouteBase>[];
     for (final source in sources) {
       if (source.path.isEmpty || source.private) {
         continue;
@@ -120,20 +127,24 @@ abstract class RouteLoaderBase implements RouteLoader {
         builder: (context) => Stream.fromFuture(source.load()),
       );
 
-      routes.add(Route(
-        path: source.url,
-        builder: (_, __) => pageBuilder,
-      ));
+      routes.add(
+        Route(
+          path: source.url,
+          builder: (_, _) => pageBuilder,
+        ),
+      );
 
       for (final output in config.secondaryOutputs) {
         if (output.pattern.matchAsPrefix(source.path) != null) {
-          routes.add(Route(
-            path: output.createRoute(source.url),
-            builder: (_, __) => InheritedSecondaryOutput(
-              builder: output.build,
-              child: pageBuilder,
+          routes.add(
+            Route(
+              path: output.createRoute(source.url),
+              builder: (_, _) => InheritedSecondaryOutput(
+                builder: output.build,
+                child: pageBuilder,
+              ),
             ),
-          ));
+          );
         }
       }
     }

--- a/packages/jaspr_content/lib/src/secondary_output/markdown_output.dart
+++ b/packages/jaspr_content/lib/src/secondary_output/markdown_output.dart
@@ -20,9 +20,11 @@ class MarkdownOutput extends SecondaryOutput {
 
   @override
   Component build(Page page) {
-    return Builder(builder: (context) sync* {
-      context.setHeader('Content-Type', 'text/markdown');
-      context.setStatusCode(200, responseBody: page.content);
-    });
+    return Builder(
+      builder: (context) sync* {
+        context.setHeader('Content-Type', 'text/markdown');
+        context.setStatusCode(200, responseBody: page.content);
+      },
+    );
   }
 }

--- a/packages/jaspr_content/lib/src/secondary_output/rss_output.dart
+++ b/packages/jaspr_content/lib/src/secondary_output/rss_output.dart
@@ -8,7 +8,8 @@ abstract class RSSFilter {
   static const optOut = _OptOutRSSFilter();
   static const optIn = _OptInRSSFilter();
 
-  const factory RSSFilter.custom(bool Function(Page page) include) = _CustomRSSFilter;
+  const factory RSSFilter.custom(bool Function(Page page) include) =
+      _CustomRSSFilter;
 
   bool include(Page page);
 }
@@ -64,10 +65,15 @@ class RSSOutput extends SecondaryOutput {
 
   @override
   Component build(Page page) {
-    return Builder(builder: (context) sync* {
-      context.setHeader('Content-Type', 'text/xml');
-      context.setStatusCode(200, responseBody: renderRssFeed(page, context.pages));
-    });
+    return Builder(
+      builder: (context) sync* {
+        context.setHeader('Content-Type', 'text/xml');
+        context.setStatusCode(
+          200,
+          responseBody: renderRssFeed(page, context.pages),
+        );
+      },
+    );
   }
 
   /// The standard date format for dates within an RSS feed.
@@ -86,10 +92,13 @@ class RSSOutput extends SecondaryOutput {
   String renderRssFeed(Page page, List<Page> pages) {
     final title = this.title ?? page.data['site']?['title'] ?? '/';
     final siteUrl = this.siteUrl ?? page.data['site']?['url'] ?? '';
-    final description = this.description ?? page.data['site']?['description'] ?? '/';
+    final description =
+        this.description ?? page.data['site']?['description'] ?? '/';
     final language = this.language ?? page.data['site']?['language'] ?? 'en-US';
 
-    final pubDate = page.data['site']?['publishDate'] ?? rssDateFormat.format(DateTime.now());
+    final pubDate =
+        page.data['site']?['publishDate'] ??
+        rssDateFormat.format(DateTime.now());
     final lastBuildDate = rssDateFormat.format(DateTime.now());
 
     final items = <String>[];
@@ -101,7 +110,8 @@ class RSSOutput extends SecondaryOutput {
 
       final item = itemBuilder(page);
 
-      var itemSource = '''
+      var itemSource =
+          '''
     <item>
       <title>${item.title}</title>
       <link>$siteUrl${page.url}</link>''';
@@ -126,7 +136,8 @@ class RSSOutput extends SecondaryOutput {
       items.add(itemSource);
     }
 
-    final feed = '''
+    final feed =
+        '''
 <rss version="2.0">
   <channel>
     <title>$title</title>

--- a/packages/jaspr_content/lib/src/secondary_output/secondary_output.dart
+++ b/packages/jaspr_content/lib/src/secondary_output/secondary_output.dart
@@ -25,7 +25,8 @@ class InheritedSecondaryOutput extends InheritedComponent {
   final Component Function(Page) builder;
 
   static InheritedSecondaryOutput? of(BuildContext context) {
-    return context.dependOnInheritedComponentOfExactType<InheritedSecondaryOutput>();
+    return context
+        .dependOnInheritedComponentOfExactType<InheritedSecondaryOutput>();
   }
 
   @override

--- a/packages/jaspr_content/lib/src/template_engine/mustache_template_engine.dart
+++ b/packages/jaspr_content/lib/src/template_engine/mustache_template_engine.dart
@@ -3,7 +3,8 @@ import '../page.dart';
 import 'template_engine.dart';
 
 dynamic _defaultPrepareValues(Page page, List<Page> pages) {
-  return {...page.data}..putIfAbsent('pages', () => pages.map((p) => p.data['page']).toList());
+  return {...page.data}
+    ..putIfAbsent('pages', () => pages.map((p) => p.data['page']).toList());
 }
 
 /// A template engine that uses the Mustache templating language.

--- a/packages/jaspr_content/lib/src/theme/_reset.dart
+++ b/packages/jaspr_content/lib/src/theme/_reset.dart
@@ -27,7 +27,11 @@ final _defaultCodeFont = FontFamily.list([
 final List<StyleRule> _resetStyles = [
   css('*, :after, :before').styles(
     boxSizing: BoxSizing.borderBox,
-    border: Border(width: Unit.zero, style: BorderStyle.solid, color: Color('#e5e7eb')),
+    border: Border(
+      width: Unit.zero,
+      style: BorderStyle.solid,
+      color: Color('#e5e7eb'),
+    ),
   ),
   css(':host,html').styles(
     lineHeight: 1.5.em,
@@ -107,7 +111,9 @@ final List<StyleRule> _resetStyles = [
   css('button, select').styles(
     textTransform: TextTransform.none,
   ),
-  css('button, input[type=button], input[type=reset], input[type=submit]').styles(
+  css(
+    'button, input[type=button], input[type=reset], input[type=submit]',
+  ).styles(
     raw: {
       '-webkit-appearance': 'button',
       'background-color': 'transparent',

--- a/packages/jaspr_content/lib/src/theme/colors.dart
+++ b/packages/jaspr_content/lib/src/theme/colors.dart
@@ -29,29 +29,106 @@ class ContentColors {
     tdBorders,
   ];
 
-  static final ColorToken primary = ColorToken('primary', ThemeColors.gray.$900, dark: Colors.white);
-  static final ColorToken background = ColorToken('background', ThemeColors.gray.$100, dark: ThemeColors.gray.$950);
-  static final ColorToken text = ColorToken('text', ThemeColors.gray.$700, dark: ThemeColors.gray.$200);
-  static final ColorToken headings = ColorToken('content-headings', ThemeColors.gray.$900, dark: Colors.white);
-  static final ColorToken lead = ColorToken('content-lead', ThemeColors.gray.$600, dark: ThemeColors.gray.$400);
-  static final ColorToken links = ColorToken('content-links', ThemeColors.gray.$900, dark: Colors.white);
-  static final ColorToken bold = ColorToken('content-bold', ThemeColors.gray.$900, dark: Colors.white);
-  static final ColorToken counters = ColorToken('content-counters', ThemeColors.gray.$500, dark: ThemeColors.gray.$400);
-  static final ColorToken bullets = ColorToken('content-bullets', ThemeColors.gray.$300, dark: ThemeColors.gray.$600);
-  static final ColorToken hr = ColorToken('content-hr', ThemeColors.gray.$200, dark: ThemeColors.gray.$700);
-  static final ColorToken quotes = ColorToken('content-quotes', ThemeColors.gray.$900, dark: ThemeColors.gray.$100);
-  static final ColorToken quoteBorders =
-      ColorToken('content-quote-borders', ThemeColors.gray.$200, dark: ThemeColors.gray.$700);
-  static final ColorToken captions = ColorToken('content-captions', ThemeColors.gray.$500, dark: ThemeColors.gray.$400);
-  static final ColorToken kbd = ColorToken('content-kbd', ThemeColors.gray.$900, dark: Colors.white);
-  static final ColorToken kbdShadows = ColorToken('content-kbd-shadows', ThemeColors.gray.$900, dark: Colors.white);
-  static final ColorToken code = ColorToken('content-code', ThemeColors.gray.$900, dark: Colors.white);
-  static final ColorToken preCode = ColorToken('content-pre-code', ThemeColors.gray.$200, dark: ThemeColors.gray.$300);
-  static final ColorToken preBg = ColorToken('content-pre-bg', ThemeColors.gray.$800, dark: Color('rgb(0 0 0 / 50%)'));
-  static final ColorToken thBorders =
-      ColorToken('content-th-borders', ThemeColors.gray.$300, dark: ThemeColors.gray.$600);
-  static final ColorToken tdBorders =
-      ColorToken('content-td-borders', ThemeColors.gray.$200, dark: ThemeColors.gray.$700);
+  static final ColorToken primary = ColorToken(
+    'primary',
+    ThemeColors.gray.$900,
+    dark: Colors.white,
+  );
+  static final ColorToken background = ColorToken(
+    'background',
+    ThemeColors.gray.$100,
+    dark: ThemeColors.gray.$950,
+  );
+  static final ColorToken text = ColorToken(
+    'text',
+    ThemeColors.gray.$700,
+    dark: ThemeColors.gray.$200,
+  );
+  static final ColorToken headings = ColorToken(
+    'content-headings',
+    ThemeColors.gray.$900,
+    dark: Colors.white,
+  );
+  static final ColorToken lead = ColorToken(
+    'content-lead',
+    ThemeColors.gray.$600,
+    dark: ThemeColors.gray.$400,
+  );
+  static final ColorToken links = ColorToken(
+    'content-links',
+    ThemeColors.gray.$900,
+    dark: Colors.white,
+  );
+  static final ColorToken bold = ColorToken(
+    'content-bold',
+    ThemeColors.gray.$900,
+    dark: Colors.white,
+  );
+  static final ColorToken counters = ColorToken(
+    'content-counters',
+    ThemeColors.gray.$500,
+    dark: ThemeColors.gray.$400,
+  );
+  static final ColorToken bullets = ColorToken(
+    'content-bullets',
+    ThemeColors.gray.$300,
+    dark: ThemeColors.gray.$600,
+  );
+  static final ColorToken hr = ColorToken(
+    'content-hr',
+    ThemeColors.gray.$200,
+    dark: ThemeColors.gray.$700,
+  );
+  static final ColorToken quotes = ColorToken(
+    'content-quotes',
+    ThemeColors.gray.$900,
+    dark: ThemeColors.gray.$100,
+  );
+  static final ColorToken quoteBorders = ColorToken(
+    'content-quote-borders',
+    ThemeColors.gray.$200,
+    dark: ThemeColors.gray.$700,
+  );
+  static final ColorToken captions = ColorToken(
+    'content-captions',
+    ThemeColors.gray.$500,
+    dark: ThemeColors.gray.$400,
+  );
+  static final ColorToken kbd = ColorToken(
+    'content-kbd',
+    ThemeColors.gray.$900,
+    dark: Colors.white,
+  );
+  static final ColorToken kbdShadows = ColorToken(
+    'content-kbd-shadows',
+    ThemeColors.gray.$900,
+    dark: Colors.white,
+  );
+  static final ColorToken code = ColorToken(
+    'content-code',
+    ThemeColors.gray.$900,
+    dark: Colors.white,
+  );
+  static final ColorToken preCode = ColorToken(
+    'content-pre-code',
+    ThemeColors.gray.$200,
+    dark: ThemeColors.gray.$300,
+  );
+  static final ColorToken preBg = ColorToken(
+    'content-pre-bg',
+    ThemeColors.gray.$800,
+    dark: Color('rgb(0 0 0 / 50%)'),
+  );
+  static final ColorToken thBorders = ColorToken(
+    'content-th-borders',
+    ThemeColors.gray.$300,
+    dark: ThemeColors.gray.$600,
+  );
+  static final ColorToken tdBorders = ColorToken(
+    'content-td-borders',
+    ThemeColors.gray.$200,
+    dark: ThemeColors.gray.$700,
+  );
 }
 
 /// A color that holds a variant for light and dark themes.
@@ -65,7 +142,7 @@ class ThemeColor implements Color {
   String get value => light.value;
 
   @override
-  operator ==(Object other) {
+  bool operator ==(Object other) {
     return other is ThemeColor && other.light == light && other.dark == dark;
   }
 
@@ -90,12 +167,19 @@ class ColorToken extends ThemeColor {
   /// If [color] is a [ThemeColor], it will apply both the light and dark colors.
   /// Else only the light color will be applied.
   ColorToken apply(Color color) {
-    return ColorToken(name, color, dark: color is ThemeColor ? color.dark : null);
+    return ColorToken(
+      name,
+      color,
+      dark: color is ThemeColor ? color.dark : null,
+    );
   }
 
   @override
-  operator ==(Object other) {
-    return other is ColorToken && other.name == name && other.light == light && other.dark == dark;
+  bool operator ==(Object other) {
+    return other is ColorToken &&
+        other.name == name &&
+        other.light == light &&
+        other.dark == dark;
   }
 
   @override
@@ -111,7 +195,10 @@ extension on List<ColorToken> {
     bool mergeColors = true,
   }) {
     if (mergeColors && colors != null) {
-      final map = {for (final color in this) color.name: color, for (final color in colors) color.name: color};
+      final map = {
+        for (final color in this) color.name: color,
+        for (final color in colors) color.name: color,
+      };
       return map.values.toList();
     } else {
       return colors ?? this;
@@ -123,7 +210,9 @@ extension on List<ColorToken> {
       for (final color in this) '--${color.name}': color,
     };
 
-    final light = {for (final entry in colors.entries) entry.key: entry.value.light.value};
+    final light = {
+      for (final entry in colors.entries) entry.key: entry.value.light.value,
+    };
 
     final dark = {
       for (final entry in colors.entries)

--- a/packages/jaspr_content/lib/src/theme/theme.dart
+++ b/packages/jaspr_content/lib/src/theme/theme.dart
@@ -21,24 +21,26 @@ class ContentTheme {
     FontFamily? font,
     FontFamily? codeFont,
     ContentTypography? typography,
-  })  : colors = ContentColors._base.apply(colors: [
-          ...colors,
-          if (primary != null) ContentColors.primary.apply(primary),
-          if (background != null) ContentColors.background.apply(background),
-          if (text != null) ContentColors.text.apply(text),
-        ]),
-        font = font ?? defaultFont,
-        codeFont = codeFont ?? defaultCodeFont,
-        typography = typography ?? ContentTypography.base,
-        reset = true;
+  }) : colors = ContentColors._base.apply(
+         colors: [
+           ...colors,
+           if (primary != null) ContentColors.primary.apply(primary),
+           if (background != null) ContentColors.background.apply(background),
+           if (text != null) ContentColors.text.apply(text),
+         ],
+       ),
+       font = font ?? defaultFont,
+       codeFont = codeFont ?? defaultCodeFont,
+       typography = typography ?? ContentTypography.base,
+       reset = true;
 
   /// Disables any theming and styles for the page.
   const ContentTheme.none()
-      : colors = const [],
-        font = null,
-        codeFont = null,
-        typography = const ContentTypography(styles: Styles(), rules: []),
-        reset = false;
+    : colors = const [],
+      font = null,
+      codeFont = null,
+      typography = const ContentTypography(styles: Styles(), rules: []),
+      reset = false;
 
   /// A set of color tokens for the site.
   final List<ColorToken> colors;
@@ -69,7 +71,9 @@ class ContentTheme {
     bool mergeColors = true,
   }) {
     return copyWith(
-      colors: mergeColors && colors != null ? this.colors.apply(colors: colors) : colors ?? this.colors,
+      colors: mergeColors && colors != null
+          ? this.colors.apply(colors: colors)
+          : colors ?? this.colors,
       font: font ?? this.font,
       codeFont: codeFont ?? this.codeFont,
       typography: typography,
@@ -94,8 +98,12 @@ class ContentTheme {
     final colors = this.colors;
     final typography = this.typography;
 
-    final hasTextToken = colors.any((color) => color.name == ContentColors.text.name);
-    final hasBackgroundToken = colors.any((color) => color.name == ContentColors.background.name);
+    final hasTextToken = colors.any(
+      (color) => color.name == ContentColors.text.name,
+    );
+    final hasBackgroundToken = colors.any(
+      (color) => color.name == ContentColors.background.name,
+    );
 
     return [
       ...colors.build(),

--- a/packages/jaspr_content/lib/src/theme/typography.dart
+++ b/packages/jaspr_content/lib/src/theme/typography.dart
@@ -19,8 +19,12 @@ class ContentTypography {
     bool mergeRules = true,
   }) {
     return ContentTypography(
-      styles: mergeStyles && styles != null ? this.styles.combine(styles) : styles ?? this.styles,
-      rules: mergeRules && rules != null ? [...this.rules, ...rules] : rules ?? this.rules,
+      styles: mergeStyles && styles != null
+          ? this.styles.combine(styles)
+          : styles ?? this.styles,
+      rules: mergeRules && rules != null
+          ? [...this.rules, ...rules]
+          : rules ?? this.rules,
     );
   }
 }
@@ -41,8 +45,9 @@ List<StyleRule> _scopeContent(List<StyleRule> rules) {
   return rules.expand((rule) => rule.resolve('')).map((rule) {
     if (rule is BlockStyleRule) {
       return BlockStyleRule(
-        selector:
-            Selector(':where(${rule.selector.selector}):not(:where([class~=not-content],[class~=not-content] *))'),
+        selector: Selector(
+          ':where(${rule.selector.selector}):not(:where([class~=not-content],[class~=not-content] *))',
+        ),
         styles: rule.styles,
       );
     }

--- a/packages/jaspr_content/pubspec.yaml
+++ b/packages/jaspr_content/pubspec.yaml
@@ -1,6 +1,6 @@
 name: jaspr_content
 description: Jaspr plugin for content driven sites.
-version: 0.1.1
+version: 0.2.0-wip
 homepage: https://jaspr.site
 issue_tracker: https://github.com/schultek/jaspr/issues
 documentation: https://docs.jaspr.site
@@ -14,7 +14,7 @@ topics:
   - markdown
 
 environment:
-  sdk: '>=3.5.0 <4.0.0'
+  sdk: ^3.8.0
 
 dependencies:
   fbh_front_matter: ^0.0.1
@@ -32,7 +32,7 @@ dependencies:
   yaml: ^3.1.3
 
 dev_dependencies:
-  lints: ^5.0.0
+  lints: ^6.0.0
   test: ^1.24.0
 
 dependency_overrides:


### PR DESCRIPTION
To make contributing a bit easier and more consistent, update constraint to Dart 3.8 with the recent format fixes, set `trailing_commas: preserve`, run the formatter, and update the lints package.
