### PR TITLE
[content] Fix and clean up `GitHubButton`

### DIFF
--- a/apps/website/lib/components/github_button.dart
+++ b/apps/website/lib/components/github_button.dart
@@ -7,14 +7,14 @@ import 'package:website/constants/theme.dart';
 
 import 'icon.dart';
 
-class GithubButton extends StatefulComponent {
-  const GithubButton({super.key});
+class GitHubButton extends StatefulComponent {
+  const GitHubButton({super.key});
 
   @override
-  State createState() => GithubButtonState();
+  State createState() => GitHubButtonState();
 }
 
-class GithubButtonState extends State<GithubButton> {
+class GitHubButtonState extends State<GitHubButton> {
   bool loaded = false;
 
   int stars = 9999;

--- a/apps/website/lib/jaspr_options.dart
+++ b/apps/website/lib/jaspr_options.dart
@@ -80,7 +80,7 @@ JasprOptions get defaultJasprOptions => JasprOptions(
       styles: () => [
         ...prefix0.CodeBlock.styles,
         ...prefix1.CodeWindow.styles,
-        ...prefix2.GithubButtonState.styles,
+        ...prefix2.GitHubButtonState.styles,
         ...prefix3.GradientBorder.styles,
         ...prefix4.Icon.styles,
         ...prefix5.LinkButton.styles,

--- a/apps/website/lib/layout/header.dart
+++ b/apps/website/lib/layout/header.dart
@@ -69,7 +69,7 @@ class HeaderState extends State<Header> {
               target: Target.blank,
               ariaLabel: 'Join Discord'),
         ]),
-        GithubButton(),
+        GitHubButton(),
       ]),
     ]);
 

--- a/docs/content/concepts/page_layouts.mdx
+++ b/docs/content/concepts/page_layouts.mdx
@@ -196,7 +196,7 @@ BlogLayout(
       Link(text: 'Home', href: '/'),
       Link(text: 'Articles', href: '/articles'),
       ThemeToggle(), // Described below
-      GithubButton(repo: '<user>/<repo>'), // Described below
+      GitHubButton(repo: '<user>/<repo>'), // Described below
     ],
   )
 )
@@ -237,15 +237,15 @@ div(attributes: {'data-has-sidebar': ''}, [
 ])
 ```
 
-### GithubButton
+### GitHubButton
 
-The `GithubButton` component can be used to display a link to a GitHub repository including its number of stars and forks.
+The `GitHubButton` component can be used to display a link to a GitHub repository including its number of stars and forks.
 
 ```dart
-GithubButton(repo: '<user>/<repo>')
+GitHubButton(repo: '<user>/<repo>')
 ```
 
-![GithubButton Screenshot](/content/assets/github_button.png)
+![GitHubButton Screenshot](/content/assets/github_button.png)
 
 ### ThemeToggle
 

--- a/docs/content/guides/customizing_rendering.mdx
+++ b/docs/content/guides/customizing_rendering.mdx
@@ -326,7 +326,7 @@ void main() {
               // Support toggling between light and dark mode.
               ThemeToggle(),
               // Show a github button with live stars and forks count.
-              GithubButton(repo: '<username>/<repo>'),
+              GitHubButton(repo: '<username>/<repo>'),
             ]
           ),
           sidebar: Sidebar(groups: [

--- a/docs/content/layouts/blog_layout.mdx
+++ b/docs/content/layouts/blog_layout.mdx
@@ -53,7 +53,7 @@ ContentApp(
         logo: 'https://raw.githubusercontent.com/schultek/jaspr/refs/heads/main/assets/logo.png',
         items: [
           ThemeToggle(),
-          GithubButton(repo: 'schultek/jaspr'),
+          GitHubButton(repo: 'schultek/jaspr'),
         ],
       ),
     ),

--- a/docs/content/layouts/docs_layout.mdx
+++ b/docs/content/layouts/docs_layout.mdx
@@ -53,7 +53,7 @@ ContentApp(
         logo: 'https://raw.githubusercontent.com/schultek/jaspr/refs/heads/main/assets/logo.png',
         items: [
           ThemeToggle(),
-          GithubButton(repo: 'schultek/jaspr'),
+          GitHubButton(repo: 'schultek/jaspr'),
         ],
       ),
       sidebar: Sidebar(groups: [

--- a/packages/jaspr_cli/tool/templates/docs/__brick__/lib/main.dart
+++ b/packages/jaspr_cli/tool/templates/docs/__brick__/lib/main.dart
@@ -64,7 +64,7 @@ void main() {
             // Enables switching between light and dark mode.
             ThemeToggle(),
             // Shows github stats.
-            GithubButton(repo: 'schultek/jaspr'),
+            GitHubButton(repo: 'schultek/jaspr'),
           ],
         ),
         sidebar: Sidebar(groups: [

--- a/packages/jaspr_content/CHANGELOG.md
+++ b/packages/jaspr_content/CHANGELOG.md
@@ -3,6 +3,8 @@
 - Added support for `sitemap: false` in the page data to exclude pages from the sitemap.
 - Ignores files and folders in the content directory starting with `.` (in addition to `_`).
 - Require Dart 3.6 or later to match the other Jaspr packages.
+- Renamed the `GithubButton` component to `GitHubButton`.
+- Fixed `GitHubButton` not linking to the correct repository.
 
 ## 0.2.0
 

--- a/packages/jaspr_content/lib/components/github_button.dart
+++ b/packages/jaspr_content/lib/components/github_button.dart
@@ -3,74 +3,25 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 import 'package:jaspr/jaspr.dart';
 
+@Deprecated('Migrate to GitHubButton instead.')
+typedef GithubButton = GitHubButton;
+
 /// A button that links to a GitHub repository and shows stars and forks.
 @client
-class GithubButton extends StatefulComponent {
-  const GithubButton({
+final class GitHubButton extends StatefulComponent {
+  /// Create a new [GitHubButton] component that links to the specified GitHub [repo]
+  /// and shows the amount of stars and forks it has.
+  const GitHubButton({
     required this.repo,
     super.key,
   });
 
+  /// The ID of the GitHub repository,
+  /// in the form `<organization or user name>/<repository name>`.
   final String repo;
 
   @override
-  State createState() => GithubButtonState();
-}
-
-class GithubButtonState extends State<GithubButton> with PreloadStateMixin<GithubButton> {
-  int? stars;
-  int? forks;
-
-  bool get loaded => stars != null;
-
-  @override
-  Future<void> preloadState() async {
-    if (!kGenerateMode && kReleaseMode) {
-      await loadRepositoryData();
-    }
-  }
-
-  @override
-  void initState() {
-    super.initState();
-
-    if (kIsWeb) {
-      loadRepositoryData().then((_) {
-        setState(() {});
-      });
-    }
-  }
-
-  Future<void> loadRepositoryData() async {
-    final response = await http.get(Uri.parse('https://api.github.com/repos/${component.repo}'));
-    if (response.statusCode != 200) {
-      return;
-    }
-    final data = jsonDecode(response.body) as Map<String, dynamic>;
-    final {"stargazers_count": int stars, "forks_count": int forks} = data;
-
-    this.stars = stars;
-    this.forks = forks;
-  }
-
-  @override
-  Iterable<Component> build(BuildContext context) sync* {
-    yield a(href: 'https://github.com/${component.repo}', target: Target.blank, classes: 'github-button not-content', [
-      div(classes: 'github-icon', [
-        GithubIcon(),
-      ]),
-      div(classes: 'github-info', [
-        span([text('schultek/jaspr')]),
-        span([
-          text('★'),
-          span(styles: !loaded ? Styles(opacity: 0) : null, [text('${stars ?? 9999}')]),
-          span([]),
-          text('⑂'),
-          span(styles: !loaded ? Styles(opacity: 0) : null, [text('${forks ?? 99}')])
-        ])
-      ])
-    ]);
-  }
+  State<GitHubButton> createState() => _GitHubButtonState();
 
   @css
   static List<StyleRule> get styles => [
@@ -123,20 +74,78 @@ class GithubButtonState extends State<GithubButton> with PreloadStateMixin<Githu
       ];
 }
 
-class GithubIcon extends StatelessComponent {
+class _GitHubButtonState extends State<GitHubButton> with PreloadStateMixin<GitHubButton> {
+  int? _stars;
+  int? _forks;
+
+  bool get loaded => _stars != null;
+
   @override
-  Iterable<Component> build(BuildContext context) sync* {
+  Future<void> preloadState() async {
+    if (!kGenerateMode && kReleaseMode) {
+      await loadRepositoryData();
+    }
+  }
+
+  @override
+  void initState() {
+    super.initState();
+
+    if (kIsWeb) {
+      loadRepositoryData().then((_) {
+        setState(() {});
+      });
+    }
+  }
+
+  Future<void> loadRepositoryData() async {
+    final response = await http.get(Uri.https('api.github.com', '/repos/${component.repo}'));
+    if (response.statusCode != 200) {
+      return;
+    }
+    final data = jsonDecode(response.body) as Map<String, Object?>;
+    final {'stargazers_count': stars as int, 'forks_count': forks as int} = data;
+
+    _stars = stars;
+    _forks = forks;
+  }
+
+  @override
+  Iterable<Component> build(BuildContext _) sync* {
+    yield a(href: 'https://github.com/${component.repo}', target: Target.blank, classes: 'github-button not-content', [
+      div(classes: 'github-icon', const [
+        _GitHubIcon(),
+      ]),
+      div(classes: 'github-info', [
+        span([text(component.repo)]),
+        span([
+          text('★'),
+          span(styles: !loaded ? const Styles(opacity: 0) : null, [text('${_stars ?? 9999}')]),
+          span([]),
+          text('⑂'),
+          span(styles: !loaded ? const Styles(opacity: 0) : null, [text('${_forks ?? 99}')])
+        ])
+      ])
+    ]);
+  }
+}
+
+class _GitHubIcon extends StatelessComponent {
+  const _GitHubIcon();
+
+  @override
+  Iterable<Component> build(BuildContext _) sync* {
     yield svg(viewBox: '0 0 24 24', attributes: {
       'fill': 'currentColor'
     }, [
       path(
-        d: r"M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.0"
-            "15-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.2"
-            "05.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-"
-            "1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1"
-            ".98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.8"
-            "4 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 "
-            ".315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12",
+        d: r'M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.0'
+            '15-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.2'
+            '05.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-'
+            '1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1'
+            '.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.8'
+            '4 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 '
+            '.315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12',
         [],
       ),
     ]);


### PR DESCRIPTION
- Rename to `GitHubButton` from `GithubButton`
- Mark `GitHubButtonState` as private, to avoid unnecessarily exposing it.
- Fix `GitHubButton` always mentioning the `schultek/jaspr` repository instead of the specified repository.
- Use `Uri.https` instead of `Uri.parse` for slightly faster URI parsing/creation
- Consistently use single quotes instead of mixing between both types
- Add a few small doc comments