### PR TITLE
[jaspr] Add doc comments to classes underlying annotations

### DIFF
--- a/packages/jaspr/lib/src/foundation/annotations.dart
+++ b/packages/jaspr/lib/src/foundation/annotations.dart
@@ -1,21 +1,24 @@
 /// Used to annotate a client component.
 const client = ClientAnnotation._();
 
-class ClientAnnotation {
+/// Use with [client] to annotate a client component.
+final class ClientAnnotation {
   const ClientAnnotation._();
 }
 
 /// Used to annotate an encoder function for a custom model.
 const encoder = EncoderAnnotation._();
 
-class EncoderAnnotation {
+/// Use with [encoder] to annotate an encoder function for a custom model.
+final class EncoderAnnotation {
   const EncoderAnnotation._();
 }
 
 /// Used to annotate an decoder function for a custom model.
 const decoder = DecoderAnnotation._();
 
-class DecoderAnnotation {
+/// Use with [decoder] to annotate an decoder function for a custom model.
+final class DecoderAnnotation {
   const DecoderAnnotation._();
 }
 
@@ -48,7 +51,7 @@ class DecoderAnnotation {
 /// ```
 ///
 /// Accessing your imported elements on the wrong platform will result in runtime exceptions.
-class Import {
+final class Import {
   const Import.onWeb(this.import, {required this.show}) : platform = ImportPlatform.web;
   const Import.onServer(this.import, {required this.show}) : platform = ImportPlatform.server;
 


### PR DESCRIPTION
Add doc comments to the classes underlying the framework annotations that point back to the top-level constants that should be used.

Also make the classes `final` to more clearly indicate they can't be subclassed.