### PR TITLE
Linux file watcher

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,3 +14,4 @@ Ahmed Fwela (ahmednfwela) - Contributor
 Shubham LaV (shubhamvg) - Contributor
 Simon Lightfoot (slightfoot) - Contributor
 Matej Bačo (Meldiron) - Contributor
+Simon Binder (simolus3) - Contributor

--- a/packages/jaspr_content/CHANGELOG.md
+++ b/packages/jaspr_content/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.2 (unreleased)
+
+- Fix `FilesystemLoader` not recognizing file changes on Linux.
+
 ## 0.4.1
 
 - `jaspr` upgraded to `0.21.1`

--- a/packages/jaspr_content/CHANGELOG.md
+++ b/packages/jaspr_content/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.4.2 (unreleased)
+## Unreleased patch
 
 - Fix `FilesystemLoader` not recognizing file changes on Linux.
 

--- a/packages/jaspr_content/lib/src/route_loader/filesystem_loader.dart
+++ b/packages/jaspr_content/lib/src/route_loader/filesystem_loader.dart
@@ -4,6 +4,7 @@ import 'package:file/file.dart';
 import 'package:file/local.dart';
 import 'package:jaspr/server.dart';
 import 'package:jaspr_router/jaspr_router.dart';
+import 'package:path/path.dart' as p;
 import 'package:watcher/watcher.dart';
 
 import '../page.dart';
@@ -45,7 +46,7 @@ class FilesystemLoader extends RouteLoaderBase {
   Future<List<RouteBase>> loadRoutes(ConfigResolver resolver, bool eager) async {
     if (kDebugMode) {
       _watcherSub ??= watcherFactory(directory).events.listen((event) {
-        var path = event.path;
+        var path = p.normalize(p.relative(event.path));
         if (event.type == ChangeType.MODIFY) {
           invalidateFile(path);
         } else if (event.type == ChangeType.REMOVE) {

--- a/packages/jaspr_content/lib/src/route_loader/filesystem_loader.dart
+++ b/packages/jaspr_content/lib/src/route_loader/filesystem_loader.dart
@@ -46,6 +46,8 @@ class FilesystemLoader extends RouteLoaderBase {
   Future<List<RouteBase>> loadRoutes(ConfigResolver resolver, bool eager) async {
     if (kDebugMode) {
       _watcherSub ??= watcherFactory(directory).events.listen((event) {
+        // It looks like event.path is relative on most platforms, but an
+        // absolute path on Linux. Turn this into the expected relative path.
         var path = p.normalize(p.relative(event.path));
         if (event.type == ChangeType.MODIFY) {
           invalidateFile(path);


### PR DESCRIPTION
## Description

On Linux, a `DirectoryWatcher` seems to emit absolute paths instead of the relative paths seen on macOS (which is actually somewhat surprising to me - this may be an SDK / `package:watcher` bug since I couldn't find any documentation mentioning this).

Anyway, since e.g. `invalidateFile` compares `FilePageSource`s by their exact path, this means that updating pages on Linux does not work, which can be reproduced by running `jaspr create --template=docs my_site && jaspr serve`, visiting the page, updating `content/index.md` and reloading (served content will not change).

This fixes that issue by using relative paths on all platforms.

## Type of Change

<!-- - ❌ Breaking change -->
<!-- - ✨ New feature or improvement -->
🛠️ Bug fix
<!-- - 🧹 Code refactor -->
<!-- - 📝 Documentation -->
<!-- - 🗑️ Chore -->

## Ready Checklist

- [x] I've read the [Contribution Guide](https://github.com/schultek/jaspr/blob/main/CONTRIBUTING.md).
- [x] In case this PR changes one of the core packages, I've modified the respective **CHANGELOG.md** file using
      the [semantic_changelog](https://github.com/rrousselGit/semantic_changelog) format.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added myself to the AUTHORS file (optional, if you want to).

<!-- 
  Feel free to expand this list if you have additional todos before your PR is ready. 
-->

<!--
  If you need help, consider asking for advice on the *#contribute* channel on [Discord](https://discord.gg/XGXrGEk4c6).
-->
