### PR TITLE
[jaspr_router] Stricter type linting to avoid unintentional dynamic

### DIFF
--- a/packages/jaspr_router/analysis_options.yaml
+++ b/packages/jaspr_router/analysis_options.yaml
@@ -1,1 +1,11 @@
 include: package:jaspr_repo/package.yaml
+
+analyzer:
+  language:
+    strict-casts: true
+    strict-inference: true
+    strict-raw-types: true
+
+linter:
+  rules:
+    avoid_dynamic_calls: true

--- a/packages/jaspr_router/lib/src/router.dart
+++ b/packages/jaspr_router/lib/src/router.dart
@@ -234,14 +234,14 @@ class RouteLoader {
     });
   }
 
-  final Future future;
+  final Future<void> future;
 
   bool isPending;
 
   static Future<void> wait(Iterable<RouteLoader> loaders) {
-    var l = loaders.where((l) => l.isPending).map((l) => l.future);
-    if (l.isNotEmpty) {
-      return Future.wait(l);
+    final pendingLoaders = loaders.where((l) => l.isPending).map((l) => l.future);
+    if (pendingLoaders.isNotEmpty) {
+      return pendingLoaders.wait;
     } else {
       return SynchronousFuture(null);
     }

--- a/packages/jaspr_router/test/routing/lazy_routes_test.dart
+++ b/packages/jaspr_router/test/routing/lazy_routes_test.dart
@@ -15,7 +15,7 @@ void main() {
     });
 
     testComponents('should push lazy route', (tester) async {
-      var bCompleter = Completer.sync();
+      var bCompleter = Completer<void>.sync();
 
       tester.pumpComponent(Router(routes: [homeRoute(), route('/a'), lazyRoute('/b', bCompleter.future)]));
 
@@ -38,7 +38,7 @@ void main() {
     });
 
     testComponents('should push lazy shell route', (tester) async {
-      var bCompleter = Completer.sync();
+      var bCompleter = Completer<void>.sync();
 
       tester.pumpComponent(
         Router(

--- a/packages/jaspr_router/test/server/routing/routing_app.dart
+++ b/packages/jaspr_router/test/server/routing/routing_app.dart
@@ -26,9 +26,9 @@ class Home extends StatelessComponent {
     return span([text('Home')]);
   }
 
-  void shouldThrow(Function fn) async {
+  void shouldThrow(void Function() fn) {
     try {
-      await fn();
+      fn();
     } on UnimplementedError catch (_) {
       return;
     }

--- a/packages/jaspr_router/test/utils.dart
+++ b/packages/jaspr_router/test/utils.dart
@@ -5,7 +5,7 @@ import 'package:jaspr_test/jaspr_test.dart';
 
 RouterState findRouter(Element root) {
   RouterState? router;
-  findRouter(Element element) {
+  void findRouter(Element element) {
     if (element is StatefulElement && element.state is RouterState) {
       router = element.state as RouterState;
     } else {
@@ -77,6 +77,7 @@ Route homeRoute() => Route(
   path: '/',
   builder: (_, __) => Page(path: 'home'),
 );
+
 Route route(String path, [List<RouteBase> routes = const [], String? name, RouterRedirect? redirect]) => Route(
   path: path,
   name: name,
@@ -84,17 +85,20 @@ Route route(String path, [List<RouteBase> routes = const [], String? name, Route
   builder: (_, s) => Page(path: s.subloc),
   routes: routes,
 );
-Route lazyRoute(String path, Future future, [List<RouteBase> routes = const []]) => Route.lazy(
+
+Route lazyRoute(String path, Future<void> future, [List<RouteBase> routes = const []]) => Route.lazy(
   path: path,
   builder: (_, s) => Page(path: s.subloc),
   load: () => future,
   routes: routes,
 );
+
 ShellRoute shellRoute(String name, List<RouteBase> routes) => ShellRoute(
   builder: (_, s, c) => Page(path: name, child: c),
   routes: routes,
 );
-ShellRoute lazyShellRoute(String name, Future future, List<RouteBase> routes) => ShellRoute.lazy(
+
+ShellRoute lazyShellRoute(String name, Future<void> future, List<RouteBase> routes) => ShellRoute.lazy(
   builder: (_, s, c) => Page(path: name, child: c),
   load: () => future,
   routes: routes,


### PR DESCRIPTION
This updates the analysis to match jaspr_content as I work towards making it consistent across packages.