### PR TITLE
[content] Fix retrieving data under 'page' loaded from front matter

### DIFF
--- a/packages/jaspr_content/lib/src/data_loader/data_loader.dart
+++ b/packages/jaspr_content/lib/src/data_loader/data_loader.dart
@@ -6,6 +6,7 @@ import 'dart:convert';
 import 'package:yaml/yaml.dart' as yaml;
 
 import '../page.dart';
+import '../utils.dart';
 
 /// A data loader that loads additional data for a page.
 ///
@@ -28,22 +29,6 @@ abstract class DataLoader {
       return yaml.loadYamlNode(data).normalize();
     } else {
       return data;
-    }
-  }
-}
-
-extension on yaml.YamlNode {
-  Object normalize() {
-    if (this case yaml.YamlMap(:final nodes)) {
-      return {
-        for (final entry in nodes.entries) entry.key.toString(): entry.value.normalize(),
-      };
-    } else if (this case yaml.YamlList(:final nodes)) {
-      return [
-        for (final node in nodes) node.normalize(),
-      ];
-    } else {
-      return value;
     }
   }
 }

--- a/packages/jaspr_content/lib/src/page.dart
+++ b/packages/jaspr_content/lib/src/page.dart
@@ -13,6 +13,7 @@ import 'route_loader/route_loader.dart';
 import 'secondary_output/secondary_output.dart';
 import 'template_engine/template_engine.dart';
 import 'theme/theme.dart';
+import 'utils.dart';
 
 /// A single page of the site.
 ///
@@ -41,7 +42,7 @@ class Page {
   String content;
 
   /// Data available to the page.
-  PageDataMap _data;
+  Map<String, Object?> _data;
 
   /// Data available to the page.
   ///
@@ -49,7 +50,7 @@ class Page {
   /// different modules during the page building process.
   ///
   /// Prefer modifying or replacing data with [apply].
-  PageDataMap get data => _data;
+  PageDataMap get data => PageDataMap._(_data);
 
   /// The configuration for the page.
   ///
@@ -74,7 +75,7 @@ class Page {
     }
 
     if (data != null) {
-      _data = mergeData ? PageDataMap._(_data.merge(data)) : PageDataMap._({...data});
+      _data = mergeData ? _data.merge(data) : {...data};
     }
   }
 
@@ -274,7 +275,7 @@ extension PageHandlersExtension on Page {
   void parseFrontmatter() {
     if (config.enableFrontmatter) {
       final document = fm.parse(content);
-      apply(content: document.content, data: {'page': document.data});
+      apply(content: document.content, data: {'page': document.data.normalize});
     }
   }
 

--- a/packages/jaspr_content/lib/src/route_loader/route_loader.dart
+++ b/packages/jaspr_content/lib/src/route_loader/route_loader.dart
@@ -241,7 +241,7 @@ abstract class PageSource {
     _page = newPage;
     RouteLoader._pages.add(newPage);
 
-    // Preserve originally data to reapply
+    // Preserve original data to reapply
     // after first specifying our provided data.
     final builtData = newPage.data;
 

--- a/packages/jaspr_content/lib/src/utils.dart
+++ b/packages/jaspr_content/lib/src/utils.dart
@@ -1,0 +1,17 @@
+import 'package:yaml/yaml.dart' as yaml;
+
+extension YamlNormalize on yaml.YamlNode {
+  Object normalize() {
+    if (this case yaml.YamlMap(:final nodes)) {
+      return {
+        for (final entry in nodes.entries) entry.key.toString(): entry.value.normalize(),
+      };
+    } else if (this case yaml.YamlList(:final nodes)) {
+      return [
+        for (final node in nodes) node.normalize(),
+      ];
+    } else {
+      return value;
+    }
+  }
+}


### PR DESCRIPTION
The `page.data.page` getter expects an actual map, but the frontmatter was being added as a `YamlMap`. To fix this, this PR pulls out the `normalize` extension method used for data loading to a shared util file and uses it when loading the front matter as well.