### PR TITLE
[content] Fix resolution of partial files in `LiquidTemplateEngine`

### DIFF
--- a/packages/jaspr_content/CHANGELOG.md
+++ b/packages/jaspr_content/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased minor dev.0
+
+- The `LiquidTemplateEngine` is no longer `const`.
+- Fixed resolution of partial files in `LiquidTemplateEngine`.
+
 ## 0.3.1-dev.1
 
 - `jaspr` upgraded to `0.21.0-dev.1`


### PR DESCRIPTION
I was needing to specify my `_includes` directory as `_includes/<anything>`, I guess because `Uri` resolution works differently than path resolution.

This PR updates the handling to instead resolve the paths with `package:path` (which is already a dependency) and documents the behavior and expected format of the `includesPath` parameter.