### PR TITLE
[jaspr_pad] Dependency updates and clean up

### DIFF
--- a/apps/jaspr_pad/lib/adapters/hljs.dart
+++ b/apps/jaspr_pad/lib/adapters/hljs.dart
@@ -1,7 +1,4 @@
-@JS()
-library;
-
-import 'package:js/js.dart';
+import 'dart:js_interop';
 
 @JS('hljs.highlightAll')
 external void highlightAll();

--- a/apps/jaspr_pad/pubspec.yaml
+++ b/apps/jaspr_pad/pubspec.yaml
@@ -8,20 +8,19 @@ environment:
 
 dependencies:
   analysis_server_lib: ^0.2.5
-  archive: ^3.4.10
-  codemirror: ^0.7.11+5.65.13
+  archive: ^3.6.1
+  codemirror: ^0.7.14+5.65.18
   collection: ^1.18.0
-  dart_mappable: ^4.2.0
-  googleapis: ^13.0.0
-  googleapis_auth: ^1.4.1
-  http: ^1.1.2
+  dart_mappable: ^4.6.1
+  googleapis: ^13.2.0
+  googleapis_auth: ^1.6.0
+  http: ^1.2.1
   jaspr: ^0.21.0
   jaspr_riverpod: ^0.3.21
-  js: ^0.6.5
   markdown: ^7.1.1
   mdc_web: ^0.6.0
   path: ^1.9.0
-  sass_builder: ^2.2.1
+  sass_builder: ^2.3.1
   shelf: ^1.4.1
   shelf_router: ^1.1.2
   yaml: ^3.1.0
@@ -29,12 +28,11 @@ dependencies:
 dev_dependencies:
   build_runner: ^2.6.0
   build_web_compilers: ^4.2.0
-  dart_mappable_builder: ^4.2.0
+  dart_mappable_builder: ^4.6.1
   jaspr_builder: ^0.21.0
   jaspr_test: ^0.21.0
   lints: ^5.0.0
   test: ^1.25.0
-  yaml_writer: ^1.0.1
 
 dependency_overrides: 
   jaspr_riverpod:


### PR DESCRIPTION
- Removes `yaml_writer` as a dev dependency as it wasn't used anymore.
- Removes `package:js` as a dev dependency and replaces it with `dart:js_interop`
- Tightens a few other dependency constraints