### PR TITLE
[content] Minor cleanup and privatization to components

### DIFF
--- a/packages/jaspr_content/lib/components/_internal/code_block_copy_button.dart
+++ b/packages/jaspr_content/lib/components/_internal/code_block_copy_button.dart
@@ -16,7 +16,7 @@ class CodeBlockCopyButton extends StatefulComponent {
 }
 
 class _CodeBlockCopyButtonState extends State<CodeBlockCopyButton> {
-  bool copied = false;
+  bool _copied = false;
 
   @override
   Iterable<Component> build(BuildContext context) sync* {
@@ -29,16 +29,16 @@ class _CodeBlockCopyButtonState extends State<CodeBlockCopyButton> {
         }
         web.window.navigator.clipboard.writeText(content);
         setState(() {
-          copied = true;
+          _copied = true;
         });
         Timer(const Duration(seconds: 2), () {
           setState(() {
-            copied = false;
+            _copied = false;
           });
         });
       }
     }, [
-      copied ? CheckIcon(size: 18) : CopyIcon(size: 18),
+      _copied ? CheckIcon(size: 18) : CopyIcon(size: 18),
     ]);
   }
 }

--- a/packages/jaspr_content/lib/components/_internal/tab_bar.dart
+++ b/packages/jaspr_content/lib/components/_internal/tab_bar.dart
@@ -41,12 +41,12 @@ class TabBar extends StatefulComponent {
 }
 
 class _TabBarState extends State<TabBar> {
-  late String value;
+  String? _value;
 
   @override
   void initState() {
     super.initState();
-    value = component.initialValue;
+    _value = component.initialValue;
   }
 
   @override
@@ -54,20 +54,20 @@ class _TabBarState extends State<TabBar> {
     yield div(classes: 'tab-bar', [
       for (var item in component.items.entries)
         button(attributes: {
-          if (item.key == value) 'active': ''
+          if (item.key == _value) 'active': ''
         }, events: {
           'click': (e) {
             setState(() {
-              value = item.key;
+              _value = item.key;
             });
 
             final target = e.currentTarget as web.Element;
 
             final currentTabView = target.parentElement?.nextElementSibling?.querySelector('div[active]');
-            final nexttabView = target.parentElement?.nextElementSibling?.querySelector('div[data-tab="${item.key}"]');
+            final nextTabView = target.parentElement?.nextElementSibling?.querySelector('div[data-tab="${item.key}"]');
 
             currentTabView?.removeAttribute('active');
-            nexttabView?.setAttribute('active', '');
+            nextTabView?.setAttribute('active', '');
           }
         }, [
           text(item.value)

--- a/packages/jaspr_content/lib/components/code_block.dart
+++ b/packages/jaspr_content/lib/components/code_block.dart
@@ -45,8 +45,9 @@ class CodeBlock implements CustomComponent {
         case ElementNode(tag: 'Code' || 'CodeBlock', :final children, :final attributes) ||
             ElementNode(tag: 'pre', children: [ElementNode(tag: 'code', :final children, :final attributes)])) {
       var language = attributes['language'];
-      if (language == null && (attributes['class']?.startsWith('language-') ?? false)) {
-        language = attributes['class']!.substring('language-'.length);
+      var existingClasses = attributes['class'];
+      if (language == null && (existingClasses != null && existingClasses.startsWith('language-'))) {
+        language = existingClasses.substring('language-'.length);
       }
 
       if (!_initialized) {
@@ -90,7 +91,7 @@ class CodeBlock implements CustomComponent {
 }
 
 /// A code block component with syntax highlighting.
-class _CodeBlock extends StatelessComponent {
+final class _CodeBlock extends StatelessComponent {
   const _CodeBlock({
     required this.source,
     this.highlighter,
@@ -105,15 +106,15 @@ class _CodeBlock extends StatelessComponent {
 
   @override
   Iterable<Component> build(BuildContext context) sync* {
-    final codeblock = pre([
+    final codeBlock = pre([
       code([
-        if (highlighter != null) buildSpan(highlighter!.highlight(source)) else text(source),
+        if (highlighter case final highlighter?) buildSpan(highlighter.highlight(source)) else text(source),
       ])
     ]);
 
     yield div(classes: 'code-block', [
-      CodeBlockCopyButton(),
-      codeblock,
+      const CodeBlockCopyButton(),
+      codeBlock,
     ]);
   }
 
@@ -134,7 +135,7 @@ class _CodeBlock extends StatelessComponent {
     }
 
     return span(styles: styles, [
-      if (textSpan.text != null) text(textSpan.text!),
+      if (textSpan.text case final textSpanText?) text(textSpanText),
       for (final t in textSpan.children) buildSpan(t),
     ]);
   }

--- a/packages/jaspr_content/lib/components/github_button.dart
+++ b/packages/jaspr_content/lib/components/github_button.dart
@@ -14,63 +14,7 @@ class GithubButton extends StatefulComponent {
   final String repo;
 
   @override
-  State createState() => GithubButtonState();
-}
-
-class GithubButtonState extends State<GithubButton> with PreloadStateMixin<GithubButton> {
-  int? stars;
-  int? forks;
-
-  bool get loaded => stars != null;
-
-  @override
-  Future<void> preloadState() async {
-    if (!kGenerateMode && kReleaseMode) {
-      await loadRepositoryData();
-    }
-  }
-
-  @override
-  void initState() {
-    super.initState();
-
-    if (kIsWeb) {
-      loadRepositoryData().then((_) {
-        setState(() {});
-      });
-    }
-  }
-
-  Future<void> loadRepositoryData() async {
-    final response = await http.get(Uri.parse('https://api.github.com/repos/${component.repo}'));
-    if (response.statusCode != 200) {
-      return;
-    }
-    final data = jsonDecode(response.body) as Map<String, dynamic>;
-    final {"stargazers_count": int stars, "forks_count": int forks} = data;
-
-    this.stars = stars;
-    this.forks = forks;
-  }
-
-  @override
-  Iterable<Component> build(BuildContext context) sync* {
-    yield a(href: 'https://github.com/${component.repo}', target: Target.blank, classes: 'github-button not-content', [
-      div(classes: 'github-icon', [
-        GithubIcon(),
-      ]),
-      div(classes: 'github-info', [
-        span([text('schultek/jaspr')]),
-        span([
-          text('★'),
-          span(styles: !loaded ? Styles(opacity: 0) : null, [text('${stars ?? 9999}')]),
-          span([]),
-          text('⑂'),
-          span(styles: !loaded ? Styles(opacity: 0) : null, [text('${forks ?? 99}')])
-        ])
-      ])
-    ]);
-  }
+  State<GithubButton> createState() => _GithubButtonState();
 
   @css
   static List<StyleRule> get styles => [
@@ -123,7 +67,65 @@ class GithubButtonState extends State<GithubButton> with PreloadStateMixin<Githu
       ];
 }
 
+class _GithubButtonState extends State<GithubButton> with PreloadStateMixin<GithubButton> {
+  int? _stars;
+  int? _forks;
+
+  bool get _loaded => _stars != null;
+
+  @override
+  Future<void> preloadState() async {
+    if (!kGenerateMode && kReleaseMode) {
+      await _loadRepositoryData();
+    }
+  }
+
+  @override
+  void initState() {
+    super.initState();
+
+    if (kIsWeb) {
+      _loadRepositoryData().then((_) {
+        setState(() {});
+      });
+    }
+  }
+
+  Future<void> _loadRepositoryData() async {
+    final response = await http.get(Uri.parse('https://api.github.com/repos/${component.repo}'));
+    if (response.statusCode != 200) {
+      return;
+    }
+    final data = jsonDecode(response.body) as Map<String, dynamic>;
+    final {"stargazers_count": int stars, "forks_count": int forks} = data;
+
+    _stars = stars;
+    _forks = forks;
+  }
+
+  @override
+  Iterable<Component> build(BuildContext context) sync* {
+    yield a(href: 'https://github.com/${component.repo}', target: Target.blank, classes: 'github-button not-content', [
+      div(classes: 'github-icon', [
+        const GithubIcon(),
+      ]),
+      div(classes: 'github-info', [
+        span([text(component.repo)]),
+        span([
+          text('★'),
+          span(styles: !_loaded ? Styles(opacity: 0) : null, [text('${_stars ?? 9999}')]),
+          span([]),
+          text('⑂'),
+          span(styles: !_loaded ? Styles(opacity: 0) : null, [text('${_forks ?? 99}')])
+        ])
+      ])
+    ]);
+  }
+}
+
 class GithubIcon extends StatelessComponent {
+  const GithubIcon();
+
   @override
   Iterable<Component> build(BuildContext context) sync* {
     yield svg(viewBox: '0 0 24 24', attributes: {

--- a/packages/jaspr_content/lib/components/image.dart
+++ b/packages/jaspr_content/lib/components/image.dart
@@ -79,7 +79,7 @@ class _Image extends StatelessComponent {
   Iterable<Component> build(BuildContext context) sync* {
     yield DomComponent(tag: 'figure', classes: 'image', children: [
       img(src: src, alt: alt ?? caption),
-      if (caption != null) DomComponent(tag: 'figcaption', children: [text(caption!)]),
+      if (caption case final caption?) DomComponent(tag: 'figcaption', children: [text(caption)]),
     ]);
   }
 }

--- a/packages/jaspr_content/lib/components/sidebar_toggle_button.dart
+++ b/packages/jaspr_content/lib/components/sidebar_toggle_button.dart
@@ -6,13 +6,13 @@ import 'package:universal_web/web.dart' hide Document;
 /// A sidebar toggle button.
 @client
 class SidebarToggleButton extends StatelessComponent {
-  SidebarToggleButton({super.key});
+  const SidebarToggleButton({super.key});
 
   @override
   Iterable<Component> build(BuildContext context) sync* {
     if (!kIsWeb) {
       yield Document.head(children: [
-        Style(styles: styles),
+        Style(styles: _styles),
       ]);
     }
 
@@ -32,11 +32,11 @@ class SidebarToggleButton extends StatelessComponent {
       });
       window.document.querySelector('.sidebar-container')?.classList.add('open');
     }, [
-      raw(menuIcon),
+      raw(_menuIcon),
     ]);
   }
 
-  List<StyleRule> get styles => [
+  List<StyleRule> get _styles => [
         css('.sidebar-toggle-button').styles(
           display: Display.none,
           justifyContent: JustifyContent.center,
@@ -50,6 +50,6 @@ class SidebarToggleButton extends StatelessComponent {
       ];
 }
 
-const menuIcon = '''
+const _menuIcon = '''
 <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="4" x2="20" y1="12" y2="12"></line><line x1="4" x2="20" y1="6" y2="6"></line><line x1="4" x2="20" y1="18" y2="18"></line></svg>
 ''';

--- a/packages/jaspr_content/lib/components/theme_toggle.dart
+++ b/packages/jaspr_content/lib/components/theme_toggle.dart
@@ -9,18 +9,36 @@ class ThemeToggle extends StatefulComponent {
   const ThemeToggle({super.key});
 
   @override
-  State createState() => ThemeToggleState();
+  State<ThemeToggle> createState() => _ThemeToggleState();
+
+  @css
+  static final List<StyleRule> styles = [
+    css('.theme-toggle', [
+      css('&').styles(
+        display: Display.flex,
+        padding: Padding.all(.7.rem),
+        border: Border.unset,
+        radius: BorderRadius.circular(8.px),
+        outline: Outline.unset,
+        alignItems: AlignItems.center,
+        backgroundColor: Colors.transparent,
+      ),
+      css('&:hover').styles(
+        backgroundColor: Color('color-mix(in srgb, currentColor 5%, transparent)'),
+      ),
+    ]),
+  ];
 }
 
-class ThemeToggleState extends State<ThemeToggle> {
-  bool isDark = false;
+class _ThemeToggleState extends State<ThemeToggle> {
+  bool _isDark = false;
 
   @override
   void initState() {
     super.initState();
 
     if (!kIsWeb) return;
-    isDark = web.document.documentElement!.getAttribute('data-theme') == 'dark';
+    _isDark = web.document.documentElement!.getAttribute('data-theme') == 'dark';
   }
 
   @override
@@ -44,7 +62,7 @@ class ThemeToggleState extends State<ThemeToggle> {
     }
 
     if (kIsWeb) {
-      yield Document.html(attributes: {'data-theme': isDark ? 'dark' : 'light'});
+      yield Document.html(attributes: {'data-theme': _isDark ? 'dark' : 'light'});
     }
 
     yield button(
@@ -52,33 +70,15 @@ class ThemeToggleState extends State<ThemeToggle> {
       attributes: {'aria-label': 'Theme Toggle'},
       onClick: () {
         setState(() {
-          isDark = !isDark;
+          _isDark = !_isDark;
         });
-        web.window.localStorage.setItem('jaspr:theme', isDark ? 'dark' : 'light');
+        web.window.localStorage.setItem('jaspr:theme', _isDark ? 'dark' : 'light');
       },
       styles: !kIsWeb ? Styles(visibility: Visibility.hidden) : null,
       [
-        span(styles: Styles(display: isDark ? Display.none : null), [MoonIcon(size: 20)]),
-        span(styles: Styles(display: isDark ? null : Display.none), [SunIcon(size: 20)]),
+        span(styles: Styles(display: _isDark ? Display.none : null), [MoonIcon(size: 20)]),
+        span(styles: Styles(display: _isDark ? null : Display.none), [SunIcon(size: 20)]),
       ],
     );
   }
-
-  @css
-  static final List<StyleRule> styles = [
-    css('.theme-toggle', [
-      css('&').styles(
-        display: Display.flex,
-        padding: Padding.all(.7.rem),
-        border: Border.unset,
-        radius: BorderRadius.circular(8.px),
-        outline: Outline.unset,
-        alignItems: AlignItems.center,
-        backgroundColor: Colors.transparent,
-      ),
-      css('&:hover').styles(
-        backgroundColor: Color('color-mix(in srgb, currentColor 5%, transparent)'),
-      ),
-    ]),
-  ];
 }

--- a/packages/jaspr_content/lib/src/components/header.dart
+++ b/packages/jaspr_content/lib/src/components/header.dart
@@ -22,7 +22,7 @@ class Header extends StatelessComponent {
     ]);
 
     yield header(classes: 'header', [
-      SidebarToggleButton(),
+      const SidebarToggleButton(),
       a(classes: 'header-title', href: '/', [
         img(src: logo, alt: 'Logo'),
         span([text(title)]),

--- a/packages/jaspr_content/lib/src/components/sidebar.dart
+++ b/packages/jaspr_content/lib/src/components/sidebar.dart
@@ -32,7 +32,7 @@ class Sidebar extends StatelessComponent {
 
   @override
   Iterable<Component> build(BuildContext context) sync* {
-    var currentRoute = context.page.url;
+    final currentRoute = context.page.url;
 
     yield Document.head(children: [
       Style(styles: _styles),


### PR DESCRIPTION
- Avoid exposing state types and implementation when unnecessary.
- Take advantage of type promotion where possible to avoid not-null assertions.
- Use `const` constructors where possible in `build` methods.
- Fix a few naming inconsistencies.