### PR TITLE
[content] Minor `SidebarToggleButton` cleanup

### DIFF
--- a/packages/jaspr_content/lib/components/sidebar_toggle_button.dart
+++ b/packages/jaspr_content/lib/components/sidebar_toggle_button.dart
@@ -4,39 +4,39 @@ import 'package:jaspr/jaspr.dart';
 import 'package:universal_web/web.dart' hide Document;
 
 /// A sidebar toggle button.
+///
+/// When clicked, adds the `open` class to elements with the `.sidebar-container` class.
+/// When elements with the `.sidebar-close` or `.sidebar-barrier` class are clicked,
+/// removes the `open` class from elements with the `.sidebar-container` class.
 @client
-class SidebarToggleButton extends StatelessComponent {
-  SidebarToggleButton({super.key});
+final class SidebarToggleButton extends StatelessComponent {
+  const SidebarToggleButton({super.key});
 
   @override
   Iterable<Component> build(BuildContext context) sync* {
     if (!kIsWeb) {
       yield Document.head(children: [
-        Style(styles: styles),
+        Style(styles: _styles),
       ]);
     }
 
     yield button(classes: 'sidebar-toggle-button', onClick: () {
-      StreamSubscription? closeSub, barrierSub;
-      void close() {
+      StreamSubscription<void>? closeSub, barrierSub;
+      void close(void _) {
         closeSub?.cancel();
         barrierSub?.cancel();
         window.document.querySelector('.sidebar-container')?.classList.remove('open');
       }
 
-      closeSub = window.document.querySelector('.sidebar-close')?.onClick.listen((_) {
-        close();
-      });
-      barrierSub = window.document.querySelector('.sidebar-barrier')?.onClick.listen((_) {
-        close();
-      });
+      closeSub = window.document.querySelector('.sidebar-close')?.onClick.listen(close);
+      barrierSub = window.document.querySelector('.sidebar-barrier')?.onClick.listen(close);
       window.document.querySelector('.sidebar-container')?.classList.add('open');
     }, [
-      raw(menuIcon),
+      raw(_menuIcon),
     ]);
   }
 
-  List<StyleRule> get styles => [
+  List<StyleRule> get _styles => [
         css('.sidebar-toggle-button').styles(
           display: Display.none,
           justifyContent: JustifyContent.center,
@@ -50,6 +50,6 @@ class SidebarToggleButton extends StatelessComponent {
       ];
 }
 
-const menuIcon = '''
+const _menuIcon = '''
 <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="4" x2="20" y1="12" y2="12"></line><line x1="4" x2="20" y1="6" y2="6"></line><line x1="4" x2="20" y1="18" y2="18"></line></svg>
 ''';

--- a/packages/jaspr_content/lib/src/components/header.dart
+++ b/packages/jaspr_content/lib/src/components/header.dart
@@ -22,7 +22,7 @@ class Header extends StatelessComponent {
     ]);
 
     yield header(classes: 'header', [
-      SidebarToggleButton(),
+      const SidebarToggleButton(),
       a(classes: 'header-title', href: '/', [
         img(src: logo, alt: 'Logo'),
         span([text(title)]),


### PR DESCRIPTION
- Avoids unnecessarily exposing `styles` and `menuIcon` by privatizing them.
  This is technically a very minor breaking change but shouldn't affect anyone at this stage.
- Expands the class API doc comment.
- Other minor cleanup.