### PR TITLE
[jaspr_pad] Dependency updates and clean up

### DIFF
--- a/apps/jaspr_pad/lib/adapters/hljs.dart
+++ b/apps/jaspr_pad/lib/adapters/hljs.dart
@@ -1,7 +1,4 @@
-@JS()
-library;
-
-import 'package:js/js.dart';
+import 'dart:js_interop';
 
 @JS('hljs.highlightAll')
 external void highlightAll();

--- a/apps/jaspr_pad/lib/main.init.dart
+++ b/apps/jaspr_pad/lib/main.init.dart
@@ -1,5 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format off
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element
 

--- a/apps/jaspr_pad/lib/models/api_models.mapper.dart
+++ b/apps/jaspr_pad/lib/models/api_models.mapper.dart
@@ -1,5 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format off
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, unnecessary_cast, override_on_non_overriding_member
 // ignore_for_file: strict_raw_type, inference_failure_on_untyped_parameter
@@ -71,12 +72,13 @@ class CompileRequestMapper extends ClassMapperBase<CompileRequest> {
   final String id = 'CompileRequest';
 
   static Map<String, String> _$sources(CompileRequest v) => v.sources;
-  static const Field<CompileRequest, Map<String, String>> _f$sources = Field('sources', _$sources);
+  static const Field<CompileRequest, Map<String, String>> _f$sources = Field(
+    'sources',
+    _$sources,
+  );
 
   @override
-  final MappableFields<CompileRequest> fields = const {
-    #sources: _f$sources,
-  };
+  final MappableFields<CompileRequest> fields = const {#sources: _f$sources};
 
   static CompileRequest _instantiate(DecodingData data) {
     return CompileRequest(data.dec(_f$sources));
@@ -96,28 +98,43 @@ class CompileRequestMapper extends ClassMapperBase<CompileRequest> {
 
 mixin CompileRequestMappable {
   String toJson() {
-    return CompileRequestMapper.ensureInitialized().encodeJson<CompileRequest>(this as CompileRequest);
+    return CompileRequestMapper.ensureInitialized().encodeJson<CompileRequest>(
+      this as CompileRequest,
+    );
   }
 
   Map<String, dynamic> toMap() {
-    return CompileRequestMapper.ensureInitialized().encodeMap<CompileRequest>(this as CompileRequest);
+    return CompileRequestMapper.ensureInitialized().encodeMap<CompileRequest>(
+      this as CompileRequest,
+    );
   }
 
   CompileRequestCopyWith<CompileRequest, CompileRequest, CompileRequest> get copyWith =>
-      _CompileRequestCopyWithImpl<CompileRequest, CompileRequest>(this as CompileRequest, $identity, $identity);
+      _CompileRequestCopyWithImpl<CompileRequest, CompileRequest>(
+        this as CompileRequest,
+        $identity,
+        $identity,
+      );
   @override
   String toString() {
-    return CompileRequestMapper.ensureInitialized().stringifyValue(this as CompileRequest);
+    return CompileRequestMapper.ensureInitialized().stringifyValue(
+      this as CompileRequest,
+    );
   }
 
   @override
   bool operator ==(Object other) {
-    return CompileRequestMapper.ensureInitialized().equalsValue(this as CompileRequest, other);
+    return CompileRequestMapper.ensureInitialized().equalsValue(
+      this as CompileRequest,
+      other,
+    );
   }
 
   @override
   int get hashCode {
-    return CompileRequestMapper.ensureInitialized().hashValue(this as CompileRequest);
+    return CompileRequestMapper.ensureInitialized().hashValue(
+      this as CompileRequest,
+    );
   }
 }
 
@@ -129,7 +146,9 @@ extension CompileRequestValueCopy<$R, $Out> on ObjectCopyWith<$R, CompileRequest
 abstract class CompileRequestCopyWith<$R, $In extends CompileRequest, $Out> implements ClassCopyWith<$R, $In, $Out> {
   MapCopyWith<$R, String, String, ObjectCopyWith<$R, String, String>> get sources;
   $R call({Map<String, String>? sources});
-  CompileRequestCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t);
+  CompileRequestCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(
+    Then<$Out2, $R2> t,
+  );
 }
 
 class _CompileRequestCopyWithImpl<$R, $Out> extends ClassCopyWithBase<$R, CompileRequest, $Out>
@@ -139,15 +158,20 @@ class _CompileRequestCopyWithImpl<$R, $Out> extends ClassCopyWithBase<$R, Compil
   @override
   late final ClassMapperBase<CompileRequest> $mapper = CompileRequestMapper.ensureInitialized();
   @override
-  MapCopyWith<$R, String, String, ObjectCopyWith<$R, String, String>> get sources =>
-      MapCopyWith($value.sources, (v, t) => ObjectCopyWith(v, $identity, t), (v) => call(sources: v));
+  MapCopyWith<$R, String, String, ObjectCopyWith<$R, String, String>> get sources => MapCopyWith(
+        $value.sources,
+        (v, t) => ObjectCopyWith(v, $identity, t),
+        (v) => call(sources: v),
+      );
   @override
   $R call({Map<String, String>? sources}) => $apply(FieldCopyWithData({if (sources != null) #sources: sources}));
   @override
   CompileRequest $make(CopyWithData data) => CompileRequest(data.get(#sources, or: $value.sources));
 
   @override
-  CompileRequestCopyWith<$R2, CompileRequest, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t) =>
+  CompileRequestCopyWith<$R2, CompileRequest, $Out2> $chain<$R2, $Out2>(
+    Then<$Out2, $R2> t,
+  ) =>
       _CompileRequestCopyWithImpl<$R2, $Out2>($value, $cast, t);
 }
 
@@ -166,9 +190,15 @@ class CompileResponseMapper extends ClassMapperBase<CompileResponse> {
   final String id = 'CompileResponse';
 
   static String? _$result(CompileResponse v) => v.result;
-  static const Field<CompileResponse, String> _f$result = Field('result', _$result);
+  static const Field<CompileResponse, String> _f$result = Field(
+    'result',
+    _$result,
+  );
   static String? _$error(CompileResponse v) => v.error;
-  static const Field<CompileResponse, String> _f$error = Field('error', _$error);
+  static const Field<CompileResponse, String> _f$error = Field(
+    'error',
+    _$error,
+  );
 
   @override
   final MappableFields<CompileResponse> fields = const {
@@ -198,24 +228,37 @@ mixin CompileResponseMappable {
   }
 
   Map<String, dynamic> toMap() {
-    return CompileResponseMapper.ensureInitialized().encodeMap<CompileResponse>(this as CompileResponse);
+    return CompileResponseMapper.ensureInitialized().encodeMap<CompileResponse>(
+      this as CompileResponse,
+    );
   }
 
   CompileResponseCopyWith<CompileResponse, CompileResponse, CompileResponse> get copyWith =>
-      _CompileResponseCopyWithImpl<CompileResponse, CompileResponse>(this as CompileResponse, $identity, $identity);
+      _CompileResponseCopyWithImpl<CompileResponse, CompileResponse>(
+        this as CompileResponse,
+        $identity,
+        $identity,
+      );
   @override
   String toString() {
-    return CompileResponseMapper.ensureInitialized().stringifyValue(this as CompileResponse);
+    return CompileResponseMapper.ensureInitialized().stringifyValue(
+      this as CompileResponse,
+    );
   }
 
   @override
   bool operator ==(Object other) {
-    return CompileResponseMapper.ensureInitialized().equalsValue(this as CompileResponse, other);
+    return CompileResponseMapper.ensureInitialized().equalsValue(
+      this as CompileResponse,
+      other,
+    );
   }
 
   @override
   int get hashCode {
-    return CompileResponseMapper.ensureInitialized().hashValue(this as CompileResponse);
+    return CompileResponseMapper.ensureInitialized().hashValue(
+      this as CompileResponse,
+    );
   }
 }
 
@@ -226,7 +269,9 @@ extension CompileResponseValueCopy<$R, $Out> on ObjectCopyWith<$R, CompileRespon
 
 abstract class CompileResponseCopyWith<$R, $In extends CompileResponse, $Out> implements ClassCopyWith<$R, $In, $Out> {
   $R call({String? result, String? error});
-  CompileResponseCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t);
+  CompileResponseCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(
+    Then<$Out2, $R2> t,
+  );
 }
 
 class _CompileResponseCopyWithImpl<$R, $Out> extends ClassCopyWithBase<$R, CompileResponse, $Out>
@@ -236,14 +281,22 @@ class _CompileResponseCopyWithImpl<$R, $Out> extends ClassCopyWithBase<$R, Compi
   @override
   late final ClassMapperBase<CompileResponse> $mapper = CompileResponseMapper.ensureInitialized();
   @override
-  $R call({Object? result = $none, Object? error = $none}) =>
-      $apply(FieldCopyWithData({if (result != $none) #result: result, if (error != $none) #error: error}));
+  $R call({Object? result = $none, Object? error = $none}) => $apply(
+        FieldCopyWithData({
+          if (result != $none) #result: result,
+          if (error != $none) #error: error,
+        }),
+      );
   @override
-  CompileResponse $make(CopyWithData data) =>
-      CompileResponse(data.get(#result, or: $value.result), data.get(#error, or: $value.error));
+  CompileResponse $make(CopyWithData data) => CompileResponse(
+        data.get(#result, or: $value.result),
+        data.get(#error, or: $value.error),
+      );
 
   @override
-  CompileResponseCopyWith<$R2, CompileResponse, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t) =>
+  CompileResponseCopyWith<$R2, CompileResponse, $Out2> $chain<$R2, $Out2>(
+    Then<$Out2, $R2> t,
+  ) =>
       _CompileResponseCopyWithImpl<$R2, $Out2>($value, $cast, t);
 }
 
@@ -262,12 +315,13 @@ class AnalyzeRequestMapper extends ClassMapperBase<AnalyzeRequest> {
   final String id = 'AnalyzeRequest';
 
   static Map<String, String> _$sources(AnalyzeRequest v) => v.sources;
-  static const Field<AnalyzeRequest, Map<String, String>> _f$sources = Field('sources', _$sources);
+  static const Field<AnalyzeRequest, Map<String, String>> _f$sources = Field(
+    'sources',
+    _$sources,
+  );
 
   @override
-  final MappableFields<AnalyzeRequest> fields = const {
-    #sources: _f$sources,
-  };
+  final MappableFields<AnalyzeRequest> fields = const {#sources: _f$sources};
 
   static AnalyzeRequest _instantiate(DecodingData data) {
     return AnalyzeRequest(data.dec(_f$sources));
@@ -287,28 +341,43 @@ class AnalyzeRequestMapper extends ClassMapperBase<AnalyzeRequest> {
 
 mixin AnalyzeRequestMappable {
   String toJson() {
-    return AnalyzeRequestMapper.ensureInitialized().encodeJson<AnalyzeRequest>(this as AnalyzeRequest);
+    return AnalyzeRequestMapper.ensureInitialized().encodeJson<AnalyzeRequest>(
+      this as AnalyzeRequest,
+    );
   }
 
   Map<String, dynamic> toMap() {
-    return AnalyzeRequestMapper.ensureInitialized().encodeMap<AnalyzeRequest>(this as AnalyzeRequest);
+    return AnalyzeRequestMapper.ensureInitialized().encodeMap<AnalyzeRequest>(
+      this as AnalyzeRequest,
+    );
   }
 
   AnalyzeRequestCopyWith<AnalyzeRequest, AnalyzeRequest, AnalyzeRequest> get copyWith =>
-      _AnalyzeRequestCopyWithImpl<AnalyzeRequest, AnalyzeRequest>(this as AnalyzeRequest, $identity, $identity);
+      _AnalyzeRequestCopyWithImpl<AnalyzeRequest, AnalyzeRequest>(
+        this as AnalyzeRequest,
+        $identity,
+        $identity,
+      );
   @override
   String toString() {
-    return AnalyzeRequestMapper.ensureInitialized().stringifyValue(this as AnalyzeRequest);
+    return AnalyzeRequestMapper.ensureInitialized().stringifyValue(
+      this as AnalyzeRequest,
+    );
   }
 
   @override
   bool operator ==(Object other) {
-    return AnalyzeRequestMapper.ensureInitialized().equalsValue(this as AnalyzeRequest, other);
+    return AnalyzeRequestMapper.ensureInitialized().equalsValue(
+      this as AnalyzeRequest,
+      other,
+    );
   }
 
   @override
   int get hashCode {
-    return AnalyzeRequestMapper.ensureInitialized().hashValue(this as AnalyzeRequest);
+    return AnalyzeRequestMapper.ensureInitialized().hashValue(
+      this as AnalyzeRequest,
+    );
   }
 }
 
@@ -320,7 +389,9 @@ extension AnalyzeRequestValueCopy<$R, $Out> on ObjectCopyWith<$R, AnalyzeRequest
 abstract class AnalyzeRequestCopyWith<$R, $In extends AnalyzeRequest, $Out> implements ClassCopyWith<$R, $In, $Out> {
   MapCopyWith<$R, String, String, ObjectCopyWith<$R, String, String>> get sources;
   $R call({Map<String, String>? sources});
-  AnalyzeRequestCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t);
+  AnalyzeRequestCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(
+    Then<$Out2, $R2> t,
+  );
 }
 
 class _AnalyzeRequestCopyWithImpl<$R, $Out> extends ClassCopyWithBase<$R, AnalyzeRequest, $Out>
@@ -330,15 +401,20 @@ class _AnalyzeRequestCopyWithImpl<$R, $Out> extends ClassCopyWithBase<$R, Analyz
   @override
   late final ClassMapperBase<AnalyzeRequest> $mapper = AnalyzeRequestMapper.ensureInitialized();
   @override
-  MapCopyWith<$R, String, String, ObjectCopyWith<$R, String, String>> get sources =>
-      MapCopyWith($value.sources, (v, t) => ObjectCopyWith(v, $identity, t), (v) => call(sources: v));
+  MapCopyWith<$R, String, String, ObjectCopyWith<$R, String, String>> get sources => MapCopyWith(
+        $value.sources,
+        (v, t) => ObjectCopyWith(v, $identity, t),
+        (v) => call(sources: v),
+      );
   @override
   $R call({Map<String, String>? sources}) => $apply(FieldCopyWithData({if (sources != null) #sources: sources}));
   @override
   AnalyzeRequest $make(CopyWithData data) => AnalyzeRequest(data.get(#sources, or: $value.sources));
 
   @override
-  AnalyzeRequestCopyWith<$R2, AnalyzeRequest, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t) =>
+  AnalyzeRequestCopyWith<$R2, AnalyzeRequest, $Out2> $chain<$R2, $Out2>(
+    Then<$Out2, $R2> t,
+  ) =>
       _AnalyzeRequestCopyWithImpl<$R2, $Out2>($value, $cast, t);
 }
 
@@ -357,9 +433,15 @@ class FormatResponseMapper extends ClassMapperBase<FormatResponse> {
   final String id = 'FormatResponse';
 
   static String _$newString(FormatResponse v) => v.newString;
-  static const Field<FormatResponse, String> _f$newString = Field('newString', _$newString);
+  static const Field<FormatResponse, String> _f$newString = Field(
+    'newString',
+    _$newString,
+  );
   static int _$newOffset(FormatResponse v) => v.newOffset;
-  static const Field<FormatResponse, int> _f$newOffset = Field('newOffset', _$newOffset);
+  static const Field<FormatResponse, int> _f$newOffset = Field(
+    'newOffset',
+    _$newOffset,
+  );
 
   @override
   final MappableFields<FormatResponse> fields = const {
@@ -385,28 +467,43 @@ class FormatResponseMapper extends ClassMapperBase<FormatResponse> {
 
 mixin FormatResponseMappable {
   String toJson() {
-    return FormatResponseMapper.ensureInitialized().encodeJson<FormatResponse>(this as FormatResponse);
+    return FormatResponseMapper.ensureInitialized().encodeJson<FormatResponse>(
+      this as FormatResponse,
+    );
   }
 
   Map<String, dynamic> toMap() {
-    return FormatResponseMapper.ensureInitialized().encodeMap<FormatResponse>(this as FormatResponse);
+    return FormatResponseMapper.ensureInitialized().encodeMap<FormatResponse>(
+      this as FormatResponse,
+    );
   }
 
   FormatResponseCopyWith<FormatResponse, FormatResponse, FormatResponse> get copyWith =>
-      _FormatResponseCopyWithImpl<FormatResponse, FormatResponse>(this as FormatResponse, $identity, $identity);
+      _FormatResponseCopyWithImpl<FormatResponse, FormatResponse>(
+        this as FormatResponse,
+        $identity,
+        $identity,
+      );
   @override
   String toString() {
-    return FormatResponseMapper.ensureInitialized().stringifyValue(this as FormatResponse);
+    return FormatResponseMapper.ensureInitialized().stringifyValue(
+      this as FormatResponse,
+    );
   }
 
   @override
   bool operator ==(Object other) {
-    return FormatResponseMapper.ensureInitialized().equalsValue(this as FormatResponse, other);
+    return FormatResponseMapper.ensureInitialized().equalsValue(
+      this as FormatResponse,
+      other,
+    );
   }
 
   @override
   int get hashCode {
-    return FormatResponseMapper.ensureInitialized().hashValue(this as FormatResponse);
+    return FormatResponseMapper.ensureInitialized().hashValue(
+      this as FormatResponse,
+    );
   }
 }
 
@@ -417,7 +514,9 @@ extension FormatResponseValueCopy<$R, $Out> on ObjectCopyWith<$R, FormatResponse
 
 abstract class FormatResponseCopyWith<$R, $In extends FormatResponse, $Out> implements ClassCopyWith<$R, $In, $Out> {
   $R call({String? newString, int? newOffset});
-  FormatResponseCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t);
+  FormatResponseCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(
+    Then<$Out2, $R2> t,
+  );
 }
 
 class _FormatResponseCopyWithImpl<$R, $Out> extends ClassCopyWithBase<$R, FormatResponse, $Out>
@@ -428,13 +527,21 @@ class _FormatResponseCopyWithImpl<$R, $Out> extends ClassCopyWithBase<$R, Format
   late final ClassMapperBase<FormatResponse> $mapper = FormatResponseMapper.ensureInitialized();
   @override
   $R call({String? newString, int? newOffset}) => $apply(
-      FieldCopyWithData({if (newString != null) #newString: newString, if (newOffset != null) #newOffset: newOffset}));
+        FieldCopyWithData({
+          if (newString != null) #newString: newString,
+          if (newOffset != null) #newOffset: newOffset,
+        }),
+      );
   @override
-  FormatResponse $make(CopyWithData data) =>
-      FormatResponse(data.get(#newString, or: $value.newString), data.get(#newOffset, or: $value.newOffset));
+  FormatResponse $make(CopyWithData data) => FormatResponse(
+        data.get(#newString, or: $value.newString),
+        data.get(#newOffset, or: $value.newOffset),
+      );
 
   @override
-  FormatResponseCopyWith<$R2, FormatResponse, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t) =>
+  FormatResponseCopyWith<$R2, FormatResponse, $Out2> $chain<$R2, $Out2>(
+    Then<$Out2, $R2> t,
+  ) =>
       _FormatResponseCopyWithImpl<$R2, $Out2>($value, $cast, t);
 }
 
@@ -453,7 +560,10 @@ class FormatRequestMapper extends ClassMapperBase<FormatRequest> {
   final String id = 'FormatRequest';
 
   static String _$source(FormatRequest v) => v.source;
-  static const Field<FormatRequest, String> _f$source = Field('source', _$source);
+  static const Field<FormatRequest, String> _f$source = Field(
+    'source',
+    _$source,
+  );
   static int _$offset(FormatRequest v) => v.offset;
   static const Field<FormatRequest, int> _f$offset = Field('offset', _$offset);
 
@@ -481,28 +591,43 @@ class FormatRequestMapper extends ClassMapperBase<FormatRequest> {
 
 mixin FormatRequestMappable {
   String toJson() {
-    return FormatRequestMapper.ensureInitialized().encodeJson<FormatRequest>(this as FormatRequest);
+    return FormatRequestMapper.ensureInitialized().encodeJson<FormatRequest>(
+      this as FormatRequest,
+    );
   }
 
   Map<String, dynamic> toMap() {
-    return FormatRequestMapper.ensureInitialized().encodeMap<FormatRequest>(this as FormatRequest);
+    return FormatRequestMapper.ensureInitialized().encodeMap<FormatRequest>(
+      this as FormatRequest,
+    );
   }
 
   FormatRequestCopyWith<FormatRequest, FormatRequest, FormatRequest> get copyWith =>
-      _FormatRequestCopyWithImpl<FormatRequest, FormatRequest>(this as FormatRequest, $identity, $identity);
+      _FormatRequestCopyWithImpl<FormatRequest, FormatRequest>(
+        this as FormatRequest,
+        $identity,
+        $identity,
+      );
   @override
   String toString() {
-    return FormatRequestMapper.ensureInitialized().stringifyValue(this as FormatRequest);
+    return FormatRequestMapper.ensureInitialized().stringifyValue(
+      this as FormatRequest,
+    );
   }
 
   @override
   bool operator ==(Object other) {
-    return FormatRequestMapper.ensureInitialized().equalsValue(this as FormatRequest, other);
+    return FormatRequestMapper.ensureInitialized().equalsValue(
+      this as FormatRequest,
+      other,
+    );
   }
 
   @override
   int get hashCode {
-    return FormatRequestMapper.ensureInitialized().hashValue(this as FormatRequest);
+    return FormatRequestMapper.ensureInitialized().hashValue(
+      this as FormatRequest,
+    );
   }
 }
 
@@ -523,14 +648,22 @@ class _FormatRequestCopyWithImpl<$R, $Out> extends ClassCopyWithBase<$R, FormatR
   @override
   late final ClassMapperBase<FormatRequest> $mapper = FormatRequestMapper.ensureInitialized();
   @override
-  $R call({String? source, int? offset}) =>
-      $apply(FieldCopyWithData({if (source != null) #source: source, if (offset != null) #offset: offset}));
+  $R call({String? source, int? offset}) => $apply(
+        FieldCopyWithData({
+          if (source != null) #source: source,
+          if (offset != null) #offset: offset,
+        }),
+      );
   @override
-  FormatRequest $make(CopyWithData data) =>
-      FormatRequest(data.get(#source, or: $value.source), data.get(#offset, or: $value.offset));
+  FormatRequest $make(CopyWithData data) => FormatRequest(
+        data.get(#source, or: $value.source),
+        data.get(#offset, or: $value.offset),
+      );
 
   @override
-  FormatRequestCopyWith<$R2, FormatRequest, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t) =>
+  FormatRequestCopyWith<$R2, FormatRequest, $Out2> $chain<$R2, $Out2>(
+    Then<$Out2, $R2> t,
+  ) =>
       _FormatRequestCopyWithImpl<$R2, $Out2>($value, $cast, t);
 }
 
@@ -550,12 +683,15 @@ class AnalyzeResponseMapper extends ClassMapperBase<AnalyzeResponse> {
   final String id = 'AnalyzeResponse';
 
   static List<Issue> _$issues(AnalyzeResponse v) => v.issues;
-  static const Field<AnalyzeResponse, List<Issue>> _f$issues = Field('issues', _$issues, opt: true, def: const []);
+  static const Field<AnalyzeResponse, List<Issue>> _f$issues = Field(
+    'issues',
+    _$issues,
+    opt: true,
+    def: const [],
+  );
 
   @override
-  final MappableFields<AnalyzeResponse> fields = const {
-    #issues: _f$issues,
-  };
+  final MappableFields<AnalyzeResponse> fields = const {#issues: _f$issues};
 
   static AnalyzeResponse _instantiate(DecodingData data) {
     return AnalyzeResponse(data.dec(_f$issues));
@@ -579,24 +715,37 @@ mixin AnalyzeResponseMappable {
   }
 
   Map<String, dynamic> toMap() {
-    return AnalyzeResponseMapper.ensureInitialized().encodeMap<AnalyzeResponse>(this as AnalyzeResponse);
+    return AnalyzeResponseMapper.ensureInitialized().encodeMap<AnalyzeResponse>(
+      this as AnalyzeResponse,
+    );
   }
 
   AnalyzeResponseCopyWith<AnalyzeResponse, AnalyzeResponse, AnalyzeResponse> get copyWith =>
-      _AnalyzeResponseCopyWithImpl<AnalyzeResponse, AnalyzeResponse>(this as AnalyzeResponse, $identity, $identity);
+      _AnalyzeResponseCopyWithImpl<AnalyzeResponse, AnalyzeResponse>(
+        this as AnalyzeResponse,
+        $identity,
+        $identity,
+      );
   @override
   String toString() {
-    return AnalyzeResponseMapper.ensureInitialized().stringifyValue(this as AnalyzeResponse);
+    return AnalyzeResponseMapper.ensureInitialized().stringifyValue(
+      this as AnalyzeResponse,
+    );
   }
 
   @override
   bool operator ==(Object other) {
-    return AnalyzeResponseMapper.ensureInitialized().equalsValue(this as AnalyzeResponse, other);
+    return AnalyzeResponseMapper.ensureInitialized().equalsValue(
+      this as AnalyzeResponse,
+      other,
+    );
   }
 
   @override
   int get hashCode {
-    return AnalyzeResponseMapper.ensureInitialized().hashValue(this as AnalyzeResponse);
+    return AnalyzeResponseMapper.ensureInitialized().hashValue(
+      this as AnalyzeResponse,
+    );
   }
 }
 
@@ -608,7 +757,9 @@ extension AnalyzeResponseValueCopy<$R, $Out> on ObjectCopyWith<$R, AnalyzeRespon
 abstract class AnalyzeResponseCopyWith<$R, $In extends AnalyzeResponse, $Out> implements ClassCopyWith<$R, $In, $Out> {
   ListCopyWith<$R, Issue, IssueCopyWith<$R, Issue, Issue>> get issues;
   $R call({List<Issue>? issues});
-  AnalyzeResponseCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t);
+  AnalyzeResponseCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(
+    Then<$Out2, $R2> t,
+  );
 }
 
 class _AnalyzeResponseCopyWithImpl<$R, $Out> extends ClassCopyWithBase<$R, AnalyzeResponse, $Out>
@@ -618,15 +769,20 @@ class _AnalyzeResponseCopyWithImpl<$R, $Out> extends ClassCopyWithBase<$R, Analy
   @override
   late final ClassMapperBase<AnalyzeResponse> $mapper = AnalyzeResponseMapper.ensureInitialized();
   @override
-  ListCopyWith<$R, Issue, IssueCopyWith<$R, Issue, Issue>> get issues =>
-      ListCopyWith($value.issues, (v, t) => v.copyWith.$chain(t), (v) => call(issues: v));
+  ListCopyWith<$R, Issue, IssueCopyWith<$R, Issue, Issue>> get issues => ListCopyWith(
+        $value.issues,
+        (v, t) => v.copyWith.$chain(t),
+        (v) => call(issues: v),
+      );
   @override
   $R call({List<Issue>? issues}) => $apply(FieldCopyWithData({if (issues != null) #issues: issues}));
   @override
   AnalyzeResponse $make(CopyWithData data) => AnalyzeResponse(data.get(#issues, or: $value.issues));
 
   @override
-  AnalyzeResponseCopyWith<$R2, AnalyzeResponse, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t) =>
+  AnalyzeResponseCopyWith<$R2, AnalyzeResponse, $Out2> $chain<$R2, $Out2>(
+    Then<$Out2, $R2> t,
+  ) =>
       _AnalyzeResponseCopyWithImpl<$R2, $Out2>($value, $cast, t);
 }
 
@@ -649,15 +805,25 @@ class IssueMapper extends ClassMapperBase<Issue> {
   static IssueKind _$kind(Issue v) => v.kind;
   static const Field<Issue, IssueKind> _f$kind = Field('kind', _$kind);
   static IssueLocation _$location(Issue v) => v.location;
-  static const Field<Issue, IssueLocation> _f$location = Field('location', _$location);
+  static const Field<Issue, IssueLocation> _f$location = Field(
+    'location',
+    _$location,
+  );
   static String _$message(Issue v) => v.message;
   static const Field<Issue, String> _f$message = Field('message', _$message);
   static bool _$hasFixes(Issue v) => v.hasFixes;
   static const Field<Issue, bool> _f$hasFixes = Field('hasFixes', _$hasFixes);
   static String _$sourceName(Issue v) => v.sourceName;
-  static const Field<Issue, String> _f$sourceName = Field('sourceName', _$sourceName);
+  static const Field<Issue, String> _f$sourceName = Field(
+    'sourceName',
+    _$sourceName,
+  );
   static String? _$correction(Issue v) => v.correction;
-  static const Field<Issue, String> _f$correction = Field('correction', _$correction, opt: true);
+  static const Field<Issue, String> _f$correction = Field(
+    'correction',
+    _$correction,
+    opt: true,
+  );
   static String? _$url(Issue v) => v.url;
   static const Field<Issue, String> _f$url = Field('url', _$url, opt: true);
 
@@ -674,13 +840,14 @@ class IssueMapper extends ClassMapperBase<Issue> {
 
   static Issue _instantiate(DecodingData data) {
     return Issue(
-        kind: data.dec(_f$kind),
-        location: data.dec(_f$location),
-        message: data.dec(_f$message),
-        hasFixes: data.dec(_f$hasFixes),
-        sourceName: data.dec(_f$sourceName),
-        correction: data.dec(_f$correction),
-        url: data.dec(_f$url));
+      kind: data.dec(_f$kind),
+      location: data.dec(_f$location),
+      message: data.dec(_f$message),
+      hasFixes: data.dec(_f$hasFixes),
+      sourceName: data.dec(_f$sourceName),
+      correction: data.dec(_f$correction),
+      url: data.dec(_f$url),
+    );
   }
 
   @override
@@ -728,14 +895,15 @@ extension IssueValueCopy<$R, $Out> on ObjectCopyWith<$R, Issue, $Out> {
 
 abstract class IssueCopyWith<$R, $In extends Issue, $Out> implements ClassCopyWith<$R, $In, $Out> {
   IssueLocationCopyWith<$R, IssueLocation, IssueLocation> get location;
-  $R call(
-      {IssueKind? kind,
-      IssueLocation? location,
-      String? message,
-      bool? hasFixes,
-      String? sourceName,
-      String? correction,
-      String? url});
+  $R call({
+    IssueKind? kind,
+    IssueLocation? location,
+    String? message,
+    bool? hasFixes,
+    String? sourceName,
+    String? correction,
+    String? url,
+  });
   IssueCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t);
 }
 
@@ -749,32 +917,36 @@ class _IssueCopyWithImpl<$R, $Out> extends ClassCopyWithBase<$R, Issue, $Out>
   IssueLocationCopyWith<$R, IssueLocation, IssueLocation> get location =>
       $value.location.copyWith.$chain((v) => call(location: v));
   @override
-  $R call(
-          {IssueKind? kind,
-          IssueLocation? location,
-          String? message,
-          bool? hasFixes,
-          String? sourceName,
-          Object? correction = $none,
-          Object? url = $none}) =>
-      $apply(FieldCopyWithData({
-        if (kind != null) #kind: kind,
-        if (location != null) #location: location,
-        if (message != null) #message: message,
-        if (hasFixes != null) #hasFixes: hasFixes,
-        if (sourceName != null) #sourceName: sourceName,
-        if (correction != $none) #correction: correction,
-        if (url != $none) #url: url
-      }));
+  $R call({
+    IssueKind? kind,
+    IssueLocation? location,
+    String? message,
+    bool? hasFixes,
+    String? sourceName,
+    Object? correction = $none,
+    Object? url = $none,
+  }) =>
+      $apply(
+        FieldCopyWithData({
+          if (kind != null) #kind: kind,
+          if (location != null) #location: location,
+          if (message != null) #message: message,
+          if (hasFixes != null) #hasFixes: hasFixes,
+          if (sourceName != null) #sourceName: sourceName,
+          if (correction != $none) #correction: correction,
+          if (url != $none) #url: url,
+        }),
+      );
   @override
   Issue $make(CopyWithData data) => Issue(
-      kind: data.get(#kind, or: $value.kind),
-      location: data.get(#location, or: $value.location),
-      message: data.get(#message, or: $value.message),
-      hasFixes: data.get(#hasFixes, or: $value.hasFixes),
-      sourceName: data.get(#sourceName, or: $value.sourceName),
-      correction: data.get(#correction, or: $value.correction),
-      url: data.get(#url, or: $value.url));
+        kind: data.get(#kind, or: $value.kind),
+        location: data.get(#location, or: $value.location),
+        message: data.get(#message, or: $value.message),
+        hasFixes: data.get(#hasFixes, or: $value.hasFixes),
+        sourceName: data.get(#sourceName, or: $value.sourceName),
+        correction: data.get(#correction, or: $value.correction),
+        url: data.get(#url, or: $value.url),
+      );
 
   @override
   IssueCopyWith<$R2, Issue, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t) =>
@@ -796,13 +968,25 @@ class IssueLocationMapper extends ClassMapperBase<IssueLocation> {
   final String id = 'IssueLocation';
 
   static int _$startLine(IssueLocation v) => v.startLine;
-  static const Field<IssueLocation, int> _f$startLine = Field('startLine', _$startLine);
+  static const Field<IssueLocation, int> _f$startLine = Field(
+    'startLine',
+    _$startLine,
+  );
   static int _$endLine(IssueLocation v) => v.endLine;
-  static const Field<IssueLocation, int> _f$endLine = Field('endLine', _$endLine);
+  static const Field<IssueLocation, int> _f$endLine = Field(
+    'endLine',
+    _$endLine,
+  );
   static int _$startColumn(IssueLocation v) => v.startColumn;
-  static const Field<IssueLocation, int> _f$startColumn = Field('startColumn', _$startColumn);
+  static const Field<IssueLocation, int> _f$startColumn = Field(
+    'startColumn',
+    _$startColumn,
+  );
   static int _$endColumn(IssueLocation v) => v.endColumn;
-  static const Field<IssueLocation, int> _f$endColumn = Field('endColumn', _$endColumn);
+  static const Field<IssueLocation, int> _f$endColumn = Field(
+    'endColumn',
+    _$endColumn,
+  );
 
   @override
   final MappableFields<IssueLocation> fields = const {
@@ -814,10 +998,11 @@ class IssueLocationMapper extends ClassMapperBase<IssueLocation> {
 
   static IssueLocation _instantiate(DecodingData data) {
     return IssueLocation(
-        startLine: data.dec(_f$startLine),
-        endLine: data.dec(_f$endLine),
-        startColumn: data.dec(_f$startColumn),
-        endColumn: data.dec(_f$endColumn));
+      startLine: data.dec(_f$startLine),
+      endLine: data.dec(_f$endLine),
+      startColumn: data.dec(_f$startColumn),
+      endColumn: data.dec(_f$endColumn),
+    );
   }
 
   @override
@@ -834,28 +1019,43 @@ class IssueLocationMapper extends ClassMapperBase<IssueLocation> {
 
 mixin IssueLocationMappable {
   String toJson() {
-    return IssueLocationMapper.ensureInitialized().encodeJson<IssueLocation>(this as IssueLocation);
+    return IssueLocationMapper.ensureInitialized().encodeJson<IssueLocation>(
+      this as IssueLocation,
+    );
   }
 
   Map<String, dynamic> toMap() {
-    return IssueLocationMapper.ensureInitialized().encodeMap<IssueLocation>(this as IssueLocation);
+    return IssueLocationMapper.ensureInitialized().encodeMap<IssueLocation>(
+      this as IssueLocation,
+    );
   }
 
   IssueLocationCopyWith<IssueLocation, IssueLocation, IssueLocation> get copyWith =>
-      _IssueLocationCopyWithImpl<IssueLocation, IssueLocation>(this as IssueLocation, $identity, $identity);
+      _IssueLocationCopyWithImpl<IssueLocation, IssueLocation>(
+        this as IssueLocation,
+        $identity,
+        $identity,
+      );
   @override
   String toString() {
-    return IssueLocationMapper.ensureInitialized().stringifyValue(this as IssueLocation);
+    return IssueLocationMapper.ensureInitialized().stringifyValue(
+      this as IssueLocation,
+    );
   }
 
   @override
   bool operator ==(Object other) {
-    return IssueLocationMapper.ensureInitialized().equalsValue(this as IssueLocation, other);
+    return IssueLocationMapper.ensureInitialized().equalsValue(
+      this as IssueLocation,
+      other,
+    );
   }
 
   @override
   int get hashCode {
-    return IssueLocationMapper.ensureInitialized().hashValue(this as IssueLocation);
+    return IssueLocationMapper.ensureInitialized().hashValue(
+      this as IssueLocation,
+    );
   }
 }
 
@@ -876,21 +1076,26 @@ class _IssueLocationCopyWithImpl<$R, $Out> extends ClassCopyWithBase<$R, IssueLo
   @override
   late final ClassMapperBase<IssueLocation> $mapper = IssueLocationMapper.ensureInitialized();
   @override
-  $R call({int? startLine, int? endLine, int? startColumn, int? endColumn}) => $apply(FieldCopyWithData({
-        if (startLine != null) #startLine: startLine,
-        if (endLine != null) #endLine: endLine,
-        if (startColumn != null) #startColumn: startColumn,
-        if (endColumn != null) #endColumn: endColumn
-      }));
+  $R call({int? startLine, int? endLine, int? startColumn, int? endColumn}) => $apply(
+        FieldCopyWithData({
+          if (startLine != null) #startLine: startLine,
+          if (endLine != null) #endLine: endLine,
+          if (startColumn != null) #startColumn: startColumn,
+          if (endColumn != null) #endColumn: endColumn,
+        }),
+      );
   @override
   IssueLocation $make(CopyWithData data) => IssueLocation(
-      startLine: data.get(#startLine, or: $value.startLine),
-      endLine: data.get(#endLine, or: $value.endLine),
-      startColumn: data.get(#startColumn, or: $value.startColumn),
-      endColumn: data.get(#endColumn, or: $value.endColumn));
+        startLine: data.get(#startLine, or: $value.startLine),
+        endLine: data.get(#endLine, or: $value.endLine),
+        startColumn: data.get(#startColumn, or: $value.startColumn),
+        endColumn: data.get(#endColumn, or: $value.endColumn),
+      );
 
   @override
-  IssueLocationCopyWith<$R2, IssueLocation, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t) =>
+  IssueLocationCopyWith<$R2, IssueLocation, $Out2> $chain<$R2, $Out2>(
+    Then<$Out2, $R2> t,
+  ) =>
       _IssueLocationCopyWithImpl<$R2, $Out2>($value, $cast, t);
 }
 
@@ -910,9 +1115,15 @@ class DocumentResponseMapper extends ClassMapperBase<DocumentResponse> {
   final String id = 'DocumentResponse';
 
   static HoverInfo _$info(DocumentResponse v) => v.info;
-  static const Field<DocumentResponse, HoverInfo> _f$info = Field('info', _$info);
+  static const Field<DocumentResponse, HoverInfo> _f$info = Field(
+    'info',
+    _$info,
+  );
   static String? _$error(DocumentResponse v) => v.error;
-  static const Field<DocumentResponse, String> _f$error = Field('error', _$error);
+  static const Field<DocumentResponse, String> _f$error = Field(
+    'error',
+    _$error,
+  );
 
   @override
   final MappableFields<DocumentResponse> fields = const {
@@ -946,20 +1157,31 @@ mixin DocumentResponseMappable {
   }
 
   DocumentResponseCopyWith<DocumentResponse, DocumentResponse, DocumentResponse> get copyWith =>
-      _DocumentResponseCopyWithImpl<DocumentResponse, DocumentResponse>(this as DocumentResponse, $identity, $identity);
+      _DocumentResponseCopyWithImpl<DocumentResponse, DocumentResponse>(
+        this as DocumentResponse,
+        $identity,
+        $identity,
+      );
   @override
   String toString() {
-    return DocumentResponseMapper.ensureInitialized().stringifyValue(this as DocumentResponse);
+    return DocumentResponseMapper.ensureInitialized().stringifyValue(
+      this as DocumentResponse,
+    );
   }
 
   @override
   bool operator ==(Object other) {
-    return DocumentResponseMapper.ensureInitialized().equalsValue(this as DocumentResponse, other);
+    return DocumentResponseMapper.ensureInitialized().equalsValue(
+      this as DocumentResponse,
+      other,
+    );
   }
 
   @override
   int get hashCode {
-    return DocumentResponseMapper.ensureInitialized().hashValue(this as DocumentResponse);
+    return DocumentResponseMapper.ensureInitialized().hashValue(
+      this as DocumentResponse,
+    );
   }
 }
 
@@ -972,7 +1194,9 @@ abstract class DocumentResponseCopyWith<$R, $In extends DocumentResponse, $Out>
     implements ClassCopyWith<$R, $In, $Out> {
   HoverInfoCopyWith<$R, HoverInfo, HoverInfo> get info;
   $R call({HoverInfo? info, String? error});
-  DocumentResponseCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t);
+  DocumentResponseCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(
+    Then<$Out2, $R2> t,
+  );
 }
 
 class _DocumentResponseCopyWithImpl<$R, $Out> extends ClassCopyWithBase<$R, DocumentResponse, $Out>
@@ -984,14 +1208,22 @@ class _DocumentResponseCopyWithImpl<$R, $Out> extends ClassCopyWithBase<$R, Docu
   @override
   HoverInfoCopyWith<$R, HoverInfo, HoverInfo> get info => $value.info.copyWith.$chain((v) => call(info: v));
   @override
-  $R call({HoverInfo? info, Object? error = $none}) =>
-      $apply(FieldCopyWithData({if (info != null) #info: info, if (error != $none) #error: error}));
+  $R call({HoverInfo? info, Object? error = $none}) => $apply(
+        FieldCopyWithData({
+          if (info != null) #info: info,
+          if (error != $none) #error: error,
+        }),
+      );
   @override
-  DocumentResponse $make(CopyWithData data) =>
-      DocumentResponse(data.get(#info, or: $value.info), data.get(#error, or: $value.error));
+  DocumentResponse $make(CopyWithData data) => DocumentResponse(
+        data.get(#info, or: $value.info),
+        data.get(#error, or: $value.error),
+      );
 
   @override
-  DocumentResponseCopyWith<$R2, DocumentResponse, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t) =>
+  DocumentResponseCopyWith<$R2, DocumentResponse, $Out2> $chain<$R2, $Out2>(
+    Then<$Out2, $R2> t,
+  ) =>
       _DocumentResponseCopyWithImpl<$R2, $Out2>($value, $cast, t);
 }
 
@@ -1010,24 +1242,59 @@ class HoverInfoMapper extends ClassMapperBase<HoverInfo> {
   final String id = 'HoverInfo';
 
   static String? _$description(HoverInfo v) => v.description;
-  static const Field<HoverInfo, String> _f$description = Field('description', _$description, opt: true);
+  static const Field<HoverInfo, String> _f$description = Field(
+    'description',
+    _$description,
+    opt: true,
+  );
   static String? _$kind(HoverInfo v) => v.kind;
-  static const Field<HoverInfo, String> _f$kind = Field('kind', _$kind, opt: true);
+  static const Field<HoverInfo, String> _f$kind = Field(
+    'kind',
+    _$kind,
+    opt: true,
+  );
   static String? _$dartdoc(HoverInfo v) => v.dartdoc;
-  static const Field<HoverInfo, String> _f$dartdoc = Field('dartdoc', _$dartdoc, opt: true);
+  static const Field<HoverInfo, String> _f$dartdoc = Field(
+    'dartdoc',
+    _$dartdoc,
+    opt: true,
+  );
   static String? _$enclosingClassName(HoverInfo v) => v.enclosingClassName;
-  static const Field<HoverInfo, String> _f$enclosingClassName =
-      Field('enclosingClassName', _$enclosingClassName, opt: true);
+  static const Field<HoverInfo, String> _f$enclosingClassName = Field(
+    'enclosingClassName',
+    _$enclosingClassName,
+    opt: true,
+  );
   static String? _$libraryName(HoverInfo v) => v.libraryName;
-  static const Field<HoverInfo, String> _f$libraryName = Field('libraryName', _$libraryName, opt: true);
+  static const Field<HoverInfo, String> _f$libraryName = Field(
+    'libraryName',
+    _$libraryName,
+    opt: true,
+  );
   static String? _$parameter(HoverInfo v) => v.parameter;
-  static const Field<HoverInfo, String> _f$parameter = Field('parameter', _$parameter, opt: true);
+  static const Field<HoverInfo, String> _f$parameter = Field(
+    'parameter',
+    _$parameter,
+    opt: true,
+  );
   static bool? _$deprecated(HoverInfo v) => v.deprecated;
-  static const Field<HoverInfo, bool> _f$deprecated = Field('deprecated', _$deprecated, opt: true);
+  static const Field<HoverInfo, bool> _f$deprecated = Field(
+    'deprecated',
+    _$deprecated,
+    opt: true,
+  );
   static String? _$staticType(HoverInfo v) => v.staticType;
-  static const Field<HoverInfo, String> _f$staticType = Field('staticType', _$staticType, opt: true);
+  static const Field<HoverInfo, String> _f$staticType = Field(
+    'staticType',
+    _$staticType,
+    opt: true,
+  );
   static String? _$propagatedType(HoverInfo v) => v.propagatedType;
-  static const Field<HoverInfo, String> _f$propagatedType = Field('propagatedType', _$propagatedType, opt: true);
+  static const Field<HoverInfo, String> _f$propagatedType = Field(
+    'propagatedType',
+    _$propagatedType,
+    opt: true,
+  );
 
   @override
   final MappableFields<HoverInfo> fields = const {
@@ -1044,15 +1311,16 @@ class HoverInfoMapper extends ClassMapperBase<HoverInfo> {
 
   static HoverInfo _instantiate(DecodingData data) {
     return HoverInfo(
-        description: data.dec(_f$description),
-        kind: data.dec(_f$kind),
-        dartdoc: data.dec(_f$dartdoc),
-        enclosingClassName: data.dec(_f$enclosingClassName),
-        libraryName: data.dec(_f$libraryName),
-        parameter: data.dec(_f$parameter),
-        deprecated: data.dec(_f$deprecated),
-        staticType: data.dec(_f$staticType),
-        propagatedType: data.dec(_f$propagatedType));
+      description: data.dec(_f$description),
+      kind: data.dec(_f$kind),
+      dartdoc: data.dec(_f$dartdoc),
+      enclosingClassName: data.dec(_f$enclosingClassName),
+      libraryName: data.dec(_f$libraryName),
+      parameter: data.dec(_f$parameter),
+      deprecated: data.dec(_f$deprecated),
+      staticType: data.dec(_f$staticType),
+      propagatedType: data.dec(_f$propagatedType),
+    );
   }
 
   @override
@@ -1069,23 +1337,35 @@ class HoverInfoMapper extends ClassMapperBase<HoverInfo> {
 
 mixin HoverInfoMappable {
   String toJson() {
-    return HoverInfoMapper.ensureInitialized().encodeJson<HoverInfo>(this as HoverInfo);
+    return HoverInfoMapper.ensureInitialized().encodeJson<HoverInfo>(
+      this as HoverInfo,
+    );
   }
 
   Map<String, dynamic> toMap() {
-    return HoverInfoMapper.ensureInitialized().encodeMap<HoverInfo>(this as HoverInfo);
+    return HoverInfoMapper.ensureInitialized().encodeMap<HoverInfo>(
+      this as HoverInfo,
+    );
   }
 
-  HoverInfoCopyWith<HoverInfo, HoverInfo, HoverInfo> get copyWith =>
-      _HoverInfoCopyWithImpl<HoverInfo, HoverInfo>(this as HoverInfo, $identity, $identity);
+  HoverInfoCopyWith<HoverInfo, HoverInfo, HoverInfo> get copyWith => _HoverInfoCopyWithImpl<HoverInfo, HoverInfo>(
+        this as HoverInfo,
+        $identity,
+        $identity,
+      );
   @override
   String toString() {
-    return HoverInfoMapper.ensureInitialized().stringifyValue(this as HoverInfo);
+    return HoverInfoMapper.ensureInitialized().stringifyValue(
+      this as HoverInfo,
+    );
   }
 
   @override
   bool operator ==(Object other) {
-    return HoverInfoMapper.ensureInitialized().equalsValue(this as HoverInfo, other);
+    return HoverInfoMapper.ensureInitialized().equalsValue(
+      this as HoverInfo,
+      other,
+    );
   }
 
   @override
@@ -1100,16 +1380,17 @@ extension HoverInfoValueCopy<$R, $Out> on ObjectCopyWith<$R, HoverInfo, $Out> {
 }
 
 abstract class HoverInfoCopyWith<$R, $In extends HoverInfo, $Out> implements ClassCopyWith<$R, $In, $Out> {
-  $R call(
-      {String? description,
-      String? kind,
-      String? dartdoc,
-      String? enclosingClassName,
-      String? libraryName,
-      String? parameter,
-      bool? deprecated,
-      String? staticType,
-      String? propagatedType});
+  $R call({
+    String? description,
+    String? kind,
+    String? dartdoc,
+    String? enclosingClassName,
+    String? libraryName,
+    String? parameter,
+    bool? deprecated,
+    String? staticType,
+    String? propagatedType,
+  });
   HoverInfoCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t);
 }
 
@@ -1120,41 +1401,50 @@ class _HoverInfoCopyWithImpl<$R, $Out> extends ClassCopyWithBase<$R, HoverInfo, 
   @override
   late final ClassMapperBase<HoverInfo> $mapper = HoverInfoMapper.ensureInitialized();
   @override
-  $R call(
-          {Object? description = $none,
-          Object? kind = $none,
-          Object? dartdoc = $none,
-          Object? enclosingClassName = $none,
-          Object? libraryName = $none,
-          Object? parameter = $none,
-          Object? deprecated = $none,
-          Object? staticType = $none,
-          Object? propagatedType = $none}) =>
-      $apply(FieldCopyWithData({
-        if (description != $none) #description: description,
-        if (kind != $none) #kind: kind,
-        if (dartdoc != $none) #dartdoc: dartdoc,
-        if (enclosingClassName != $none) #enclosingClassName: enclosingClassName,
-        if (libraryName != $none) #libraryName: libraryName,
-        if (parameter != $none) #parameter: parameter,
-        if (deprecated != $none) #deprecated: deprecated,
-        if (staticType != $none) #staticType: staticType,
-        if (propagatedType != $none) #propagatedType: propagatedType
-      }));
+  $R call({
+    Object? description = $none,
+    Object? kind = $none,
+    Object? dartdoc = $none,
+    Object? enclosingClassName = $none,
+    Object? libraryName = $none,
+    Object? parameter = $none,
+    Object? deprecated = $none,
+    Object? staticType = $none,
+    Object? propagatedType = $none,
+  }) =>
+      $apply(
+        FieldCopyWithData({
+          if (description != $none) #description: description,
+          if (kind != $none) #kind: kind,
+          if (dartdoc != $none) #dartdoc: dartdoc,
+          if (enclosingClassName != $none) #enclosingClassName: enclosingClassName,
+          if (libraryName != $none) #libraryName: libraryName,
+          if (parameter != $none) #parameter: parameter,
+          if (deprecated != $none) #deprecated: deprecated,
+          if (staticType != $none) #staticType: staticType,
+          if (propagatedType != $none) #propagatedType: propagatedType,
+        }),
+      );
   @override
   HoverInfo $make(CopyWithData data) => HoverInfo(
-      description: data.get(#description, or: $value.description),
-      kind: data.get(#kind, or: $value.kind),
-      dartdoc: data.get(#dartdoc, or: $value.dartdoc),
-      enclosingClassName: data.get(#enclosingClassName, or: $value.enclosingClassName),
-      libraryName: data.get(#libraryName, or: $value.libraryName),
-      parameter: data.get(#parameter, or: $value.parameter),
-      deprecated: data.get(#deprecated, or: $value.deprecated),
-      staticType: data.get(#staticType, or: $value.staticType),
-      propagatedType: data.get(#propagatedType, or: $value.propagatedType));
+        description: data.get(#description, or: $value.description),
+        kind: data.get(#kind, or: $value.kind),
+        dartdoc: data.get(#dartdoc, or: $value.dartdoc),
+        enclosingClassName: data.get(
+          #enclosingClassName,
+          or: $value.enclosingClassName,
+        ),
+        libraryName: data.get(#libraryName, or: $value.libraryName),
+        parameter: data.get(#parameter, or: $value.parameter),
+        deprecated: data.get(#deprecated, or: $value.deprecated),
+        staticType: data.get(#staticType, or: $value.staticType),
+        propagatedType: data.get(#propagatedType, or: $value.propagatedType),
+      );
 
   @override
-  HoverInfoCopyWith<$R2, HoverInfo, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t) =>
+  HoverInfoCopyWith<$R2, HoverInfo, $Out2> $chain<$R2, $Out2>(
+    Then<$Out2, $R2> t,
+  ) =>
       _HoverInfoCopyWithImpl<$R2, $Out2>($value, $cast, t);
 }
 
@@ -1173,11 +1463,17 @@ class DocumentRequestMapper extends ClassMapperBase<DocumentRequest> {
   final String id = 'DocumentRequest';
 
   static Map<String, String> _$sources(DocumentRequest v) => v.sources;
-  static const Field<DocumentRequest, Map<String, String>> _f$sources = Field('sources', _$sources);
+  static const Field<DocumentRequest, Map<String, String>> _f$sources = Field(
+    'sources',
+    _$sources,
+  );
   static String _$name(DocumentRequest v) => v.name;
   static const Field<DocumentRequest, String> _f$name = Field('name', _$name);
   static int _$offset(DocumentRequest v) => v.offset;
-  static const Field<DocumentRequest, int> _f$offset = Field('offset', _$offset);
+  static const Field<DocumentRequest, int> _f$offset = Field(
+    'offset',
+    _$offset,
+  );
 
   @override
   final MappableFields<DocumentRequest> fields = const {
@@ -1187,7 +1483,11 @@ class DocumentRequestMapper extends ClassMapperBase<DocumentRequest> {
   };
 
   static DocumentRequest _instantiate(DecodingData data) {
-    return DocumentRequest(data.dec(_f$sources), data.dec(_f$name), data.dec(_f$offset));
+    return DocumentRequest(
+      data.dec(_f$sources),
+      data.dec(_f$name),
+      data.dec(_f$offset),
+    );
   }
 
   @override
@@ -1208,24 +1508,37 @@ mixin DocumentRequestMappable {
   }
 
   Map<String, dynamic> toMap() {
-    return DocumentRequestMapper.ensureInitialized().encodeMap<DocumentRequest>(this as DocumentRequest);
+    return DocumentRequestMapper.ensureInitialized().encodeMap<DocumentRequest>(
+      this as DocumentRequest,
+    );
   }
 
   DocumentRequestCopyWith<DocumentRequest, DocumentRequest, DocumentRequest> get copyWith =>
-      _DocumentRequestCopyWithImpl<DocumentRequest, DocumentRequest>(this as DocumentRequest, $identity, $identity);
+      _DocumentRequestCopyWithImpl<DocumentRequest, DocumentRequest>(
+        this as DocumentRequest,
+        $identity,
+        $identity,
+      );
   @override
   String toString() {
-    return DocumentRequestMapper.ensureInitialized().stringifyValue(this as DocumentRequest);
+    return DocumentRequestMapper.ensureInitialized().stringifyValue(
+      this as DocumentRequest,
+    );
   }
 
   @override
   bool operator ==(Object other) {
-    return DocumentRequestMapper.ensureInitialized().equalsValue(this as DocumentRequest, other);
+    return DocumentRequestMapper.ensureInitialized().equalsValue(
+      this as DocumentRequest,
+      other,
+    );
   }
 
   @override
   int get hashCode {
-    return DocumentRequestMapper.ensureInitialized().hashValue(this as DocumentRequest);
+    return DocumentRequestMapper.ensureInitialized().hashValue(
+      this as DocumentRequest,
+    );
   }
 }
 
@@ -1237,7 +1550,9 @@ extension DocumentRequestValueCopy<$R, $Out> on ObjectCopyWith<$R, DocumentReque
 abstract class DocumentRequestCopyWith<$R, $In extends DocumentRequest, $Out> implements ClassCopyWith<$R, $In, $Out> {
   MapCopyWith<$R, String, String, ObjectCopyWith<$R, String, String>> get sources;
   $R call({Map<String, String>? sources, String? name, int? offset});
-  DocumentRequestCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t);
+  DocumentRequestCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(
+    Then<$Out2, $R2> t,
+  );
 }
 
 class _DocumentRequestCopyWithImpl<$R, $Out> extends ClassCopyWithBase<$R, DocumentRequest, $Out>
@@ -1247,16 +1562,29 @@ class _DocumentRequestCopyWithImpl<$R, $Out> extends ClassCopyWithBase<$R, Docum
   @override
   late final ClassMapperBase<DocumentRequest> $mapper = DocumentRequestMapper.ensureInitialized();
   @override
-  MapCopyWith<$R, String, String, ObjectCopyWith<$R, String, String>> get sources =>
-      MapCopyWith($value.sources, (v, t) => ObjectCopyWith(v, $identity, t), (v) => call(sources: v));
+  MapCopyWith<$R, String, String, ObjectCopyWith<$R, String, String>> get sources => MapCopyWith(
+        $value.sources,
+        (v, t) => ObjectCopyWith(v, $identity, t),
+        (v) => call(sources: v),
+      );
   @override
-  $R call({Map<String, String>? sources, String? name, int? offset}) => $apply(FieldCopyWithData(
-      {if (sources != null) #sources: sources, if (name != null) #name: name, if (offset != null) #offset: offset}));
+  $R call({Map<String, String>? sources, String? name, int? offset}) => $apply(
+        FieldCopyWithData({
+          if (sources != null) #sources: sources,
+          if (name != null) #name: name,
+          if (offset != null) #offset: offset,
+        }),
+      );
   @override
   DocumentRequest $make(CopyWithData data) => DocumentRequest(
-      data.get(#sources, or: $value.sources), data.get(#name, or: $value.name), data.get(#offset, or: $value.offset));
+        data.get(#sources, or: $value.sources),
+        data.get(#name, or: $value.name),
+        data.get(#offset, or: $value.offset),
+      );
 
   @override
-  DocumentRequestCopyWith<$R2, DocumentRequest, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t) =>
+  DocumentRequestCopyWith<$R2, DocumentRequest, $Out2> $chain<$R2, $Out2>(
+    Then<$Out2, $R2> t,
+  ) =>
       _DocumentRequestCopyWithImpl<$R2, $Out2>($value, $cast, t);
 }

--- a/apps/jaspr_pad/lib/models/gist.mapper.dart
+++ b/apps/jaspr_pad/lib/models/gist.mapper.dart
@@ -1,5 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format off
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, unnecessary_cast, override_on_non_overriding_member
 // ignore_for_file: strict_raw_type, inference_failure_on_untyped_parameter
@@ -24,9 +25,15 @@ class GistDataMapper extends ClassMapperBase<GistData> {
   static String? _$id(GistData v) => v.id;
   static const Field<GistData, String> _f$id = Field('id', _$id);
   static String? _$description(GistData v) => v.description;
-  static const Field<GistData, String> _f$description = Field('description', _$description);
+  static const Field<GistData, String> _f$description = Field(
+    'description',
+    _$description,
+  );
   static Map<String, GistFile> _$files(GistData v) => v.files;
-  static const Field<GistData, Map<String, GistFile>> _f$files = Field('files', _$files);
+  static const Field<GistData, Map<String, GistFile>> _f$files = Field(
+    'files',
+    _$files,
+  );
 
   @override
   final MappableFields<GistData> fields = const {
@@ -36,7 +43,11 @@ class GistDataMapper extends ClassMapperBase<GistData> {
   };
 
   static GistData _instantiate(DecodingData data) {
-    return GistData(data.dec(_f$id), data.dec(_f$description), data.dec(_f$files));
+    return GistData(
+      data.dec(_f$id),
+      data.dec(_f$description),
+      data.dec(_f$files),
+    );
   }
 
   @override
@@ -53,15 +64,22 @@ class GistDataMapper extends ClassMapperBase<GistData> {
 
 mixin GistDataMappable {
   String toJson() {
-    return GistDataMapper.ensureInitialized().encodeJson<GistData>(this as GistData);
+    return GistDataMapper.ensureInitialized().encodeJson<GistData>(
+      this as GistData,
+    );
   }
 
   Map<String, dynamic> toMap() {
-    return GistDataMapper.ensureInitialized().encodeMap<GistData>(this as GistData);
+    return GistDataMapper.ensureInitialized().encodeMap<GistData>(
+      this as GistData,
+    );
   }
 
-  GistDataCopyWith<GistData, GistData, GistData> get copyWith =>
-      _GistDataCopyWithImpl<GistData, GistData>(this as GistData, $identity, $identity);
+  GistDataCopyWith<GistData, GistData, GistData> get copyWith => _GistDataCopyWithImpl<GistData, GistData>(
+        this as GistData,
+        $identity,
+        $identity,
+      );
   @override
   String toString() {
     return GistDataMapper.ensureInitialized().stringifyValue(this as GistData);
@@ -69,7 +87,10 @@ mixin GistDataMappable {
 
   @override
   bool operator ==(Object other) {
-    return GistDataMapper.ensureInitialized().equalsValue(this as GistData, other);
+    return GistDataMapper.ensureInitialized().equalsValue(
+      this as GistData,
+      other,
+    );
   }
 
   @override
@@ -96,20 +117,35 @@ class _GistDataCopyWithImpl<$R, $Out> extends ClassCopyWithBase<$R, GistData, $O
   @override
   late final ClassMapperBase<GistData> $mapper = GistDataMapper.ensureInitialized();
   @override
-  MapCopyWith<$R, String, GistFile, GistFileCopyWith<$R, GistFile, GistFile>> get files =>
-      MapCopyWith($value.files, (v, t) => v.copyWith.$chain(t), (v) => call(files: v));
+  MapCopyWith<$R, String, GistFile, GistFileCopyWith<$R, GistFile, GistFile>> get files => MapCopyWith(
+        $value.files,
+        (v, t) => v.copyWith.$chain(t),
+        (v) => call(files: v),
+      );
   @override
-  $R call({Object? id = $none, Object? description = $none, Map<String, GistFile>? files}) => $apply(FieldCopyWithData({
-        if (id != $none) #id: id,
-        if (description != $none) #description: description,
-        if (files != null) #files: files
-      }));
+  $R call({
+    Object? id = $none,
+    Object? description = $none,
+    Map<String, GistFile>? files,
+  }) =>
+      $apply(
+        FieldCopyWithData({
+          if (id != $none) #id: id,
+          if (description != $none) #description: description,
+          if (files != null) #files: files,
+        }),
+      );
   @override
   GistData $make(CopyWithData data) => GistData(
-      data.get(#id, or: $value.id), data.get(#description, or: $value.description), data.get(#files, or: $value.files));
+        data.get(#id, or: $value.id),
+        data.get(#description, or: $value.description),
+        data.get(#files, or: $value.files),
+      );
 
   @override
-  GistDataCopyWith<$R2, GistData, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t) =>
+  GistDataCopyWith<$R2, GistData, $Out2> $chain<$R2, $Out2>(
+    Then<$Out2, $R2> t,
+  ) =>
       _GistDataCopyWithImpl<$R2, $Out2>($value, $cast, t);
 }
 
@@ -128,7 +164,11 @@ class GistFileMapper extends ClassMapperBase<GistFile> {
   final String id = 'GistFile';
 
   static String _$name(GistFile v) => v.name;
-  static const Field<GistFile, String> _f$name = Field('name', _$name, key: r'filename');
+  static const Field<GistFile, String> _f$name = Field(
+    'name',
+    _$name,
+    key: r'filename',
+  );
   static String _$content(GistFile v) => v.content;
   static const Field<GistFile, String> _f$content = Field('content', _$content);
   static String _$type(GistFile v) => v.type;
@@ -159,15 +199,22 @@ class GistFileMapper extends ClassMapperBase<GistFile> {
 
 mixin GistFileMappable {
   String toJson() {
-    return GistFileMapper.ensureInitialized().encodeJson<GistFile>(this as GistFile);
+    return GistFileMapper.ensureInitialized().encodeJson<GistFile>(
+      this as GistFile,
+    );
   }
 
   Map<String, dynamic> toMap() {
-    return GistFileMapper.ensureInitialized().encodeMap<GistFile>(this as GistFile);
+    return GistFileMapper.ensureInitialized().encodeMap<GistFile>(
+      this as GistFile,
+    );
   }
 
-  GistFileCopyWith<GistFile, GistFile, GistFile> get copyWith =>
-      _GistFileCopyWithImpl<GistFile, GistFile>(this as GistFile, $identity, $identity);
+  GistFileCopyWith<GistFile, GistFile, GistFile> get copyWith => _GistFileCopyWithImpl<GistFile, GistFile>(
+        this as GistFile,
+        $identity,
+        $identity,
+      );
   @override
   String toString() {
     return GistFileMapper.ensureInitialized().stringifyValue(this as GistFile);
@@ -175,7 +222,10 @@ mixin GistFileMappable {
 
   @override
   bool operator ==(Object other) {
-    return GistFileMapper.ensureInitialized().equalsValue(this as GistFile, other);
+    return GistFileMapper.ensureInitialized().equalsValue(
+      this as GistFile,
+      other,
+    );
   }
 
   @override
@@ -201,13 +251,23 @@ class _GistFileCopyWithImpl<$R, $Out> extends ClassCopyWithBase<$R, GistFile, $O
   @override
   late final ClassMapperBase<GistFile> $mapper = GistFileMapper.ensureInitialized();
   @override
-  $R call({String? name, String? content, String? type}) => $apply(FieldCopyWithData(
-      {if (name != null) #name: name, if (content != null) #content: content, if (type != null) #type: type}));
+  $R call({String? name, String? content, String? type}) => $apply(
+        FieldCopyWithData({
+          if (name != null) #name: name,
+          if (content != null) #content: content,
+          if (type != null) #type: type,
+        }),
+      );
   @override
   GistFile $make(CopyWithData data) => GistFile(
-      data.get(#name, or: $value.name), data.get(#content, or: $value.content), data.get(#type, or: $value.type));
+        data.get(#name, or: $value.name),
+        data.get(#content, or: $value.content),
+        data.get(#type, or: $value.type),
+      );
 
   @override
-  GistFileCopyWith<$R2, GistFile, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t) =>
+  GistFileCopyWith<$R2, GistFile, $Out2> $chain<$R2, $Out2>(
+    Then<$Out2, $R2> t,
+  ) =>
       _GistFileCopyWithImpl<$R2, $Out2>($value, $cast, t);
 }

--- a/apps/jaspr_pad/lib/models/project.mapper.dart
+++ b/apps/jaspr_pad/lib/models/project.mapper.dart
@@ -1,5 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format off
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, unnecessary_cast, override_on_non_overriding_member
 // ignore_for_file: strict_raw_type, inference_failure_on_untyped_parameter
@@ -23,11 +24,70 @@ class ProjectDataBaseMapper extends ClassMapperBase<ProjectDataBase> {
   @override
   final String id = 'ProjectDataBase';
 
+  static String? _$id(ProjectDataBase v) => v.id;
+  static const Field<ProjectDataBase, String> _f$id = Field(
+    'id',
+    _$id,
+    mode: FieldMode.member,
+  );
+  static String? _$description(ProjectDataBase v) => v.description;
+  static const Field<ProjectDataBase, String> _f$description = Field(
+    'description',
+    _$description,
+    mode: FieldMode.member,
+  );
+  static String? _$htmlFile(ProjectDataBase v) => v.htmlFile;
+  static const Field<ProjectDataBase, String> _f$htmlFile = Field(
+    'htmlFile',
+    _$htmlFile,
+    mode: FieldMode.member,
+  );
+  static String? _$cssFile(ProjectDataBase v) => v.cssFile;
+  static const Field<ProjectDataBase, String> _f$cssFile = Field(
+    'cssFile',
+    _$cssFile,
+    mode: FieldMode.member,
+  );
+  static String _$mainDartFile(ProjectDataBase v) => v.mainDartFile;
+  static const Field<ProjectDataBase, String> _f$mainDartFile = Field(
+    'mainDartFile',
+    _$mainDartFile,
+    mode: FieldMode.member,
+  );
+  static Map<String, String> _$dartFiles(ProjectDataBase v) => v.dartFiles;
+  static const Field<ProjectDataBase, Map<String, String>> _f$dartFiles = Field(
+    'dartFiles',
+    _$dartFiles,
+    mode: FieldMode.member,
+  );
+  static List<String> _$fileNames(ProjectDataBase v) => v.fileNames;
+  static const Field<ProjectDataBase, List<String>> _f$fileNames = Field(
+    'fileNames',
+    _$fileNames,
+    mode: FieldMode.member,
+  );
+  static Map<String, String> _$allDartFiles(ProjectDataBase v) => v.allDartFiles;
+  static const Field<ProjectDataBase, Map<String, String>> _f$allDartFiles =
+      Field('allDartFiles', _$allDartFiles, mode: FieldMode.member);
+
   @override
-  final MappableFields<ProjectDataBase> fields = const {};
+  final MappableFields<ProjectDataBase> fields = const {
+    #id: _f$id,
+    #description: _f$description,
+    #htmlFile: _f$htmlFile,
+    #cssFile: _f$cssFile,
+    #mainDartFile: _f$mainDartFile,
+    #dartFiles: _f$dartFiles,
+    #fileNames: _f$fileNames,
+    #allDartFiles: _f$allDartFiles,
+  };
 
   static ProjectDataBase _instantiate(DecodingData data) {
-    throw MapperException.missingSubclass('ProjectDataBase', 'type', '${data.value['type']}');
+    throw MapperException.missingSubclass(
+      'ProjectDataBase',
+      'type',
+      '${data.value['type']}',
+    );
   }
 
   @override
@@ -62,16 +122,47 @@ class ProjectDataMapper extends SubClassMapperBase<ProjectData> {
   static String? _$id(ProjectData v) => v.id;
   static const Field<ProjectData, String> _f$id = Field('id', _$id, opt: true);
   static String? _$description(ProjectData v) => v.description;
-  static const Field<ProjectData, String> _f$description = Field('description', _$description, opt: true);
+  static const Field<ProjectData, String> _f$description = Field(
+    'description',
+    _$description,
+    opt: true,
+  );
   static String? _$htmlFile(ProjectData v) => v.htmlFile;
-  static const Field<ProjectData, String> _f$htmlFile = Field('htmlFile', _$htmlFile, opt: true);
+  static const Field<ProjectData, String> _f$htmlFile = Field(
+    'htmlFile',
+    _$htmlFile,
+    opt: true,
+  );
   static String? _$cssFile(ProjectData v) => v.cssFile;
-  static const Field<ProjectData, String> _f$cssFile = Field('cssFile', _$cssFile, opt: true);
+  static const Field<ProjectData, String> _f$cssFile = Field(
+    'cssFile',
+    _$cssFile,
+    opt: true,
+  );
   static String _$mainDartFile(ProjectData v) => v.mainDartFile;
-  static const Field<ProjectData, String> _f$mainDartFile = Field('mainDartFile', _$mainDartFile);
+  static const Field<ProjectData, String> _f$mainDartFile = Field(
+    'mainDartFile',
+    _$mainDartFile,
+  );
   static Map<String, String> _$dartFiles(ProjectData v) => v.dartFiles;
-  static const Field<ProjectData, Map<String, String>> _f$dartFiles =
-      Field('dartFiles', _$dartFiles, opt: true, def: const {});
+  static const Field<ProjectData, Map<String, String>> _f$dartFiles = Field(
+    'dartFiles',
+    _$dartFiles,
+    opt: true,
+    def: const {},
+  );
+  static List<String> _$fileNames(ProjectData v) => v.fileNames;
+  static const Field<ProjectData, List<String>> _f$fileNames = Field(
+    'fileNames',
+    _$fileNames,
+    mode: FieldMode.member,
+  );
+  static Map<String, String> _$allDartFiles(ProjectData v) => v.allDartFiles;
+  static const Field<ProjectData, Map<String, String>> _f$allDartFiles = Field(
+    'allDartFiles',
+    _$allDartFiles,
+    mode: FieldMode.member,
+  );
 
   @override
   final MappableFields<ProjectData> fields = const {
@@ -81,6 +172,8 @@ class ProjectDataMapper extends SubClassMapperBase<ProjectData> {
     #cssFile: _f$cssFile,
     #mainDartFile: _f$mainDartFile,
     #dartFiles: _f$dartFiles,
+    #fileNames: _f$fileNames,
+    #allDartFiles: _f$allDartFiles,
   };
 
   @override
@@ -92,12 +185,13 @@ class ProjectDataMapper extends SubClassMapperBase<ProjectData> {
 
   static ProjectData _instantiate(DecodingData data) {
     return ProjectData(
-        id: data.dec(_f$id),
-        description: data.dec(_f$description),
-        htmlFile: data.dec(_f$htmlFile),
-        cssFile: data.dec(_f$cssFile),
-        mainDartFile: data.dec(_f$mainDartFile),
-        dartFiles: data.dec(_f$dartFiles));
+      id: data.dec(_f$id),
+      description: data.dec(_f$description),
+      htmlFile: data.dec(_f$htmlFile),
+      cssFile: data.dec(_f$cssFile),
+      mainDartFile: data.dec(_f$mainDartFile),
+      dartFiles: data.dec(_f$dartFiles),
+    );
   }
 
   @override
@@ -114,23 +208,36 @@ class ProjectDataMapper extends SubClassMapperBase<ProjectData> {
 
 mixin ProjectDataMappable {
   String toJson() {
-    return ProjectDataMapper.ensureInitialized().encodeJson<ProjectData>(this as ProjectData);
+    return ProjectDataMapper.ensureInitialized().encodeJson<ProjectData>(
+      this as ProjectData,
+    );
   }
 
   Map<String, dynamic> toMap() {
-    return ProjectDataMapper.ensureInitialized().encodeMap<ProjectData>(this as ProjectData);
+    return ProjectDataMapper.ensureInitialized().encodeMap<ProjectData>(
+      this as ProjectData,
+    );
   }
 
   ProjectDataCopyWith<ProjectData, ProjectData, ProjectData> get copyWith =>
-      _ProjectDataCopyWithImpl<ProjectData, ProjectData>(this as ProjectData, $identity, $identity);
+      _ProjectDataCopyWithImpl<ProjectData, ProjectData>(
+        this as ProjectData,
+        $identity,
+        $identity,
+      );
   @override
   String toString() {
-    return ProjectDataMapper.ensureInitialized().stringifyValue(this as ProjectData);
+    return ProjectDataMapper.ensureInitialized().stringifyValue(
+      this as ProjectData,
+    );
   }
 
   @override
   bool operator ==(Object other) {
-    return ProjectDataMapper.ensureInitialized().equalsValue(this as ProjectData, other);
+    return ProjectDataMapper.ensureInitialized().equalsValue(
+      this as ProjectData,
+      other,
+    );
   }
 
   @override
@@ -146,13 +253,14 @@ extension ProjectDataValueCopy<$R, $Out> on ObjectCopyWith<$R, ProjectData, $Out
 
 abstract class ProjectDataCopyWith<$R, $In extends ProjectData, $Out> implements ClassCopyWith<$R, $In, $Out> {
   MapCopyWith<$R, String, String, ObjectCopyWith<$R, String, String>> get dartFiles;
-  $R call(
-      {String? id,
-      String? description,
-      String? htmlFile,
-      String? cssFile,
-      String? mainDartFile,
-      Map<String, String>? dartFiles});
+  $R call({
+    String? id,
+    String? description,
+    String? htmlFile,
+    String? cssFile,
+    String? mainDartFile,
+    Map<String, String>? dartFiles,
+  });
   ProjectDataCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t);
 }
 
@@ -163,34 +271,43 @@ class _ProjectDataCopyWithImpl<$R, $Out> extends ClassCopyWithBase<$R, ProjectDa
   @override
   late final ClassMapperBase<ProjectData> $mapper = ProjectDataMapper.ensureInitialized();
   @override
-  MapCopyWith<$R, String, String, ObjectCopyWith<$R, String, String>> get dartFiles =>
-      MapCopyWith($value.dartFiles, (v, t) => ObjectCopyWith(v, $identity, t), (v) => call(dartFiles: v));
+  MapCopyWith<$R, String, String, ObjectCopyWith<$R, String, String>> get dartFiles => MapCopyWith(
+        $value.dartFiles,
+        (v, t) => ObjectCopyWith(v, $identity, t),
+        (v) => call(dartFiles: v),
+      );
   @override
-  $R call(
-          {Object? id = $none,
-          Object? description = $none,
-          Object? htmlFile = $none,
-          Object? cssFile = $none,
-          String? mainDartFile,
-          Map<String, String>? dartFiles}) =>
-      $apply(FieldCopyWithData({
-        if (id != $none) #id: id,
-        if (description != $none) #description: description,
-        if (htmlFile != $none) #htmlFile: htmlFile,
-        if (cssFile != $none) #cssFile: cssFile,
-        if (mainDartFile != null) #mainDartFile: mainDartFile,
-        if (dartFiles != null) #dartFiles: dartFiles
-      }));
+  $R call({
+    Object? id = $none,
+    Object? description = $none,
+    Object? htmlFile = $none,
+    Object? cssFile = $none,
+    String? mainDartFile,
+    Map<String, String>? dartFiles,
+  }) =>
+      $apply(
+        FieldCopyWithData({
+          if (id != $none) #id: id,
+          if (description != $none) #description: description,
+          if (htmlFile != $none) #htmlFile: htmlFile,
+          if (cssFile != $none) #cssFile: cssFile,
+          if (mainDartFile != null) #mainDartFile: mainDartFile,
+          if (dartFiles != null) #dartFiles: dartFiles,
+        }),
+      );
   @override
   ProjectData $make(CopyWithData data) => ProjectData(
-      id: data.get(#id, or: $value.id),
-      description: data.get(#description, or: $value.description),
-      htmlFile: data.get(#htmlFile, or: $value.htmlFile),
-      cssFile: data.get(#cssFile, or: $value.cssFile),
-      mainDartFile: data.get(#mainDartFile, or: $value.mainDartFile),
-      dartFiles: data.get(#dartFiles, or: $value.dartFiles));
+        id: data.get(#id, or: $value.id),
+        description: data.get(#description, or: $value.description),
+        htmlFile: data.get(#htmlFile, or: $value.htmlFile),
+        cssFile: data.get(#cssFile, or: $value.cssFile),
+        mainDartFile: data.get(#mainDartFile, or: $value.mainDartFile),
+        dartFiles: data.get(#dartFiles, or: $value.dartFiles),
+      );
 
   @override
-  ProjectDataCopyWith<$R2, ProjectData, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t) =>
+  ProjectDataCopyWith<$R2, ProjectData, $Out2> $chain<$R2, $Out2>(
+    Then<$Out2, $R2> t,
+  ) =>
       _ProjectDataCopyWithImpl<$R2, $Out2>($value, $cast, t);
 }

--- a/apps/jaspr_pad/lib/models/sample.mapper.dart
+++ b/apps/jaspr_pad/lib/models/sample.mapper.dart
@@ -1,5 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format off
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, unnecessary_cast, override_on_non_overriding_member
 // ignore_for_file: strict_raw_type, inference_failure_on_untyped_parameter
@@ -23,7 +24,10 @@ class SampleMapper extends ClassMapperBase<Sample> {
   static String _$id(Sample v) => v.id;
   static const Field<Sample, String> _f$id = Field('id', _$id);
   static String _$description(Sample v) => v.description;
-  static const Field<Sample, String> _f$description = Field('description', _$description);
+  static const Field<Sample, String> _f$description = Field(
+    'description',
+    _$description,
+  );
   static int? _$index(Sample v) => v.index;
   static const Field<Sample, int> _f$index = Field('index', _$index);
 
@@ -35,7 +39,11 @@ class SampleMapper extends ClassMapperBase<Sample> {
   };
 
   static Sample _instantiate(DecodingData data) {
-    return Sample(data.dec(_f$id), data.dec(_f$description), data.dec(_f$index));
+    return Sample(
+      data.dec(_f$id),
+      data.dec(_f$description),
+      data.dec(_f$index),
+    );
   }
 
   @override
@@ -93,14 +101,19 @@ class _SampleCopyWithImpl<$R, $Out> extends ClassCopyWithBase<$R, Sample, $Out>
   @override
   late final ClassMapperBase<Sample> $mapper = SampleMapper.ensureInitialized();
   @override
-  $R call({String? id, String? description, Object? index = $none}) => $apply(FieldCopyWithData({
-        if (id != null) #id: id,
-        if (description != null) #description: description,
-        if (index != $none) #index: index
-      }));
+  $R call({String? id, String? description, Object? index = $none}) => $apply(
+        FieldCopyWithData({
+          if (id != null) #id: id,
+          if (description != null) #description: description,
+          if (index != $none) #index: index,
+        }),
+      );
   @override
   Sample $make(CopyWithData data) => Sample(
-      data.get(#id, or: $value.id), data.get(#description, or: $value.description), data.get(#index, or: $value.index));
+        data.get(#id, or: $value.id),
+        data.get(#description, or: $value.description),
+        data.get(#index, or: $value.index),
+      );
 
   @override
   SampleCopyWith<$R2, Sample, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t) =>
@@ -123,7 +136,10 @@ class SampleResponseMapper extends ClassMapperBase<SampleResponse> {
   final String id = 'SampleResponse';
 
   static ProjectData? _$project(SampleResponse v) => v.project;
-  static const Field<SampleResponse, ProjectData> _f$project = Field('project', _$project);
+  static const Field<SampleResponse, ProjectData> _f$project = Field(
+    'project',
+    _$project,
+  );
   static String? _$error(SampleResponse v) => v.error;
   static const Field<SampleResponse, String> _f$error = Field('error', _$error);
 
@@ -151,28 +167,43 @@ class SampleResponseMapper extends ClassMapperBase<SampleResponse> {
 
 mixin SampleResponseMappable {
   String toJson() {
-    return SampleResponseMapper.ensureInitialized().encodeJson<SampleResponse>(this as SampleResponse);
+    return SampleResponseMapper.ensureInitialized().encodeJson<SampleResponse>(
+      this as SampleResponse,
+    );
   }
 
   Map<String, dynamic> toMap() {
-    return SampleResponseMapper.ensureInitialized().encodeMap<SampleResponse>(this as SampleResponse);
+    return SampleResponseMapper.ensureInitialized().encodeMap<SampleResponse>(
+      this as SampleResponse,
+    );
   }
 
   SampleResponseCopyWith<SampleResponse, SampleResponse, SampleResponse> get copyWith =>
-      _SampleResponseCopyWithImpl<SampleResponse, SampleResponse>(this as SampleResponse, $identity, $identity);
+      _SampleResponseCopyWithImpl<SampleResponse, SampleResponse>(
+        this as SampleResponse,
+        $identity,
+        $identity,
+      );
   @override
   String toString() {
-    return SampleResponseMapper.ensureInitialized().stringifyValue(this as SampleResponse);
+    return SampleResponseMapper.ensureInitialized().stringifyValue(
+      this as SampleResponse,
+    );
   }
 
   @override
   bool operator ==(Object other) {
-    return SampleResponseMapper.ensureInitialized().equalsValue(this as SampleResponse, other);
+    return SampleResponseMapper.ensureInitialized().equalsValue(
+      this as SampleResponse,
+      other,
+    );
   }
 
   @override
   int get hashCode {
-    return SampleResponseMapper.ensureInitialized().hashValue(this as SampleResponse);
+    return SampleResponseMapper.ensureInitialized().hashValue(
+      this as SampleResponse,
+    );
   }
 }
 
@@ -184,7 +215,9 @@ extension SampleResponseValueCopy<$R, $Out> on ObjectCopyWith<$R, SampleResponse
 abstract class SampleResponseCopyWith<$R, $In extends SampleResponse, $Out> implements ClassCopyWith<$R, $In, $Out> {
   ProjectDataCopyWith<$R, ProjectData, ProjectData>? get project;
   $R call({ProjectData? project, String? error});
-  SampleResponseCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t);
+  SampleResponseCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(
+    Then<$Out2, $R2> t,
+  );
 }
 
 class _SampleResponseCopyWithImpl<$R, $Out> extends ClassCopyWithBase<$R, SampleResponse, $Out>
@@ -197,13 +230,21 @@ class _SampleResponseCopyWithImpl<$R, $Out> extends ClassCopyWithBase<$R, Sample
   ProjectDataCopyWith<$R, ProjectData, ProjectData>? get project =>
       $value.project?.copyWith.$chain((v) => call(project: v));
   @override
-  $R call({Object? project = $none, Object? error = $none}) =>
-      $apply(FieldCopyWithData({if (project != $none) #project: project, if (error != $none) #error: error}));
+  $R call({Object? project = $none, Object? error = $none}) => $apply(
+        FieldCopyWithData({
+          if (project != $none) #project: project,
+          if (error != $none) #error: error,
+        }),
+      );
   @override
-  SampleResponse $make(CopyWithData data) =>
-      SampleResponse(data.get(#project, or: $value.project), data.get(#error, or: $value.error));
+  SampleResponse $make(CopyWithData data) => SampleResponse(
+        data.get(#project, or: $value.project),
+        data.get(#error, or: $value.error),
+      );
 
   @override
-  SampleResponseCopyWith<$R2, SampleResponse, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t) =>
+  SampleResponseCopyWith<$R2, SampleResponse, $Out2> $chain<$R2, $Out2>(
+    Then<$Out2, $R2> t,
+  ) =>
       _SampleResponseCopyWithImpl<$R2, $Out2>($value, $cast, t);
 }

--- a/apps/jaspr_pad/lib/models/tutorial.mapper.dart
+++ b/apps/jaspr_pad/lib/models/tutorial.mapper.dart
@@ -1,5 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format off
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, unnecessary_cast, override_on_non_overriding_member
 // ignore_for_file: strict_raw_type, inference_failure_on_untyped_parameter
@@ -26,13 +27,73 @@ class TutorialDataMapper extends SubClassMapperBase<TutorialData> {
   static String _$id(TutorialData v) => v.id;
   static const Field<TutorialData, String> _f$id = Field('id', _$id);
   static String _$description(TutorialData v) => v.description;
-  static const Field<TutorialData, String> _f$description = Field('description', _$description);
+  static const Field<TutorialData, String> _f$description = Field(
+    'description',
+    _$description,
+  );
   static int _$currentStep(TutorialData v) => v.currentStep;
-  static const Field<TutorialData, int> _f$currentStep = Field('currentStep', _$currentStep);
+  static const Field<TutorialData, int> _f$currentStep = Field(
+    'currentStep',
+    _$currentStep,
+  );
   static List<TutorialStepConfig> _$configs(TutorialData v) => v.configs;
-  static const Field<TutorialData, List<TutorialStepConfig>> _f$configs = Field('configs', _$configs);
+  static const Field<TutorialData, List<TutorialStepConfig>> _f$configs = Field(
+    'configs',
+    _$configs,
+  );
   static Map<String, TutorialStep> _$steps(TutorialData v) => v.steps;
-  static const Field<TutorialData, Map<String, TutorialStep>> _f$steps = Field('steps', _$steps);
+  static const Field<TutorialData, Map<String, TutorialStep>> _f$steps = Field(
+    'steps',
+    _$steps,
+  );
+  static String _$currentStepId(TutorialData v) => v.currentStepId;
+  static const Field<TutorialData, String> _f$currentStepId = Field(
+    'currentStepId',
+    _$currentStepId,
+    mode: FieldMode.member,
+  );
+  static TutorialStep _$step(TutorialData v) => v.step;
+  static const Field<TutorialData, TutorialStep> _f$step = Field(
+    'step',
+    _$step,
+    mode: FieldMode.member,
+  );
+  static String? _$cssFile(TutorialData v) => v.cssFile;
+  static const Field<TutorialData, String> _f$cssFile = Field(
+    'cssFile',
+    _$cssFile,
+    mode: FieldMode.member,
+  );
+  static Map<String, String> _$dartFiles(TutorialData v) => v.dartFiles;
+  static const Field<TutorialData, Map<String, String>> _f$dartFiles = Field(
+    'dartFiles',
+    _$dartFiles,
+    mode: FieldMode.member,
+  );
+  static Map<String, String> _$allDartFiles(TutorialData v) => v.allDartFiles;
+  static const Field<TutorialData, Map<String, String>> _f$allDartFiles = Field(
+    'allDartFiles',
+    _$allDartFiles,
+    mode: FieldMode.member,
+  );
+  static List<String> _$fileNames(TutorialData v) => v.fileNames;
+  static const Field<TutorialData, List<String>> _f$fileNames = Field(
+    'fileNames',
+    _$fileNames,
+    mode: FieldMode.member,
+  );
+  static String? _$htmlFile(TutorialData v) => v.htmlFile;
+  static const Field<TutorialData, String> _f$htmlFile = Field(
+    'htmlFile',
+    _$htmlFile,
+    mode: FieldMode.member,
+  );
+  static String _$mainDartFile(TutorialData v) => v.mainDartFile;
+  static const Field<TutorialData, String> _f$mainDartFile = Field(
+    'mainDartFile',
+    _$mainDartFile,
+    mode: FieldMode.member,
+  );
 
   @override
   final MappableFields<TutorialData> fields = const {
@@ -41,6 +102,14 @@ class TutorialDataMapper extends SubClassMapperBase<TutorialData> {
     #currentStep: _f$currentStep,
     #configs: _f$configs,
     #steps: _f$steps,
+    #currentStepId: _f$currentStepId,
+    #step: _f$step,
+    #cssFile: _f$cssFile,
+    #dartFiles: _f$dartFiles,
+    #allDartFiles: _f$allDartFiles,
+    #fileNames: _f$fileNames,
+    #htmlFile: _f$htmlFile,
+    #mainDartFile: _f$mainDartFile,
   };
 
   @override
@@ -52,7 +121,12 @@ class TutorialDataMapper extends SubClassMapperBase<TutorialData> {
 
   static TutorialData _instantiate(DecodingData data) {
     return TutorialData(
-        data.dec(_f$id), data.dec(_f$description), data.dec(_f$currentStep), data.dec(_f$configs), data.dec(_f$steps));
+      data.dec(_f$id),
+      data.dec(_f$description),
+      data.dec(_f$currentStep),
+      data.dec(_f$configs),
+      data.dec(_f$steps),
+    );
   }
 
   @override
@@ -69,28 +143,43 @@ class TutorialDataMapper extends SubClassMapperBase<TutorialData> {
 
 mixin TutorialDataMappable {
   String toJson() {
-    return TutorialDataMapper.ensureInitialized().encodeJson<TutorialData>(this as TutorialData);
+    return TutorialDataMapper.ensureInitialized().encodeJson<TutorialData>(
+      this as TutorialData,
+    );
   }
 
   Map<String, dynamic> toMap() {
-    return TutorialDataMapper.ensureInitialized().encodeMap<TutorialData>(this as TutorialData);
+    return TutorialDataMapper.ensureInitialized().encodeMap<TutorialData>(
+      this as TutorialData,
+    );
   }
 
   TutorialDataCopyWith<TutorialData, TutorialData, TutorialData> get copyWith =>
-      _TutorialDataCopyWithImpl<TutorialData, TutorialData>(this as TutorialData, $identity, $identity);
+      _TutorialDataCopyWithImpl<TutorialData, TutorialData>(
+        this as TutorialData,
+        $identity,
+        $identity,
+      );
   @override
   String toString() {
-    return TutorialDataMapper.ensureInitialized().stringifyValue(this as TutorialData);
+    return TutorialDataMapper.ensureInitialized().stringifyValue(
+      this as TutorialData,
+    );
   }
 
   @override
   bool operator ==(Object other) {
-    return TutorialDataMapper.ensureInitialized().equalsValue(this as TutorialData, other);
+    return TutorialDataMapper.ensureInitialized().equalsValue(
+      this as TutorialData,
+      other,
+    );
   }
 
   @override
   int get hashCode {
-    return TutorialDataMapper.ensureInitialized().hashValue(this as TutorialData);
+    return TutorialDataMapper.ensureInitialized().hashValue(
+      this as TutorialData,
+    );
   }
 }
 
@@ -103,12 +192,13 @@ abstract class TutorialDataCopyWith<$R, $In extends TutorialData, $Out> implemen
   ListCopyWith<$R, TutorialStepConfig, TutorialStepConfigCopyWith<$R, TutorialStepConfig, TutorialStepConfig>>
       get configs;
   MapCopyWith<$R, String, TutorialStep, TutorialStepCopyWith<$R, TutorialStep, TutorialStep>> get steps;
-  $R call(
-      {String? id,
-      String? description,
-      int? currentStep,
-      List<TutorialStepConfig>? configs,
-      Map<String, TutorialStep>? steps});
+  $R call({
+    covariant String? id,
+    covariant String? description,
+    int? currentStep,
+    List<TutorialStepConfig>? configs,
+    Map<String, TutorialStep>? steps,
+  });
   TutorialDataCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t);
 }
 
@@ -120,34 +210,47 @@ class _TutorialDataCopyWithImpl<$R, $Out> extends ClassCopyWithBase<$R, Tutorial
   late final ClassMapperBase<TutorialData> $mapper = TutorialDataMapper.ensureInitialized();
   @override
   ListCopyWith<$R, TutorialStepConfig, TutorialStepConfigCopyWith<$R, TutorialStepConfig, TutorialStepConfig>>
-      get configs => ListCopyWith($value.configs, (v, t) => v.copyWith.$chain(t), (v) => call(configs: v));
+      get configs => ListCopyWith(
+            $value.configs,
+            (v, t) => v.copyWith.$chain(t),
+            (v) => call(configs: v),
+          );
   @override
-  MapCopyWith<$R, String, TutorialStep, TutorialStepCopyWith<$R, TutorialStep, TutorialStep>> get steps =>
-      MapCopyWith($value.steps, (v, t) => v.copyWith.$chain(t), (v) => call(steps: v));
+  MapCopyWith<$R, String, TutorialStep, TutorialStepCopyWith<$R, TutorialStep, TutorialStep>> get steps => MapCopyWith(
+        $value.steps,
+        (v, t) => v.copyWith.$chain(t),
+        (v) => call(steps: v),
+      );
   @override
-  $R call(
-          {String? id,
-          String? description,
-          int? currentStep,
-          List<TutorialStepConfig>? configs,
-          Map<String, TutorialStep>? steps}) =>
-      $apply(FieldCopyWithData({
-        if (id != null) #id: id,
-        if (description != null) #description: description,
-        if (currentStep != null) #currentStep: currentStep,
-        if (configs != null) #configs: configs,
-        if (steps != null) #steps: steps
-      }));
+  $R call({
+    String? id,
+    String? description,
+    int? currentStep,
+    List<TutorialStepConfig>? configs,
+    Map<String, TutorialStep>? steps,
+  }) =>
+      $apply(
+        FieldCopyWithData({
+          if (id != null) #id: id,
+          if (description != null) #description: description,
+          if (currentStep != null) #currentStep: currentStep,
+          if (configs != null) #configs: configs,
+          if (steps != null) #steps: steps,
+        }),
+      );
   @override
   TutorialData $make(CopyWithData data) => TutorialData(
-      data.get(#id, or: $value.id),
-      data.get(#description, or: $value.description),
-      data.get(#currentStep, or: $value.currentStep),
-      data.get(#configs, or: $value.configs),
-      data.get(#steps, or: $value.steps));
+        data.get(#id, or: $value.id),
+        data.get(#description, or: $value.description),
+        data.get(#currentStep, or: $value.currentStep),
+        data.get(#configs, or: $value.configs),
+        data.get(#steps, or: $value.steps),
+      );
 
   @override
-  TutorialDataCopyWith<$R2, TutorialData, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t) =>
+  TutorialDataCopyWith<$R2, TutorialData, $Out2> $chain<$R2, $Out2>(
+    Then<$Out2, $R2> t,
+  ) =>
       _TutorialDataCopyWithImpl<$R2, $Out2>($value, $cast, t);
 }
 
@@ -168,7 +271,10 @@ class TutorialStepConfigMapper extends ClassMapperBase<TutorialStepConfig> {
   static String _$id(TutorialStepConfig v) => v.id;
   static const Field<TutorialStepConfig, String> _f$id = Field('id', _$id);
   static String _$name(TutorialStepConfig v) => v.name;
-  static const Field<TutorialStepConfig, String> _f$name = Field('name', _$name);
+  static const Field<TutorialStepConfig, String> _f$name = Field(
+    'name',
+    _$name,
+  );
 
   @override
   final MappableFields<TutorialStepConfig> fields = const {
@@ -203,32 +309,45 @@ mixin TutorialStepConfigMappable {
 
   TutorialStepConfigCopyWith<TutorialStepConfig, TutorialStepConfig, TutorialStepConfig> get copyWith =>
       _TutorialStepConfigCopyWithImpl<TutorialStepConfig, TutorialStepConfig>(
-          this as TutorialStepConfig, $identity, $identity);
+        this as TutorialStepConfig,
+        $identity,
+        $identity,
+      );
   @override
   String toString() {
-    return TutorialStepConfigMapper.ensureInitialized().stringifyValue(this as TutorialStepConfig);
+    return TutorialStepConfigMapper.ensureInitialized().stringifyValue(
+      this as TutorialStepConfig,
+    );
   }
 
   @override
   bool operator ==(Object other) {
-    return TutorialStepConfigMapper.ensureInitialized().equalsValue(this as TutorialStepConfig, other);
+    return TutorialStepConfigMapper.ensureInitialized().equalsValue(
+      this as TutorialStepConfig,
+      other,
+    );
   }
 
   @override
   int get hashCode {
-    return TutorialStepConfigMapper.ensureInitialized().hashValue(this as TutorialStepConfig);
+    return TutorialStepConfigMapper.ensureInitialized().hashValue(
+      this as TutorialStepConfig,
+    );
   }
 }
 
 extension TutorialStepConfigValueCopy<$R, $Out> on ObjectCopyWith<$R, TutorialStepConfig, $Out> {
-  TutorialStepConfigCopyWith<$R, TutorialStepConfig, $Out> get $asTutorialStepConfig =>
-      $base.as((v, t, t2) => _TutorialStepConfigCopyWithImpl<$R, $Out>(v, t, t2));
+  TutorialStepConfigCopyWith<$R, TutorialStepConfig, $Out> get $asTutorialStepConfig => $base.as(
+        (v, t, t2) => _TutorialStepConfigCopyWithImpl<$R, $Out>(v, t, t2),
+      );
 }
 
 abstract class TutorialStepConfigCopyWith<$R, $In extends TutorialStepConfig, $Out>
     implements ClassCopyWith<$R, $In, $Out> {
   $R call({String? id, String? name});
-  TutorialStepConfigCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t);
+  TutorialStepConfigCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(
+    Then<$Out2, $R2> t,
+  );
 }
 
 class _TutorialStepConfigCopyWithImpl<$R, $Out> extends ClassCopyWithBase<$R, TutorialStepConfig, $Out>
@@ -238,14 +357,19 @@ class _TutorialStepConfigCopyWithImpl<$R, $Out> extends ClassCopyWithBase<$R, Tu
   @override
   late final ClassMapperBase<TutorialStepConfig> $mapper = TutorialStepConfigMapper.ensureInitialized();
   @override
-  $R call({String? id, String? name}) =>
-      $apply(FieldCopyWithData({if (id != null) #id: id, if (name != null) #name: name}));
+  $R call({String? id, String? name}) => $apply(
+        FieldCopyWithData({if (id != null) #id: id, if (name != null) #name: name}),
+      );
   @override
-  TutorialStepConfig $make(CopyWithData data) =>
-      TutorialStepConfig(data.get(#id, or: $value.id), data.get(#name, or: $value.name));
+  TutorialStepConfig $make(CopyWithData data) => TutorialStepConfig(
+        data.get(#id, or: $value.id),
+        data.get(#name, or: $value.name),
+      );
 
   @override
-  TutorialStepConfigCopyWith<$R2, TutorialStepConfig, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t) =>
+  TutorialStepConfigCopyWith<$R2, TutorialStepConfig, $Out2> $chain<$R2, $Out2>(
+    Then<$Out2, $R2> t,
+  ) =>
       _TutorialStepConfigCopyWithImpl<$R2, $Out2>($value, $cast, t);
 }
 
@@ -274,9 +398,65 @@ class TutorialStepMapper extends SubClassMapperBase<TutorialStep> {
   static ProjectData _$step(TutorialStep v) => v.step;
   static const Field<TutorialStep, ProjectData> _f$step = Field('step', _$step);
   static ProjectData? _$solution(TutorialStep v) => v.solution;
-  static const Field<TutorialStep, ProjectData> _f$solution = Field('solution', _$solution);
+  static const Field<TutorialStep, ProjectData> _f$solution = Field(
+    'solution',
+    _$solution,
+  );
   static bool _$showSolution(TutorialStep v) => v.showSolution;
-  static const Field<TutorialStep, bool> _f$showSolution = Field('showSolution', _$showSolution, opt: true, def: false);
+  static const Field<TutorialStep, bool> _f$showSolution = Field(
+    'showSolution',
+    _$showSolution,
+    opt: true,
+    def: false,
+  );
+  static ProjectData _$data(TutorialStep v) => v.data;
+  static const Field<TutorialStep, ProjectData> _f$data = Field(
+    'data',
+    _$data,
+    mode: FieldMode.member,
+  );
+  static Map<String, String> _$allDartFiles(TutorialStep v) => v.allDartFiles;
+  static const Field<TutorialStep, Map<String, String>> _f$allDartFiles = Field(
+    'allDartFiles',
+    _$allDartFiles,
+    mode: FieldMode.member,
+  );
+  static String? _$cssFile(TutorialStep v) => v.cssFile;
+  static const Field<TutorialStep, String> _f$cssFile = Field(
+    'cssFile',
+    _$cssFile,
+    mode: FieldMode.member,
+  );
+  static Map<String, String> _$dartFiles(TutorialStep v) => v.dartFiles;
+  static const Field<TutorialStep, Map<String, String>> _f$dartFiles = Field(
+    'dartFiles',
+    _$dartFiles,
+    mode: FieldMode.member,
+  );
+  static String? _$description(TutorialStep v) => v.description;
+  static const Field<TutorialStep, String> _f$description = Field(
+    'description',
+    _$description,
+    mode: FieldMode.member,
+  );
+  static List<String> _$fileNames(TutorialStep v) => v.fileNames;
+  static const Field<TutorialStep, List<String>> _f$fileNames = Field(
+    'fileNames',
+    _$fileNames,
+    mode: FieldMode.member,
+  );
+  static String? _$htmlFile(TutorialStep v) => v.htmlFile;
+  static const Field<TutorialStep, String> _f$htmlFile = Field(
+    'htmlFile',
+    _$htmlFile,
+    mode: FieldMode.member,
+  );
+  static String _$mainDartFile(TutorialStep v) => v.mainDartFile;
+  static const Field<TutorialStep, String> _f$mainDartFile = Field(
+    'mainDartFile',
+    _$mainDartFile,
+    mode: FieldMode.member,
+  );
 
   @override
   final MappableFields<TutorialStep> fields = const {
@@ -286,6 +466,14 @@ class TutorialStepMapper extends SubClassMapperBase<TutorialStep> {
     #step: _f$step,
     #solution: _f$solution,
     #showSolution: _f$showSolution,
+    #data: _f$data,
+    #allDartFiles: _f$allDartFiles,
+    #cssFile: _f$cssFile,
+    #dartFiles: _f$dartFiles,
+    #description: _f$description,
+    #fileNames: _f$fileNames,
+    #htmlFile: _f$htmlFile,
+    #mainDartFile: _f$mainDartFile,
   };
 
   @override
@@ -296,8 +484,14 @@ class TutorialStepMapper extends SubClassMapperBase<TutorialStep> {
   late final ClassMapperBase superMapper = ProjectDataBaseMapper.ensureInitialized();
 
   static TutorialStep _instantiate(DecodingData data) {
-    return TutorialStep(data.dec(_f$id), data.dec(_f$name), data.dec(_f$text), data.dec(_f$step), data.dec(_f$solution),
-        data.dec(_f$showSolution));
+    return TutorialStep(
+      data.dec(_f$id),
+      data.dec(_f$name),
+      data.dec(_f$text),
+      data.dec(_f$step),
+      data.dec(_f$solution),
+      data.dec(_f$showSolution),
+    );
   }
 
   @override
@@ -314,28 +508,43 @@ class TutorialStepMapper extends SubClassMapperBase<TutorialStep> {
 
 mixin TutorialStepMappable {
   String toJson() {
-    return TutorialStepMapper.ensureInitialized().encodeJson<TutorialStep>(this as TutorialStep);
+    return TutorialStepMapper.ensureInitialized().encodeJson<TutorialStep>(
+      this as TutorialStep,
+    );
   }
 
   Map<String, dynamic> toMap() {
-    return TutorialStepMapper.ensureInitialized().encodeMap<TutorialStep>(this as TutorialStep);
+    return TutorialStepMapper.ensureInitialized().encodeMap<TutorialStep>(
+      this as TutorialStep,
+    );
   }
 
   TutorialStepCopyWith<TutorialStep, TutorialStep, TutorialStep> get copyWith =>
-      _TutorialStepCopyWithImpl<TutorialStep, TutorialStep>(this as TutorialStep, $identity, $identity);
+      _TutorialStepCopyWithImpl<TutorialStep, TutorialStep>(
+        this as TutorialStep,
+        $identity,
+        $identity,
+      );
   @override
   String toString() {
-    return TutorialStepMapper.ensureInitialized().stringifyValue(this as TutorialStep);
+    return TutorialStepMapper.ensureInitialized().stringifyValue(
+      this as TutorialStep,
+    );
   }
 
   @override
   bool operator ==(Object other) {
-    return TutorialStepMapper.ensureInitialized().equalsValue(this as TutorialStep, other);
+    return TutorialStepMapper.ensureInitialized().equalsValue(
+      this as TutorialStep,
+      other,
+    );
   }
 
   @override
   int get hashCode {
-    return TutorialStepMapper.ensureInitialized().hashValue(this as TutorialStep);
+    return TutorialStepMapper.ensureInitialized().hashValue(
+      this as TutorialStep,
+    );
   }
 }
 
@@ -347,7 +556,14 @@ extension TutorialStepValueCopy<$R, $Out> on ObjectCopyWith<$R, TutorialStep, $O
 abstract class TutorialStepCopyWith<$R, $In extends TutorialStep, $Out> implements ClassCopyWith<$R, $In, $Out> {
   ProjectDataCopyWith<$R, ProjectData, ProjectData> get step;
   ProjectDataCopyWith<$R, ProjectData, ProjectData>? get solution;
-  $R call({String? id, String? name, String? text, ProjectData? step, ProjectData? solution, bool? showSolution});
+  $R call({
+    covariant String? id,
+    String? name,
+    String? text,
+    ProjectData? step,
+    ProjectData? solution,
+    bool? showSolution,
+  });
   TutorialStepCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t);
 }
 
@@ -363,26 +579,38 @@ class _TutorialStepCopyWithImpl<$R, $Out> extends ClassCopyWithBase<$R, Tutorial
   ProjectDataCopyWith<$R, ProjectData, ProjectData>? get solution =>
       $value.solution?.copyWith.$chain((v) => call(solution: v));
   @override
-  $R call({String? id, String? name, String? text, ProjectData? step, Object? solution = $none, bool? showSolution}) =>
-      $apply(FieldCopyWithData({
-        if (id != null) #id: id,
-        if (name != null) #name: name,
-        if (text != null) #text: text,
-        if (step != null) #step: step,
-        if (solution != $none) #solution: solution,
-        if (showSolution != null) #showSolution: showSolution
-      }));
+  $R call({
+    String? id,
+    String? name,
+    String? text,
+    ProjectData? step,
+    Object? solution = $none,
+    bool? showSolution,
+  }) =>
+      $apply(
+        FieldCopyWithData({
+          if (id != null) #id: id,
+          if (name != null) #name: name,
+          if (text != null) #text: text,
+          if (step != null) #step: step,
+          if (solution != $none) #solution: solution,
+          if (showSolution != null) #showSolution: showSolution,
+        }),
+      );
   @override
   TutorialStep $make(CopyWithData data) => TutorialStep(
-      data.get(#id, or: $value.id),
-      data.get(#name, or: $value.name),
-      data.get(#text, or: $value.text),
-      data.get(#step, or: $value.step),
-      data.get(#solution, or: $value.solution),
-      data.get(#showSolution, or: $value.showSolution));
+        data.get(#id, or: $value.id),
+        data.get(#name, or: $value.name),
+        data.get(#text, or: $value.text),
+        data.get(#step, or: $value.step),
+        data.get(#solution, or: $value.solution),
+        data.get(#showSolution, or: $value.showSolution),
+      );
 
   @override
-  TutorialStepCopyWith<$R2, TutorialStep, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t) =>
+  TutorialStepCopyWith<$R2, TutorialStep, $Out2> $chain<$R2, $Out2>(
+    Then<$Out2, $R2> t,
+  ) =>
       _TutorialStepCopyWithImpl<$R2, $Out2>($value, $cast, t);
 }
 
@@ -402,9 +630,15 @@ class TutorialResponseMapper extends ClassMapperBase<TutorialResponse> {
   final String id = 'TutorialResponse';
 
   static TutorialConfig? _$tutorial(TutorialResponse v) => v.tutorial;
-  static const Field<TutorialResponse, TutorialConfig> _f$tutorial = Field('tutorial', _$tutorial);
+  static const Field<TutorialResponse, TutorialConfig> _f$tutorial = Field(
+    'tutorial',
+    _$tutorial,
+  );
   static String? _$error(TutorialResponse v) => v.error;
-  static const Field<TutorialResponse, String> _f$error = Field('error', _$error);
+  static const Field<TutorialResponse, String> _f$error = Field(
+    'error',
+    _$error,
+  );
 
   @override
   final MappableFields<TutorialResponse> fields = const {
@@ -438,20 +672,31 @@ mixin TutorialResponseMappable {
   }
 
   TutorialResponseCopyWith<TutorialResponse, TutorialResponse, TutorialResponse> get copyWith =>
-      _TutorialResponseCopyWithImpl<TutorialResponse, TutorialResponse>(this as TutorialResponse, $identity, $identity);
+      _TutorialResponseCopyWithImpl<TutorialResponse, TutorialResponse>(
+        this as TutorialResponse,
+        $identity,
+        $identity,
+      );
   @override
   String toString() {
-    return TutorialResponseMapper.ensureInitialized().stringifyValue(this as TutorialResponse);
+    return TutorialResponseMapper.ensureInitialized().stringifyValue(
+      this as TutorialResponse,
+    );
   }
 
   @override
   bool operator ==(Object other) {
-    return TutorialResponseMapper.ensureInitialized().equalsValue(this as TutorialResponse, other);
+    return TutorialResponseMapper.ensureInitialized().equalsValue(
+      this as TutorialResponse,
+      other,
+    );
   }
 
   @override
   int get hashCode {
-    return TutorialResponseMapper.ensureInitialized().hashValue(this as TutorialResponse);
+    return TutorialResponseMapper.ensureInitialized().hashValue(
+      this as TutorialResponse,
+    );
   }
 }
 
@@ -464,7 +709,9 @@ abstract class TutorialResponseCopyWith<$R, $In extends TutorialResponse, $Out>
     implements ClassCopyWith<$R, $In, $Out> {
   TutorialConfigCopyWith<$R, TutorialConfig, TutorialConfig>? get tutorial;
   $R call({TutorialConfig? tutorial, String? error});
-  TutorialResponseCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t);
+  TutorialResponseCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(
+    Then<$Out2, $R2> t,
+  );
 }
 
 class _TutorialResponseCopyWithImpl<$R, $Out> extends ClassCopyWithBase<$R, TutorialResponse, $Out>
@@ -477,14 +724,22 @@ class _TutorialResponseCopyWithImpl<$R, $Out> extends ClassCopyWithBase<$R, Tuto
   TutorialConfigCopyWith<$R, TutorialConfig, TutorialConfig>? get tutorial =>
       $value.tutorial?.copyWith.$chain((v) => call(tutorial: v));
   @override
-  $R call({Object? tutorial = $none, Object? error = $none}) =>
-      $apply(FieldCopyWithData({if (tutorial != $none) #tutorial: tutorial, if (error != $none) #error: error}));
+  $R call({Object? tutorial = $none, Object? error = $none}) => $apply(
+        FieldCopyWithData({
+          if (tutorial != $none) #tutorial: tutorial,
+          if (error != $none) #error: error,
+        }),
+      );
   @override
-  TutorialResponse $make(CopyWithData data) =>
-      TutorialResponse(data.get(#tutorial, or: $value.tutorial), data.get(#error, or: $value.error));
+  TutorialResponse $make(CopyWithData data) => TutorialResponse(
+        data.get(#tutorial, or: $value.tutorial),
+        data.get(#error, or: $value.error),
+      );
 
   @override
-  TutorialResponseCopyWith<$R2, TutorialResponse, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t) =>
+  TutorialResponseCopyWith<$R2, TutorialResponse, $Out2> $chain<$R2, $Out2>(
+    Then<$Out2, $R2> t,
+  ) =>
       _TutorialResponseCopyWithImpl<$R2, $Out2>($value, $cast, t);
 }
 
@@ -509,9 +764,15 @@ class TutorialConfigMapper extends ClassMapperBase<TutorialConfig> {
   static String _$name(TutorialConfig v) => v.name;
   static const Field<TutorialConfig, String> _f$name = Field('name', _$name);
   static List<TutorialStepConfig> _$steps(TutorialConfig v) => v.steps;
-  static const Field<TutorialConfig, List<TutorialStepConfig>> _f$steps = Field('steps', _$steps);
+  static const Field<TutorialConfig, List<TutorialStepConfig>> _f$steps = Field(
+    'steps',
+    _$steps,
+  );
   static TutorialStep _$initialStep(TutorialConfig v) => v.initialStep;
-  static const Field<TutorialConfig, TutorialStep> _f$initialStep = Field('initialStep', _$initialStep);
+  static const Field<TutorialConfig, TutorialStep> _f$initialStep = Field(
+    'initialStep',
+    _$initialStep,
+  );
 
   @override
   final MappableFields<TutorialConfig> fields = const {
@@ -522,7 +783,12 @@ class TutorialConfigMapper extends ClassMapperBase<TutorialConfig> {
   };
 
   static TutorialConfig _instantiate(DecodingData data) {
-    return TutorialConfig(data.dec(_f$id), data.dec(_f$name), data.dec(_f$steps), data.dec(_f$initialStep));
+    return TutorialConfig(
+      data.dec(_f$id),
+      data.dec(_f$name),
+      data.dec(_f$steps),
+      data.dec(_f$initialStep),
+    );
   }
 
   @override
@@ -539,28 +805,43 @@ class TutorialConfigMapper extends ClassMapperBase<TutorialConfig> {
 
 mixin TutorialConfigMappable {
   String toJson() {
-    return TutorialConfigMapper.ensureInitialized().encodeJson<TutorialConfig>(this as TutorialConfig);
+    return TutorialConfigMapper.ensureInitialized().encodeJson<TutorialConfig>(
+      this as TutorialConfig,
+    );
   }
 
   Map<String, dynamic> toMap() {
-    return TutorialConfigMapper.ensureInitialized().encodeMap<TutorialConfig>(this as TutorialConfig);
+    return TutorialConfigMapper.ensureInitialized().encodeMap<TutorialConfig>(
+      this as TutorialConfig,
+    );
   }
 
   TutorialConfigCopyWith<TutorialConfig, TutorialConfig, TutorialConfig> get copyWith =>
-      _TutorialConfigCopyWithImpl<TutorialConfig, TutorialConfig>(this as TutorialConfig, $identity, $identity);
+      _TutorialConfigCopyWithImpl<TutorialConfig, TutorialConfig>(
+        this as TutorialConfig,
+        $identity,
+        $identity,
+      );
   @override
   String toString() {
-    return TutorialConfigMapper.ensureInitialized().stringifyValue(this as TutorialConfig);
+    return TutorialConfigMapper.ensureInitialized().stringifyValue(
+      this as TutorialConfig,
+    );
   }
 
   @override
   bool operator ==(Object other) {
-    return TutorialConfigMapper.ensureInitialized().equalsValue(this as TutorialConfig, other);
+    return TutorialConfigMapper.ensureInitialized().equalsValue(
+      this as TutorialConfig,
+      other,
+    );
   }
 
   @override
   int get hashCode {
-    return TutorialConfigMapper.ensureInitialized().hashValue(this as TutorialConfig);
+    return TutorialConfigMapper.ensureInitialized().hashValue(
+      this as TutorialConfig,
+    );
   }
 }
 
@@ -573,8 +854,15 @@ abstract class TutorialConfigCopyWith<$R, $In extends TutorialConfig, $Out> impl
   ListCopyWith<$R, TutorialStepConfig, TutorialStepConfigCopyWith<$R, TutorialStepConfig, TutorialStepConfig>>
       get steps;
   TutorialStepCopyWith<$R, TutorialStep, TutorialStep> get initialStep;
-  $R call({String? id, String? name, List<TutorialStepConfig>? steps, TutorialStep? initialStep});
-  TutorialConfigCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t);
+  $R call({
+    String? id,
+    String? name,
+    List<TutorialStepConfig>? steps,
+    TutorialStep? initialStep,
+  });
+  TutorialConfigCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(
+    Then<$Out2, $R2> t,
+  );
 }
 
 class _TutorialConfigCopyWithImpl<$R, $Out> extends ClassCopyWithBase<$R, TutorialConfig, $Out>
@@ -585,26 +873,40 @@ class _TutorialConfigCopyWithImpl<$R, $Out> extends ClassCopyWithBase<$R, Tutori
   late final ClassMapperBase<TutorialConfig> $mapper = TutorialConfigMapper.ensureInitialized();
   @override
   ListCopyWith<$R, TutorialStepConfig, TutorialStepConfigCopyWith<$R, TutorialStepConfig, TutorialStepConfig>>
-      get steps => ListCopyWith($value.steps, (v, t) => v.copyWith.$chain(t), (v) => call(steps: v));
+      get steps => ListCopyWith(
+            $value.steps,
+            (v, t) => v.copyWith.$chain(t),
+            (v) => call(steps: v),
+          );
   @override
   TutorialStepCopyWith<$R, TutorialStep, TutorialStep> get initialStep =>
       $value.initialStep.copyWith.$chain((v) => call(initialStep: v));
   @override
-  $R call({String? id, String? name, List<TutorialStepConfig>? steps, TutorialStep? initialStep}) =>
-      $apply(FieldCopyWithData({
-        if (id != null) #id: id,
-        if (name != null) #name: name,
-        if (steps != null) #steps: steps,
-        if (initialStep != null) #initialStep: initialStep
-      }));
+  $R call({
+    String? id,
+    String? name,
+    List<TutorialStepConfig>? steps,
+    TutorialStep? initialStep,
+  }) =>
+      $apply(
+        FieldCopyWithData({
+          if (id != null) #id: id,
+          if (name != null) #name: name,
+          if (steps != null) #steps: steps,
+          if (initialStep != null) #initialStep: initialStep,
+        }),
+      );
   @override
   TutorialConfig $make(CopyWithData data) => TutorialConfig(
-      data.get(#id, or: $value.id),
-      data.get(#name, or: $value.name),
-      data.get(#steps, or: $value.steps),
-      data.get(#initialStep, or: $value.initialStep));
+        data.get(#id, or: $value.id),
+        data.get(#name, or: $value.name),
+        data.get(#steps, or: $value.steps),
+        data.get(#initialStep, or: $value.initialStep),
+      );
 
   @override
-  TutorialConfigCopyWith<$R2, TutorialConfig, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t) =>
+  TutorialConfigCopyWith<$R2, TutorialConfig, $Out2> $chain<$R2, $Out2>(
+    Then<$Out2, $R2> t,
+  ) =>
       _TutorialConfigCopyWithImpl<$R2, $Out2>($value, $cast, t);
 }

--- a/apps/jaspr_pad/lib/server/download.dart
+++ b/apps/jaspr_pad/lib/server/download.dart
@@ -21,13 +21,8 @@ Future<Response> downloadProject(Request request) async {
 }
 
 class ZipProjectEncoder {
-  late OutputStream _output;
-  late ZipEncoder _encoder;
-
-  ZipProjectEncoder() {
-    _encoder = ZipEncoder();
-    _output = OutputStream();
-  }
+  final OutputMemoryStream _output = OutputMemoryStream();
+  final ZipEncoder _encoder = ZipEncoder();
 
   Future<void> zipProject(ProjectData project) async {
     _encoder.startEncode(_output);
@@ -66,7 +61,7 @@ class ZipProjectEncoder {
   }
 
   void addFromSource(String file, String source) {
-    _encoder.addFile(ArchiveFile.string(file, source));
+    _encoder.add(ArchiveFile.string(file, source));
   }
 
   void close() {

--- a/apps/jaspr_pad/pubspec.yaml
+++ b/apps/jaspr_pad/pubspec.yaml
@@ -10,16 +10,15 @@ resolution: workspace
 
 dependencies:
   analysis_server_lib: ^0.2.5
-  archive: ^3.4.10
-  codemirror: ^0.7.11+5.65.13
+  archive: ^4.0.7
+  codemirror: ^0.7.14+5.65.18
   collection: ^1.18.0
-  dart_mappable: ^4.2.0
-  googleapis: ^13.0.0
-  googleapis_auth: ^1.4.1
-  http: ^1.1.2
+  dart_mappable: ^4.6.0
+  googleapis: ^13.2.0
+  googleapis_auth: ^1.6.0
+  http: ^1.2.1
   jaspr: ^0.20.0
   jaspr_riverpod: ^0.3.21
-  js: ^0.6.5
   markdown: ^7.1.1
   mdc_web: ^0.6.0
   path: ^1.9.0
@@ -31,14 +30,13 @@ dependencies:
 dev_dependencies:
   build_runner: ^2.6.0
   build_web_compilers: ^4.2.0
-  dart_mappable_builder: ^4.2.0
+  dart_mappable_builder: ^4.6.0
   jaspr_builder: ^0.20.0
   jaspr_lints: #^0.4.0
     path: ../../packages/jaspr_lints
   jaspr_test: ^0.20.0
   lints: ^5.0.0
   test: ^1.25.0
-  yaml_writer: ^1.0.1
 
 jaspr:
   mode: server

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: _flutterfire_internals
-      sha256: "401dd18096f5eaa140404ccbbbf346f83c850e6f27049698a7ee75a3488ddb32"
+      sha256: ff0a84a2734d9e1089f8aedd5c0af0061b82fb94e95260d943404e0ef2134b11
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.52"
+    version: "1.3.59"
   adaptive_number:
     dependency: transitive
     description:
@@ -77,10 +77,10 @@ packages:
     dependency: transitive
     description:
       name: archive
-      sha256: cb6a278ef2dbb298455e1a713bda08524a175630ec643a242c399c932a0a1f7d
+      sha256: "2fde1607386ab523f7a36bb3e7edb43bd58e6edaf2ffb29d8a6d578b297fdbbd"
       url: "https://pub.dev"
     source: hosted
-    version: "3.6.1"
+    version: "4.0.7"
   args:
     dependency: transitive
     description:
@@ -109,10 +109,10 @@ packages:
     dependency: transitive
     description:
       name: bazel_worker
-      sha256: "57035594b87d9f5af99f1a80e1edf5411dadbdf5acfc4f90403e3849f57dd0f0"
+      sha256: "373a6ef07caa6c674c1cf144a5fe1e0f712c040552031ce669f298e35f7e110a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "1.1.3"
   boolean_selector:
     dependency: transitive
     description:
@@ -141,18 +141,18 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: "7d95cbbb1526ab5ae977df9b4cc660963b9b27f6d1075c0b34653868911385e4"
+      sha256: "6439a9c71a4e6eca8d9490c1b380a25b02675aa688137dfbe66d2062884a23ac"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
+    version: "3.0.2"
   build_config:
     dependency: transitive
     description:
       name: build_config
-      sha256: "4ae2de3e1e67ea270081eaee972e1bd8f027d459f249e0f1186730784c2e7e33"
+      sha256: "4f64382b97504dc2fcdf487d5aae33418e08b4703fc21249e4db6d804a4d0187"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "1.2.0"
   build_daemon:
     dependency: transitive
     description:
@@ -173,34 +173,34 @@ packages:
     dependency: transitive
     description:
       name: build_resolvers
-      sha256: "38c9c339333a09b090a638849a4c56e70a404c6bdd3b511493addfbc113b60c2"
+      sha256: "2b21a125d66a86b9511cc3fb6c668c42e9a1185083922bf60e46d483a81a9712"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
+    version: "3.0.2"
   build_runner:
     dependency: transitive
     description:
       name: build_runner
-      sha256: b971d4a1c789eba7be3e6fe6ce5e5b50fd3719e3cb485b3fad6d04358304351d
+      sha256: fd3c09f4bbff7fa6e8d8ef688a0b2e8a6384e6483a25af0dac75fef362bcfe6f
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.0"
+    version: "2.7.0"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
-      sha256: c04e612ca801cd0928ccdb891c263a2b1391cb27940a5ea5afcf9ba894de5d62
+      sha256: ab27e46c8aa233e610cf6084ee6d8a22c6f873a0a9929241d8855b7a72978ae7
       url: "https://pub.dev"
     source: hosted
-    version: "9.2.0"
+    version: "9.3.0"
   build_test:
     dependency: transitive
     description:
       name: build_test
-      sha256: "090115dcc4a30c2e1dc0fdefbaa57d0d8d0237c964636bd7ba6928cfde9bf92f"
+      sha256: "995d0ef7273d8eebc1ce3c1ec1d3a958d5a059d0a020cc888c049d8e7f1a38ad"
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.0"
+    version: "3.3.2"
   build_web_compilers:
     dependency: transitive
     description:
@@ -261,18 +261,18 @@ packages:
     dependency: transitive
     description:
       name: charcode
-      sha256: fb98c0f6d12c920a02ee2d998da788bca066ca5f148492b7085ee23372b12306
+      sha256: fb0f1107cac15a5ea6ef0a6ef71a807b9e4267c713bb93e00e92d737cc8dbd8a
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.4.0"
   checked_yaml:
     dependency: transitive
     description:
       name: checked_yaml
-      sha256: feb6bed21949061731a7a75fc5d2aa727cf160b91af9a3e464c5e3a32e28b5ff
+      sha256: "959525d3162f249993882720d52b7e0c833978df229be20702b33d48d91de70f"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.4"
   ci:
     dependency: transitive
     description:
@@ -289,6 +289,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.5.1"
+  cli_config:
+    dependency: transitive
+    description:
+      name: cli_config
+      sha256: ac20a183a07002b700f0c25e61b7ee46b23c309d76ab7b7640a028f18e4d99ec
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   cli_launcher:
     dependency: transitive
     description:
@@ -297,14 +305,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.3.2+1"
-  cli_pkg:
-    dependency: transitive
-    description:
-      name: cli_pkg
-      sha256: eeeea1e0773c5d53fb80a179f82f12c96c50487a37b3cf0174499eb9884c55b2
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.12.0"
   cli_repl:
     dependency: transitive
     description:
@@ -333,26 +333,26 @@ packages:
     dependency: transitive
     description:
       name: cloud_firestore
-      sha256: "8dfe49146560af035314477995bdfb4a7104f33cb7f881748572fbda38ecfa55"
+      sha256: "2d33da4465bdb81b6685c41b535895065adcb16261beb398f5f3bbc623979e9c"
       url: "https://pub.dev"
     source: hosted
-    version: "5.6.4"
+    version: "5.6.12"
   cloud_firestore_platform_interface:
     dependency: transitive
     description:
       name: cloud_firestore_platform_interface
-      sha256: dc0bcc3239a4feaa4b7b184dc4b689bc97e6cea1a8320ee0d7ee64b3607858ea
+      sha256: "413c4e01895cf9cb3de36fa5c219479e06cd4722876274ace5dfc9f13ab2e39b"
       url: "https://pub.dev"
     source: hosted
-    version: "6.6.4"
+    version: "6.6.12"
   cloud_firestore_web:
     dependency: transitive
     description:
       name: cloud_firestore_web
-      sha256: "5091ed6771c886c9a93b1ec1ffa61770056210f1a3312095a73a5a4bab0c6a9f"
+      sha256: c1e30fc4a0fcedb08723fb4b1f12ee4e56d937cbf9deae1bda43cbb6367bb4cf
       url: "https://pub.dev"
     source: hosted
-    version: "4.4.4"
+    version: "4.4.12"
   code_builder:
     dependency: transitive
     description:
@@ -397,10 +397,10 @@ packages:
     dependency: transitive
     description:
       name: coverage
-      sha256: e3493833ea012784c740e341952298f1cc77f1f01b1bbc3eb4eecf6984fb7f43
+      sha256: "5da775aa218eaf2151c721b16c01c7676fbfdd99cebba2bf64e8b807a28ff94d"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.15.0"
   cross_file:
     dependency: transitive
     description:
@@ -485,10 +485,10 @@ packages:
     dependency: transitive
     description:
       name: dart_frog
-      sha256: "569db68a710bcadf96d8addc8988d09a93c4a9521cb6467c2df5ee0ab939c8a4"
+      sha256: "84b8f82413f622dfdcfba6982522f8752ece09b49fea9a35f8794a0b2bc357e4"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.3"
   dart_jsonwebtoken:
     dependency: transitive
     description:
@@ -524,10 +524,10 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "27eb0ae77836989a3bc541ce55595e8ceee0992807f14511552a898ddd0d88ac"
+      sha256: "8a0e5fba27e8ee025d2ffb4ee820b4e6e2cf5e4246a6b1a477eb66866947e0bb"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.1.1"
   dds:
     dependency: transitive
     description:
@@ -540,10 +540,10 @@ packages:
     dependency: transitive
     description:
       name: dds_service_extensions
-      sha256: "5a5f0f9af646505f5bb21159c78ae5c275cd8bdb99e1a8e27f2f395c49568743"
+      sha256: afe0fce921953ac0c5bb276bccd7e36fa5035d7769567d122523fdd09beb4d03
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "2.1.0"
   devtools_shared:
     dependency: transitive
     description:
@@ -556,10 +556,10 @@ packages:
     dependency: transitive
     description:
       name: dtd
-      sha256: "0284e4d02b9be48142c1adf0d14670fb56f0f333837e61d269e3ca7839d5e183"
+      sha256: "14a0360d898ded87c3d99591fc386b8a6ea5d432927bee709b22130cd25b993a"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.0"
+    version: "2.5.1"
   dwds:
     dependency: transitive
     description:
@@ -652,10 +652,10 @@ packages:
     dependency: transitive
     description:
       name: file_selector_macos
-      sha256: "271ab9986df0c135d45c3cdb6bd0faa5db6f4976d3e4b437cf7d0f258d941bfc"
+      sha256: "19124ff4a3d8864fdc62072b6a2ef6c222d55a3404fe14893a3c02744907b60c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.4+2"
+    version: "0.9.4+4"
   file_selector_platform_interface:
     dependency: transitive
     description:
@@ -676,50 +676,50 @@ packages:
     dependency: transitive
     description:
       name: firebase_auth
-      sha256: d0e2213daf3a740a379d4b788865dee6ada220496640abd875adb8f0fdbe5ba6
+      sha256: "0fed2133bee1369ee1118c1fef27b2ce0d84c54b7819a2b17dada5cfec3b03ff"
       url: "https://pub.dev"
     source: hosted
-    version: "5.5.0"
+    version: "5.7.0"
   firebase_auth_platform_interface:
     dependency: transitive
     description:
       name: firebase_auth_platform_interface
-      sha256: "9c291bafc2a88599405fc810a4b4c249a40065b094379afb701efe443a3b0653"
+      sha256: "871c9df4ec9a754d1a793f7eb42fa3b94249d464cfb19152ba93e14a5966b386"
       url: "https://pub.dev"
     source: hosted
-    version: "7.6.0"
+    version: "7.7.3"
   firebase_auth_web:
     dependency: transitive
     description:
       name: firebase_auth_web
-      sha256: a971b2f3a9c16b45e12687bb2e3d0da0c6fc272c4fbf6fa7833d0587844cca4d
+      sha256: d9ada769c43261fd1b18decf113186e915c921a811bd5014f5ea08f4cf4bc57e
       url: "https://pub.dev"
     source: hosted
-    version: "5.14.0"
+    version: "5.15.3"
   firebase_core:
     dependency: transitive
     description:
       name: firebase_core
-      sha256: "6a4ea0f1d533443c8afc3d809cd36a4e2b8f2e2e711f697974f55bb31d71d1b8"
+      sha256: "7be63a3f841fc9663342f7f3a011a42aef6a61066943c90b1c434d79d5c995c5"
       url: "https://pub.dev"
     source: hosted
-    version: "3.12.0"
+    version: "3.15.2"
   firebase_core_platform_interface:
     dependency: transitive
     description:
       name: firebase_core_platform_interface
-      sha256: d7253d255ff10f85cfd2adaba9ac17bae878fa3ba577462451163bd9f1d1f0bf
+      sha256: "5dbc900677dcbe5873d22ad7fbd64b047750124f1f9b7ebe2a33b9ddccc838eb"
       url: "https://pub.dev"
     source: hosted
-    version: "5.4.0"
+    version: "6.0.0"
   firebase_core_web:
     dependency: transitive
     description:
       name: firebase_core_web
-      sha256: e47f5c2776de018fa19bc9f6f723df136bc75cdb164d64b65305babd715c8e41
+      sha256: "0ed0dc292e8f9ac50992e2394e9d336a0275b6ae400d64163fdf0a8a8b556c37"
       url: "https://pub.dev"
     source: hosted
-    version: "2.21.0"
+    version: "2.24.1"
   fixnum:
     dependency: transitive
     description:
@@ -753,10 +753,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_plugin_android_lifecycle
-      sha256: "615a505aef59b151b46bbeef55b36ce2b6ed299d160c51d84281946f0aa0ce0e"
+      sha256: b0694b7fb1689b0e6cc193b3f1fcac6423c4f93c74fb20b806c6b6f196db0c31
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.24"
+    version: "2.0.30"
   flutter_riverpod:
     dependency: transitive
     description:
@@ -811,50 +811,50 @@ packages:
     dependency: transitive
     description:
       name: google_identity_services_web
-      sha256: "55580f436822d64c8ff9a77e37d61f5fb1e6c7ec9d632a43ee324e2a05c3c6c9"
+      sha256: "5d187c46dc59e02646e10fe82665fc3884a9b71bc1c90c2b8b749316d33ee454"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.3"
+    version: "0.3.3+1"
   google_sign_in:
     dependency: transitive
     description:
       name: google_sign_in
-      sha256: fad6ddc80c427b0bba705f2116204ce1173e09cf299f85e053d57a55e5b2dd56
+      sha256: d0a2c3bcb06e607bb11e4daca48bd4b6120f0bbc4015ccebbe757d24ea60ed2a
       url: "https://pub.dev"
     source: hosted
-    version: "6.2.2"
+    version: "6.3.0"
   google_sign_in_android:
     dependency: transitive
     description:
       name: google_sign_in_android
-      sha256: "7af72e5502c313865c729223b60e8ae7bce0a1011b250c24edcf30d3d7032748"
+      sha256: d5e23c56a4b84b6427552f1cf3f98f716db3b1d1a647f16b96dbb5b93afa2805
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.35"
+    version: "6.2.1"
   google_sign_in_ios:
     dependency: transitive
     description:
       name: google_sign_in_ios
-      sha256: "8468465516a6fdc283ffbbb06ec03a860ee34e9ff84b0454074978705b42379b"
+      sha256: "102005f498ce18442e7158f6791033bbc15ad2dcc0afa4cf4752e2722a516c96"
       url: "https://pub.dev"
     source: hosted
-    version: "5.8.0"
+    version: "5.9.0"
   google_sign_in_platform_interface:
     dependency: transitive
     description:
       name: google_sign_in_platform_interface
-      sha256: "1f6e5787d7a120cc0359ddf315c92309069171306242e181c09472d1b00a2971"
+      sha256: "5f6f79cf139c197261adb6ac024577518ae48fdff8e53205c5373b5f6430a8aa"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.5"
+    version: "2.5.0"
   google_sign_in_web:
     dependency: transitive
     description:
       name: google_sign_in_web
-      sha256: ada595df6c30cead48e66b1f3a050edf0c5cf2ba60c185d69690e08adcc6281b
+      sha256: "460547beb4962b7623ac0fb8122d6b8268c951cf0b646dd150d60498430e4ded"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.4+3"
+    version: "0.12.4+4"
   googleapis:
     dependency: transitive
     description:
@@ -887,14 +887,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.2"
-  grinder:
-    dependency: transitive
-    description:
-      name: grinder
-      sha256: e1996e485d2b56bb164a8585679758d488fbf567273f51c432c8733fee1f6188
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.9.5"
   highlight:
     dependency: transitive
     description:
@@ -915,10 +907,10 @@ packages:
     dependency: transitive
     description:
       name: html
-      sha256: "1fc58edeaec4307368c60d59b7e15b9d658b57d7f3125098b6294153c75337ec"
+      sha256: "6d1264f2dffa1b1101c25a91dff0dc2daee4c18e87cd8538729773c073dbf602"
       url: "https://pub.dev"
     source: hosted
-    version: "0.15.5"
+    version: "0.15.6"
   html_unescape:
     dependency: transitive
     description:
@@ -963,10 +955,10 @@ packages:
     dependency: transitive
     description:
       name: image
-      sha256: f31d52537dc417fdcde36088fdf11d191026fd5e4fae742491ebd40e5a8bea7d
+      sha256: "4e973fcf4caae1a4be2fa0a13157aa38a8f9cb049db6529aa00b4d71abc4d928"
       url: "https://pub.dev"
     source: hosted
-    version: "4.3.0"
+    version: "4.5.4"
   image_cropper:
     dependency: transitive
     description:
@@ -979,82 +971,82 @@ packages:
     dependency: transitive
     description:
       name: image_cropper_for_web
-      sha256: "34256c8fb7fcb233251787c876bb37271744459b593a948a2db73caa323034d0"
+      sha256: fd81ebe36f636576094377aab32673c4e5d1609b32dec16fad98d2b71f1250a9
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.2"
+    version: "6.1.0"
   image_cropper_platform_interface:
     dependency: transitive
     description:
       name: image_cropper_platform_interface
-      sha256: e8e9d2ca36360387aee39295ce49029362ae4df3071f23e8e71f2b81e40b7531
+      sha256: "6ca6b81769abff9a4dcc3bbd3d75f5dfa9de6b870ae9613c8cd237333a4283af"
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.0"
+    version: "7.1.0"
   image_picker:
     dependency: transitive
     description:
       name: image_picker
-      sha256: "021834d9c0c3de46bf0fe40341fa07168407f694d9b2bb18d532dc1261867f7a"
+      sha256: "736eb56a911cf24d1859315ad09ddec0b66104bc41a7f8c5b96b4e2620cf5041"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "1.2.0"
   image_picker_android:
     dependency: transitive
     description:
       name: image_picker_android
-      sha256: "82652a75e3dd667a91187769a6a2cc81bd8c111bbead698d8e938d2b63e5e89a"
+      sha256: "28f3987ca0ec702d346eae1d90eda59603a2101b52f1e234ded62cff1d5cfa6e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.12+21"
+    version: "0.8.13+1"
   image_picker_for_web:
     dependency: transitive
     description:
       name: image_picker_for_web
-      sha256: "717eb042ab08c40767684327be06a5d8dbb341fe791d514e4b92c7bbe1b7bb83"
+      sha256: "40c2a6a0da15556dc0f8e38a3246064a971a9f512386c3339b89f76db87269b6"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.6"
+    version: "3.1.0"
   image_picker_ios:
     dependency: transitive
     description:
       name: image_picker_ios
-      sha256: "05da758e67bc7839e886b3959848aa6b44ff123ab4b28f67891008afe8ef9100"
+      sha256: eb06fe30bab4c4497bad449b66448f50edcc695f1c59408e78aa3a8059eb8f0e
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.12+2"
+    version: "0.8.13"
   image_picker_linux:
     dependency: transitive
     description:
       name: image_picker_linux
-      sha256: "4ed1d9bb36f7cd60aa6e6cd479779cc56a4cb4e4de8f49d487b1aaad831300fa"
+      sha256: "1f81c5f2046b9ab724f85523e4af65be1d47b038160a8c8deed909762c308ed4"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.1+1"
+    version: "0.2.2"
   image_picker_macos:
     dependency: transitive
     description:
       name: image_picker_macos
-      sha256: "1b90ebbd9dcf98fb6c1d01427e49a55bd96b5d67b8c67cf955d60a5de74207c1"
+      sha256: d58cd9d67793d52beefd6585b12050af0a7663c0c2a6ece0fb110a35d6955e04
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.1+2"
+    version: "0.2.2"
   image_picker_platform_interface:
     dependency: transitive
     description:
       name: image_picker_platform_interface
-      sha256: "886d57f0be73c4b140004e78b9f28a8914a09e50c2d816bdd0520051a71236a0"
+      sha256: "9f143b0dba3e459553209e20cc425c9801af48e6dfa4f01a0fcf927be3f41665"
       url: "https://pub.dev"
     source: hosted
-    version: "2.10.1"
+    version: "2.11.0"
   image_picker_windows:
     dependency: transitive
     description:
       name: image_picker_windows
-      sha256: "6ad07afc4eb1bc25f3a01084d28520496c4a3bb0cb13685435838167c9dcedeb"
+      sha256: d248c86554a72b5495a31c56f060cf73a41c7ff541689327b1a7dbccc33adfae
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.1+1"
+    version: "0.2.2"
   intl:
     dependency: transitive
     description:
@@ -1067,10 +1059,10 @@ packages:
     dependency: transitive
     description:
       name: io
-      sha256: "2ec25704aba361659e10e3e5f5d672068d332fc8ac516421d483a11e5cbd061e"
+      sha256: dfd5a80599cf0165756e3181807ed3e77daf6dd4137caaad72d0b7931597650b
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.5"
   jaspr_web_compilers:
     dependency: transitive
     description:
@@ -1179,18 +1171,18 @@ packages:
     dependency: transitive
     description:
       name: mason
-      sha256: "4439bb2902b24298ff5c8e4d173afd7c665d9837ae0324608e7d2963c37e7928"
+      sha256: de5681849fd49bb4f53f703f439b1d9dac64ff472e49b5dfb23ad5d837185780
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.0"
+    version: "0.1.1"
   mason_logger:
     dependency: transitive
     description:
       name: mason_logger
-      sha256: "28afd064c416f454aaabb870ecac813f25aec4a0c01fd13078624a5c26797a46"
+      sha256: "6d5a989ff41157915cb5162ed6e41196d5e31b070d2f86e1c2edf216996a158c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.2"
+    version: "0.3.3"
   matcher:
     dependency: transitive
     description:
@@ -1264,30 +1256,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
-  native_stack_traces:
-    dependency: transitive
-    description:
-      name: native_stack_traces
-      sha256: "64d2f4bcf3b69326fb9bc91b4dd3a06f94bb5bbc3a65e25ae6467ace0b34bfd3"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.5.7"
-  native_synchronization:
-    dependency: transitive
-    description:
-      name: native_synchronization
-      sha256: "047fa3665d611e178edc167e56166714f125750f064d20216892f1cca69d9d1d"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.3.1"
   node_interop:
     dependency: transitive
     description:
       name: node_interop
-      sha256: "3af2420c728173806f4378cf89c53ba9f27f7f67792b898561bff9d390deb98e"
+      sha256: "4848ac408c0cdd0f70136b755df816a8e4c96c244e5377a3fb3b8f8950666150"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.2.0"
   node_preamble:
     dependency: transitive
     description:
@@ -1316,10 +1292,10 @@ packages:
     dependency: transitive
     description:
       name: package_config
-      sha256: "92d4488434b520a62570293fbd33bb556c7d49230791c1b4bbd973baf6d2dc67"
+      sha256: f096c55ebb7deb7e384101542bfba8c52696c1b56fca2eb62827989ef2353bbc
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.2.0"
   path:
     dependency: transitive
     description:
@@ -1340,18 +1316,18 @@ packages:
     dependency: transitive
     description:
       name: path_provider_android
-      sha256: "4adf4fd5423ec60a29506c76581bc05854c55e3a0b72d35bb28d661c9686edf2"
+      sha256: "993381400e94d18469750e5b9dcb8206f15bc09f9da86b9e44a9b0092a0066db"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.15"
+    version: "2.2.18"
   path_provider_foundation:
     dependency: transitive
     description:
       name: path_provider_foundation
-      sha256: "4843174df4d288f5e29185bd6e72a6fbdf5a4a4602717eed565497429f179942"
+      sha256: "16eef174aacb07e09c351502740fa6254c165757638eba1e9116b0a781201bbd"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.1"
+    version: "2.4.2"
   path_provider_linux:
     dependency: transitive
     description:
@@ -1424,22 +1400,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.1"
+  posix:
+    dependency: transitive
+    description:
+      name: posix
+      sha256: "6323a5b0fa688b6a010df4905a56b00181479e6d10534cecfecede2aa55add61"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.0.3"
   postgres:
     dependency: transitive
     description:
       name: postgres
-      sha256: "83ba7afb0e778cc1f373e514c6110d323b81dfbaced774d3a7f4a0e21536eb45"
+      sha256: "9aaa6f4872956adef653535a4e2133b167465c1a68c22b9bd0744ef1244e9393"
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.8"
+    version: "3.5.6"
   process:
     dependency: transitive
     description:
       name: process
-      sha256: "107d8be718f120bbba9dcd1e95e3bd325b1b4a4f07db64154635ba03f2567a0d"
+      sha256: c6248e4526673988586e8c00bb22a49210c258dc91df5227d5da9748ecf79744
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.3"
+    version: "5.0.5"
   prompts:
     dependency: transitive
     description:
@@ -1484,10 +1468,10 @@ packages:
     dependency: transitive
     description:
       name: quiver
-      sha256: b1c1ac5ce6688d77f65f3375a9abb9319b3cb32486bdc7a1e0fdf004d7ba4e47
+      sha256: ea0b925899e64ecdfbf9c7becb60d5b50e706ade44a85b2363be2a22d88117d2
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.1"
+    version: "3.2.2"
   redis:
     dependency: transitive
     description:
@@ -1540,10 +1524,10 @@ packages:
     dependency: transitive
     description:
       name: sass
-      sha256: e65ec3215d10bbea7b3dc90d5394546c0b1b749d9faada52aa5626605a077ab2
+      sha256: "341b33ebcb8fe3ed6c793bcfe1d01edd886bc58d68ff3febf29c0b391ac24296"
       url: "https://pub.dev"
     source: hosted
-    version: "1.85.0"
+    version: "1.66.0"
   sass_builder:
     dependency: transitive
     description:
@@ -1628,18 +1612,18 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences
-      sha256: "846849e3e9b68f3ef4b60c60cf4b3e02e9321bc7f4d8c4692cf87ffa82fc8a3a"
+      sha256: "6e8bf70b7fef813df4e9a36f658ac46d107db4b4cfe1048b477d4e453a8159f5"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.2"
+    version: "2.5.3"
   shared_preferences_android:
     dependency: transitive
     description:
       name: shared_preferences_android
-      sha256: a768fc8ede5f0c8e6150476e14f38e2417c0864ca36bb4582be8e21925a03c22
+      sha256: a2608114b1ffdcbc9c120eb71a0e207c71da56202852d4aab8a5e30a82269e74
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.6"
+    version: "2.4.12"
   shared_preferences_foundation:
     dependency: transitive
     description:
@@ -1801,18 +1785,18 @@ packages:
     dependency: transitive
     description:
       name: sqflite_android
-      sha256: "2b3070c5fa881839f8b402ee4a39c1b4d561704d4ebbbcfb808a119bc2a1701b"
+      sha256: ecd684501ebc2ae9a83536e8b15731642b9570dc8623e0073d227d0ee2bfea88
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.1"
+    version: "2.4.2+2"
   sqflite_common:
     dependency: transitive
     description:
       name: sqflite_common
-      sha256: "84731e8bfd8303a3389903e01fb2141b6e59b5973cacbb0929021df08dddbe8b"
+      sha256: "6ef422a4525ecc601db6c0a2233ff448c731307906e92cabc9ba292afaae16a6"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.5"
+    version: "2.5.6"
   sqflite_darwin:
     dependency: transitive
     description:
@@ -1833,10 +1817,10 @@ packages:
     dependency: transitive
     description:
       name: sse
-      sha256: "4389a01d5bc7ef3e90fbc645f8e7c6d8711268adb1f511e14ae9c71de47ee32b"
+      sha256: fcc97470240bb37377f298e2bd816f09fd7216c07928641c0560719f50603643
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.7"
+    version: "4.1.8"
   stack_trace:
     dependency: transitive
     description:
@@ -1889,10 +1873,10 @@ packages:
     dependency: transitive
     description:
       name: synchronized
-      sha256: "0669c70faae6270521ee4f05bffd2919892d42d1276e6c495be80174b6bc0ef6"
+      sha256: c254ade258ec8282947a0acbbc90b9575b4f19673533ee46f2f6e9b3aeefd7c0
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.1"
+    version: "3.4.0"
   syntax_highlight_lite:
     dependency: transitive
     description:
@@ -1941,14 +1925,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.11"
-  test_process:
-    dependency: transitive
-    description:
-      name: test_process
-      sha256: ea79c090deffc87d8276a5d28bb498d080a9873be6b1074d9dcfb82eb87e138e
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.1.1"
   timezone:
     dependency: transitive
     description:
@@ -1977,34 +1953,34 @@ packages:
     dependency: transitive
     description:
       name: typed_data
-      sha256: "26f87ade979c47a150c9eaab93ccd2bebe70a27dc0b4b29517f2904f04eb11a5"
+      sha256: f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.4.0"
   unified_analytics:
     dependency: transitive
     description:
       name: unified_analytics
-      sha256: b85c6ace8bf31b3cfd358a1b727db501eb30ee71984abcb3bfbcdec45e3172da
+      sha256: "8d1429a4b27320a9c4fc854287d18c8fde1549bf622165c5837202a9f370b53d"
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.1"
+    version: "8.0.5"
   universal_web:
     dependency: transitive
     description:
       name: universal_web
-      sha256: fd161c6424fd78625097429b0050c2ea967304fb2b8b5ea0c0f51cd41b915053
+      sha256: "045d5d5277f7dd3b6838b08098f5ec4cfb15b790c5d3deb8e79f642ae1af3ad2"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0+2"
+    version: "1.1.1"
   unorm_dart:
     dependency: transitive
     description:
       name: unorm_dart
-      sha256: "23d8bf65605401a6a32cff99435fed66ef3dab3ddcad3454059165df46496a3b"
+      sha256: "8e3870a1caa60bde8352f9597dd3535d8068613269444f8e35ea8925ec84c1f5"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0"
+    version: "0.3.1+1"
   uuid:
     dependency: transitive
     description:
@@ -2049,26 +2025,26 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: cd3543bd5798f6ad290ea73d210f423502e71900302dde696f8bff84bf89a1cb
+      sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   web_socket:
     dependency: transitive
     description:
       name: web_socket
-      sha256: "3c12d96c0c9a4eec095246debcea7b86c0324f22df69893d538fcc6f1b8cce83"
+      sha256: "34d64019aa8e36bf9842ac014bb5d2f5586ca73df5e4d9bf5c936975cae6982c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.6"
+    version: "1.0.1"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      sha256: "0b8e2457400d8a859b7b2030786835a28a8e80836ef64402abef392ff4f1d0e5"
+      sha256: d645757fb0f4773d602444000a8131ff5d48c9e47adfe9772652dd1a4f2d45c8
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.3"
   webdev:
     dependency: transitive
     description:
@@ -2089,10 +2065,10 @@ packages:
     dependency: transitive
     description:
       name: win32
-      sha256: b89e6e24d1454e149ab20fbb225af58660f0c0bf4475544650700d8e2da54aef
+      sha256: "66814138c3562338d05613a6e368ed8cfb237ad6d64a9e9334be3f309acfca03"
       url: "https://pub.dev"
     source: hosted
-    version: "5.11.0"
+    version: "5.14.0"
   x509:
     dependency: transitive
     description:
@@ -2133,14 +2109,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.2"
-  yaml_writer:
-    dependency: transitive
-    description:
-      name: yaml_writer
-      sha256: "76740047e3d4b1687c588bc8cb3466bea55a7d915a91bb23e99ea2a8c58337b6"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.3"
 sdks:
   dart: ">=3.9.0 <3.10.0-z"
-  flutter: ">=3.24.0"
+  flutter: ">=3.29.0"


### PR DESCRIPTION
- Removes `yaml_writer` as a dev dependency as it wasn't used anymore.
- Removes `package:js` as a dev dependency and replaces it with `dart:js_interop`
- Updates `package:archive` to v4 and makes the necessary migrations
- Tightens a few other dependency constraints, including dart_mappable
- Regenerates various built files
