### PR TITLE
[jaspr] Create helper function for `wbr` element

### DIFF
--- a/packages/jaspr/CHANGELOG.md
+++ b/packages/jaspr/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased patch
 
 - Added support for disabling the sitemap generation for specific pages of `jaspr_content` sites.
+- Added the `wbr` function for creating a line-break opportunity element.
 
 ## 0.19.1
 

--- a/packages/jaspr/lib/src/components/html/text.dart
+++ b/packages/jaspr/lib/src/components/html/text.dart
@@ -273,3 +273,22 @@ Component u(List<Component> children,
     children: children,
   );
 }
+
+/// The &lt;wbr&gt; HTML element represents a word break opportunity—a position within text where the browser may optionally break a line, though its line-breaking rules would not otherwise create a break at that location.
+Component wbr(
+    {Key? key,
+    String? id,
+    String? classes,
+    Styles? styles,
+    Map<String, String>? attributes,
+    Map<String, EventCallback>? events}) {
+  return DomComponent(
+    tag: 'wbr',
+    key: key,
+    id: id,
+    classes: classes,
+    styles: styles,
+    attributes: attributes,
+    events: events,
+  );
+}

--- a/packages/jaspr/tool/data/html.json
+++ b/packages/jaspr/tool/data/html.json
@@ -209,6 +209,10 @@
     },
     "u": {
       "doc": "The &lt;u&gt; HTML element represents a span of inline text which should be rendered in a way that indicates that it has a non-textual annotation. This is rendered by default as a simple solid underline, but may be altered using CSS."
+    },
+    "wbr": {
+      "doc": "The &lt;wbr&gt; HTML element represents a word break opportunity—a position within text where the browser may optionally break a line, though its line-breaking rules would not otherwise create a break at that location.",
+      "self_closing": true
     }
   },
   "media": {

--- a/packages/jaspr_lints/lib/src/all_html_tags.dart
+++ b/packages/jaspr_lints/lib/src/all_html_tags.dart
@@ -34,6 +34,7 @@ const allHtmlTags = {
   'span',
   'strong',
   'u',
+  'wbr',
   'audio',
   'img',
   'video',
@@ -77,5 +78,5 @@ const allHtmlTags = {
   'tr',
   'td',
   'col',
-  'colgroup'
+  'colgroup',
 };


### PR DESCRIPTION
## Description

Adds the [`<wbr>` element](https://developer.mozilla.org/docs/Web/HTML/Reference/Elements/wbr) to `html.json` and regenerates the HTML libraries to add a `wbr()` convenience function.

## Type of Change

- ✨ New feature or improvement