### PR TITLE
Use defined http client in `ServerApp.requestRouteGeneration`

### DIFF
--- a/packages/jaspr/CHANGELOG.md
+++ b/packages/jaspr/CHANGELOG.md
@@ -3,6 +3,8 @@
 - Added support for disabling the sitemap generation for specific pages of `jaspr_content` sites.
 - Moved `DomValidator` class to foundation library.
 - Added the `wbr` function for creating a line-break opportunity element.
+- Fixed an error where building too many routes in succession
+  caused ports to be exhausted on macOS.
 
 ## 0.19.1
 

--- a/packages/jaspr/lib/src/server/server_app.dart
+++ b/packages/jaspr/lib/src/server/server_app.dart
@@ -85,8 +85,9 @@ class ServerApp {
   }
 
   static Future<void> _sendDebugMessage(Object message) async {
-    await http.post(
-      Uri.parse('http://localhost:$jasprProxyPort/\$jasprMessageHandler'),
+    final postWithClient = _client?.post ?? http.post;
+    await postWithClient(
+      Uri.http('localhost:$jasprProxyPort', r'$jasprMessageHandler'),
       body: jsonEncode(message),
     );
   }


### PR DESCRIPTION
Use the already specified http client in `ServerApp.requestRouteGeneration`, to prevent port exhaustion when requesting many routes in succession.

Fixes https://github.com/schultek/jaspr/issues/480
