### PR TITLE
[jaspr_cli] Work around --define issue in Dart 3.10 dev builds

### DIFF
--- a/packages/jaspr_cli/lib/src/commands/build_command.dart
+++ b/packages/jaspr_cli/lib/src/commands/build_command.dart
@@ -206,7 +206,9 @@ class BuildCommand extends BaseCommand with ProxyHelper, FlutterHelper {
       var process = await Process.start(
         Platform.executable,
         [
-          'run',
+          // Use direct `dart` entry point for now due to
+          // https://github.com/dart-lang/sdk/issues/61373.
+          // 'run',
           '--enable-asserts',
           '-Djaspr.flags.release=true',
           '-Djaspr.flags.generate=true',

--- a/packages/jaspr_cli/lib/src/commands/dev_command.dart
+++ b/packages/jaspr_cli/lib/src/commands/dev_command.dart
@@ -142,7 +142,9 @@ abstract class DevCommand extends BaseCommand with ProxyHelper, FlutterHelper {
     var userDefines = getServerDartDefines();
 
     var args = [
-      'run',
+      // Use direct `dart` entry point for now due to
+      // https://github.com/dart-lang/sdk/issues/61373.
+      // 'run',
       if (!release) ...[
         '--enable-vm-service',
         '--enable-asserts',


### PR DESCRIPTION
Add a workaround for https://github.com/dart-lang/sdk/issues/61373 so `jaspr build` and `jaspr serve` work as expected even with the issue in 3.10 beta and dev builds. Once resolved, we can revert the workaround, but this way of using `dart` is also supported, so there's no rush to do so.