### PR TITLE
[docs]: Update the @css examples to use getters

### DIFF
--- a/docs/api/utils/at_css.mdx
+++ b/docs/api/utils/at_css.mdx
@@ -17,7 +17,7 @@ When used as the `@css` annotation, you can register any amount of style definit
 
 ```dart
 @css
-static List<StyleRule> get styles => [
+List<StyleRule> get styles => [
   // Style rules in here (covered in next section)
   /* ... */
 ];

--- a/docs/concepts/styling.mdx
+++ b/docs/concepts/styling.mdx
@@ -93,7 +93,7 @@ Provide a `MediaQuery` as well as child styles to the function:
 
 ```dart
 @css
-static List<StyleRule> get styles => [
+List<StyleRule> get styles => [
     css('.main').styles(
       display: Display.flex, 
       flexDirection: FlexDirection.row,


### PR DESCRIPTION
## Description

Some examples of styles declarations using `@css` annotation seems to be outdated. It had property syntax. I updated it to getter syntax (was suggested by the linter in one of my projects).

**Affected pages:**
- https://docs.jaspr.site/api/utils/at_css
- https://docs.jaspr.site/concepts/styling

## Type of Change

<!-- Uncomment all that apply: -->

<!-- - ❌ Breaking change -->
<!-- - ✨ New feature or improvement -->
<!-- - 🛠️ Bug fix -->
<!-- - 🧹 Code refactor -->
📝 Documentation
<!-- - 🗑️ Chore -->

## Ready Checklist

- [x] I've read the [Contribution Guide](https://github.com/schultek/jaspr/blob/main/CONTRIBUTING.md).
- [x] In case this PR changes one of the core packages, I've modified the respective **CHANGELOG.md** file using
      the [semantic_changelog](https://github.com/rrousselGit/semantic_changelog) format.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added myself to the AUTHORS file (optional, if you want to).
