### PR TITLE
[content] Properly fix applying frontmatter page data

### DIFF
--- a/packages/jaspr_content/lib/src/page.dart
+++ b/packages/jaspr_content/lib/src/page.dart
@@ -275,7 +275,8 @@ extension PageHandlersExtension on Page {
   void parseFrontmatter() {
     if (config.enableFrontmatter) {
       final document = fm.parse(content);
-      apply(content: document.content, data: {'page': document.data.normalize});
+      final normalizedData = document.data.normalize();
+      apply(content: document.content, data: {'page': normalizedData});
     }
   }
 

--- a/packages/jaspr_content/lib/src/utils.dart
+++ b/packages/jaspr_content/lib/src/utils.dart
@@ -1,17 +1,22 @@
 import 'package:yaml/yaml.dart' as yaml;
 
-extension YamlNormalize on yaml.YamlNode {
-  Object normalize() {
-    if (this case yaml.YamlMap(:final nodes)) {
-      return {
+extension YamlMapNormalize on yaml.YamlMap {
+  Map<String, Object?> normalize() => {
         for (final entry in nodes.entries) entry.key.toString(): entry.value.normalize(),
       };
-    } else if (this case yaml.YamlList(:final nodes)) {
-      return [
+}
+
+extension YamlListNormalize on yaml.YamlList {
+  List<Object?> normalize() => [
         for (final node in nodes) node.normalize(),
       ];
-    } else {
-      return value;
-    }
-  }
+}
+
+extension YamlNodeNormalize on yaml.YamlNode {
+  Object normalize() => switch (this) {
+        final yaml.YamlMap map => map.normalize(),
+        final yaml.YamlList list => list.normalize(),
+        final yaml.YamlScalar scalar => scalar.value,
+        final value => value,
+      };
 }


### PR DESCRIPTION
In https://github.com/schultek/jaspr/pull/473, I somehow removed the `()` and didn't realize. Unfortunately the context type is `Object?` so the tear off wasn't caught.

To help avoid this though (besides adding tests which we should do), I added additional `normalize` extension methods that keep the map and list nature of the yaml types.