### PR TITLE
Fix CI workflows for changes to `examples/` and `apps/`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,13 +5,19 @@ on:
       - main
     paths:
       - '.github/workflows/test.yml'
+      - 'apps/**'
+      - 'examples/**'
       - 'packages/**'
+      - 'pubspec.lock'
   push:
     branches:
       - main
     paths:
       - '.github/workflows/test.yml'
+      - 'apps/**'
+      - 'examples/**'
       - 'packages/**'
+      - 'pubspec.lock'
 
 name: Test Pipeline
 


### PR DESCRIPTION
If changes are only made to the `examples/` or `apps/` directories, the CI workflows weren't running, causing them to constantly show as not started on PRs. However, since they're part of the workspace (and therefore analysis checks), CI should be run on changes to them.