### PR TITLE
Fix Dart Frog link in backend documentation

### DIFF
--- a/docs/going_further/backend.mdx
+++ b/docs/going_further/backend.mdx
@@ -70,7 +70,7 @@ or checkout the [example](https://github.com/schultek/jaspr/tree/main/examples/b
 
 ## Dart Frog
 
-[`dart_frog`](https://dart-frog.dev/) is a new backend framework built by Very Good Ventures. You
+[`dart_frog`](https://dart-frog.dev/) is a minimalistic backend framework for Dart. You
 can combine it with jaspr to build powerful fullstack web applications that use dart_frog for managing
 the backend api and jaspr for rendering the frontend app.
 


### PR DESCRIPTION
Corrected the link for the Dart Frog framework.