### PR TITLE
Change double to duration

### DIFF
--- a/packages/jaspr/CHANGELOG.md
+++ b/packages/jaspr/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 - Fix tooling daemon crash while analyzing component scopes.
 
+- Added `ms` getter on int to allow shorthand conversion to durations (in milliseconds).
+- **Breaking**: `Transition`'s `duration` and `delay` are now of type `Duration` instead of `double`.
+
 ## 0.21.2
 
 - Added html domain to tooling daemon.
@@ -70,7 +73,7 @@
 
 - Added `allowedPathSuffixes` option to `Jaspr.initializeApp()` to enable handling route paths with extensions other than `html`.
 
-- Added support for generating a **sitemap.xml** in static mode. To enable this, pass `--sitemap-domain=my.domain.com` to `jaspr build`. 
+- Added support for generating a **sitemap.xml** in static mode. To enable this, pass `--sitemap-domain=my.domain.com` to `jaspr build`.
 
   Add sitemap params like `changefreq` and `priority` to your routes by using `Route(settings: RouteSettings(priority: 0.5))` or set them through `ServerApp.requestRouteGeneration()`.
 
@@ -109,7 +112,7 @@
 
 - **BREAKING** Changed `AppBinding`s `Uri get currentUri` to `String get currentUrl`.
 
-- **BREAKING** Changed return type of `renderComponent()` from `Future<String>` to `Future<({int statusCode, String body, Map<String, List<String>> headers})>`. 
+- **BREAKING** Changed return type of `renderComponent()` from `Future<String>` to `Future<({int statusCode, String body, Map<String, List<String>> headers})>`.
 
   The rendered html is accessible through the `body` property. `statusCode` and `headers` can be used to create a response object when part of a custom http handler.
 
@@ -120,6 +123,7 @@
 - Deprecated having seperate style groups (`Styles.box()`, `Styles.text()`, `Styles.background()`, etc. as well as `.box()`, `.text()`, etc.). All styling properties are now available under the single `Styles()` constructur and `.styles()` method.
 
   **Before:**
+
   ```dart
   css('.main')
     .box(width: 100.px, height: 100.px)
@@ -128,6 +132,7 @@
   ````
 
   **After:**
+
   ```dart
   css('.main').styles(
     width: 100.px,
@@ -148,7 +153,6 @@
 - Update logo and website links.
 
 ## 0.17.0
-
 
 - **BREAKING** Removed `currentState` from `GlobalKey`, use `GlobalStateKey` instead.
 - Added `GlobalStateKey<T extends State>` to access the state of a component using `currentState`.
@@ -280,11 +284,14 @@
   To enable this a custom model class must have two methods:
 
   - An instance method that encodes the model to a primitive value and is annotated with `@encoder`:
+
     ```dart
     @encoder
     String toJson() { ... }
     ```
+
   - A static method that decodes the model from a primitive value and is annotated with `@decoder`:
+
     ```dart
     @decoder
     static MyModel fromJson(String json) { ... }
@@ -593,7 +600,7 @@
     jaspr_web_compilers: ^4.0.4
   ```
 
-  For an example see `examples/flutter_plugin_interop`](https://github.com/schultek/Jaspr/tree/main/examples/flutter_plugin_interop).
+  For an example see [`examples/flutter_plugin_interop`](https://github.com/schultek/Jaspr/tree/main/examples/flutter_plugin_interop).
 
 - Improved **flutter element embedding**.
 
@@ -603,7 +610,7 @@
   This removes the need for any kind of interop between apps as they can directly communicate
   through the usual primitives of passing properties and callbacks.
 
-  For an example see `examples/flutter_embedding`](https://github.com/schultek/jaspr/tree/main/examples/flutter_embedding).
+  For an example see [`examples/flutter_embedding`](https://github.com/schultek/jaspr/tree/main/examples/flutter_embedding).
 
 - `jaspr build` now outputs to `/build/jaspr` instead of `/build`.
 
@@ -646,10 +653,12 @@
 ## 0.3.0
 
 - **BREAKING** The cli is now a separate package: `jaspr_cli`. To migrate run:
+
   ```shell
     dart pub global deactivate jaspr
     dart pub global activate jaspr_cli
   ```
+
   The usage stays the same with `jaspr create`, `jaspr serve` and `jaspr build`.
 
 ## 0.2.0

--- a/packages/jaspr/lib/src/foundation/styles/properties/transition.dart
+++ b/packages/jaspr/lib/src/foundation/styles/properties/transition.dart
@@ -1,7 +1,7 @@
 import 'unit.dart';
 
 abstract class Transition {
-  const factory Transition(String property, {required double duration, Curve? curve, double? delay}) = _Transition;
+  const factory Transition(String property, {required Duration duration, Curve? curve, Duration? delay}) = _Transition;
   const factory Transition.combine(List<Transition> transitions) = _CombineTransition;
 
   String get value;
@@ -11,16 +11,16 @@ class _Transition implements Transition {
   const _Transition(this.property, {required this.duration, this.curve, this.delay});
 
   final String property;
-  final double duration;
+  final Duration duration;
   final Curve? curve;
-  final double? delay;
+  final Duration? delay;
 
   @override
   String get value => [
     property,
-    '${duration.numstr}ms',
+    duration.cssMs,
     if (curve != null) curve!.value,
-    if (delay != null) '${delay!.numstr}ms',
+    if (delay != null) delay!.cssMs,
   ].join(' ');
 }
 

--- a/packages/jaspr/lib/src/foundation/styles/properties/unit.dart
+++ b/packages/jaspr/lib/src/foundation/styles/properties/unit.dart
@@ -182,3 +182,13 @@ extension NumberString on double {
     return roundToDouble() == this ? round().toString() : toString();
   }
 }
+
+extension DurationExt on int {
+  /// Shorthand for `Duration(milliseconds: this)`
+  Duration get ms => Duration(milliseconds: this);
+}
+
+extension CssDurationFormat on Duration {
+  /// Get time in CSS milliseconds format i.e., `<duration>ms`
+  String get cssMs => '${inMilliseconds}ms';
+}

--- a/packages/jaspr/lib/src/foundation/styles/styles.dart
+++ b/packages/jaspr/lib/src/foundation/styles/styles.dart
@@ -1,6 +1,6 @@
 import 'properties/all.dart';
 
-export 'properties/all.dart' hide NumberString;
+export 'properties/all.dart' hide NumberString, CssDurationFormat;
 
 /// Represents a set of css styles by pairs of property and value.
 abstract class Styles with StylesMixin<Styles> {

--- a/packages/jaspr/test/foundation/styles/properties/units_test.dart
+++ b/packages/jaspr/test/foundation/styles/properties/units_test.dart
@@ -129,5 +129,11 @@ void main() {
         expect(insets.styles, equals({'top': '10px', 'bottom': '10px'}));
       });
     });
+
+    group('duration', () {
+      test('extension on int', () {
+        expect(500.ms, equals(Duration(milliseconds: 500)));
+      });
+    });
   });
 }

--- a/packages/jaspr/test/foundation/styles/properties_test.dart
+++ b/packages/jaspr/test/foundation/styles/properties_test.dart
@@ -59,7 +59,7 @@ void main() {
         cursor: Cursor.crosshair,
         userSelect: UserSelect.none,
         pointerEvents: PointerEvents.fill,
-        transition: Transition('width', duration: 500),
+        transition: Transition('width', duration: Duration(milliseconds: 500)),
         transform: Transform.scale(2),
         // Flexbox Styles
         flexDirection: FlexDirection.column,


### PR DESCRIPTION
Closes #572 
<!--
  Thanks for contributing! 💙

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
This adds:
- a getter on `int` to allow shorthand conversion to `Duration`s (in milliseconds)
- an internal extension to convert `Duration` to CSS format milliseconds time. This extension is somewhat needed because there are other places where `Duration` is also needed example `Animation` (coming in my next PR) and possibly CSS variables.
- **Breaking**: `Transition`'s `duration` and `delay` arguments are now `Duration` instead of `double`.

<!-- Describe your changes in detail -->

## Type of Change

<!-- Uncomment all that apply: -->

- ❌ Breaking change
- ✨ New feature or improvement
<!-- - 🛠️ Bug fix -->
<!-- - 🧹 Code refactor -->
<!-- - 📝 Documentation -->
<!-- - 🗑️ Chore -->

## Ready Checklist

- [x] I've read the [Contribution Guide](https://github.com/schultek/jaspr/blob/main/CONTRIBUTING.md).
- [x] In case this PR changes one of the core packages, I've modified the respective **CHANGELOG.md** file using
      the [semantic_changelog](https://github.com/rrousselGit/semantic_changelog) format.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added myself to the AUTHORS file (optional, if you want to).

<!-- 
  Feel free to expand this list if you have additional todos before your PR is ready. 
-->

<!--
  If you need help, consider asking for advice on the *#contribute* channel on [Discord](https://discord.gg/XGXrGEk4c6).
-->
