### PR TITLE
Fix sitemap generation bug in top-level route

### DIFF
--- a/packages/jaspr/CHANGELOG.md
+++ b/packages/jaspr/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased patch
+
+- Fixed sitemap generation bug in top-level route ('/')
+
 ## 0.20.0
 
 - **Breaking**: Removed the children parameter from `input` and `col` methods as

--- a/packages/jaspr_cli/lib/src/commands/build_command.dart
+++ b/packages/jaspr_cli/lib/src/commands/build_command.dart
@@ -178,10 +178,9 @@ class BuildCommand extends BaseCommand with ProxyHelper, FlutterHelper {
           if (!serverStartedCompleter.isCompleted) {
             serverStartedCompleter.complete();
           }
-          if (generatedRoutes.containsKey(route)) {
-            return;
+          if (!generatedRoutes.containsKey(route)) {
+            queuedRoutes.insert(0, route);
           }
-          queuedRoutes.insert(0, route);
 
           final lastmod = message['lastmod'] is String ? message['lastmod'] : null;
           final changefreq = message['changefreq'] is String ? message['changefreq'] : null;


### PR DESCRIPTION
## Description

Currently, when enabling sitemaps, the sitemap properties for the top-level root ('/') are not properly applied.
After investigating, I discovered that this is due to `requestRouteGeneration('/')` being called without a sitemap property in [packages/jaspr/lib/src/server/server_app.dart](https://github.com/schultek/jaspr/blob/1d7f0488fd232e14307395a50be7d5b7c5d795f2/packages/jaspr/lib/src/server/server_app.dart#L57).
However, it currently appears difficult to retrieve the sitemap property for the top-level root in this function.
After consideration, I concluded that the easiest solution is to slightly modify the build code in `jaspr_cli` so that the build process retrieves the sitemap property at the last request instead of the first.
As the project owner, if you find a better solution, please consider modifying it accordingly.
Thank you.

## Type of Change

<!-- Uncomment all that apply: -->

<!-- - ❌ Breaking change -->
<!-- - ✨ New feature or improvement -->
🛠️ Bug fix
<!-- - 🧹 Code refactor -->
<!-- - 📝 Documentation -->
<!-- - 🗑️ Chore -->

## Ready Checklist

- [x] I've read the [Contribution Guide](https://github.com/schultek/jaspr/blob/main/CONTRIBUTING.md).
- [x] In case this PR changes one of the core packages, I've modified the respective **CHANGELOG.md** file using
      the [semantic_changelog](https://github.com/rrousselGit/semantic_changelog) format.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added myself to the AUTHORS file (optional, if you want to).

<!-- 
  Feel free to expand this list if you have additional todos before your PR is ready. 
-->

<!--
  If you need help, consider asking for advice on the *#contribute* channel on [Discord](https://discord.gg/XGXrGEk4c6).
-->
