### PR TITLE
[jaspr_cli] Enable `strict-inference` and `strict-raw-types`

### DIFF
--- a/packages/jaspr_cli/analysis_options.yaml
+++ b/packages/jaspr_cli/analysis_options.yaml
@@ -4,6 +4,11 @@ analyzer:
   exclude:
     - tool/scaffold/**
     - tool/templates/**
+  language:
+    # TODO: Enable and fix remaining strict-casts diagnostics.
+    # strict-casts: true
+    strict-inference: true
+    strict-raw-types: true
   
 linter:
   rules:

--- a/packages/jaspr_cli/lib/src/commands/base_command.dart
+++ b/packages/jaspr_cli/lib/src/commands/base_command.dart
@@ -35,7 +35,7 @@ abstract class BaseCommand extends Command<int> {
         StreamGroup.merge([
           ProcessSignal.sigint.watch(),
           // SIGTERM is not supported on Windows.
-          Platform.isWindows ? const Stream.empty() : ProcessSignal.sigterm.watch(),
+          Platform.isWindows ? const Stream<void>.empty() : ProcessSignal.sigterm.watch(),
         ]).listen((signal) async {
           cancelCount++;
           if (cancelCount > 1) exit(1);
@@ -165,7 +165,7 @@ abstract class BaseCommand extends Command<int> {
       return exitCode;
     }
 
-    await Future.delayed(Duration(seconds: 2));
+    await Future<void>.delayed(Duration(seconds: 2));
 
     await errSub.cancel();
     await outSub.cancel();

--- a/packages/jaspr_cli/lib/src/commands/build_command.dart
+++ b/packages/jaspr_cli/lib/src/commands/build_command.dart
@@ -185,7 +185,7 @@ class BuildCommand extends BaseCommand with ProxyHelper, FlutterHelper {
       Map<String, ({String? lastmod, String? changefreq, double? priority})?> generatedRoutes = {};
       List<String> queuedRoutes = [];
 
-      var serverStartedCompleter = Completer();
+      var serverStartedCompleter = Completer<void>();
 
       await startProxy(
         '5567',

--- a/packages/jaspr_cli/lib/src/commands/dev_command.dart
+++ b/packages/jaspr_cli/lib/src/commands/dev_command.dart
@@ -186,7 +186,7 @@ abstract class DevCommand extends BaseCommand with ProxyHelper, FlutterHelper {
     // Wait until server is reachable.
     var n = 0;
     while (true) {
-      await Future.delayed(Duration(seconds: 2));
+      await Future<void>.delayed(Duration(seconds: 2));
       try {
         await http.head(Uri.parse('http://localhost:$port'));
         break;
@@ -313,7 +313,7 @@ abstract class DevCommand extends BaseCommand with ProxyHelper, FlutterHelper {
       await workflow.shutDown();
     });
 
-    var buildCompleter = Completer();
+    var buildCompleter = Completer<void>();
 
     var timer = Timer(Duration(seconds: 20), () {
       if (!buildCompleter.isCompleted) {

--- a/packages/jaspr_cli/lib/src/dev/client_workflow.dart
+++ b/packages/jaspr_cli/lib/src/dev/client_workflow.dart
@@ -81,7 +81,7 @@ class ClientWorkflow {
     });
   }
 
-  final _doneCompleter = Completer();
+  final _doneCompleter = Completer<void>();
   final BuildDaemonClient client;
   final Logger logger;
 

--- a/packages/jaspr_cli/lib/src/domains/scopes_domain.dart
+++ b/packages/jaspr_cli/lib/src/domains/scopes_domain.dart
@@ -133,8 +133,8 @@ class ScopesDomain extends Domain {
         final packagesContent = context.contextRoot.packagesFile?.readAsStringSync();
         final packagesJson = jsonDecode(packagesContent ?? '{}');
         if (packagesJson case {
-          'packages': List packages,
-        } when packages.any((p) => p['name'] == 'jaspr_web_compilers')) {
+          'packages': List<Object?> packages,
+        } when packages.cast<Map<String, Object?>>().any((p) => p['name'] == 'jaspr_web_compilers')) {
           usesJasprWebCompilers = true;
         }
       } catch (_) {

--- a/packages/jaspr_cli/lib/src/helpers/flutter_helpers.dart
+++ b/packages/jaspr_cli/lib/src/helpers/flutter_helpers.dart
@@ -79,7 +79,7 @@ mixin FlutterHelper on BaseCommand {
 Future<void> copyFiles(String from, String to, [List<String> targets = const ['']]) async {
   var moveTargets = [...targets];
 
-  var moves = <Future>[];
+  var moves = <Future<void>>[];
   while (moveTargets.isNotEmpty) {
     var moveTarget = moveTargets.removeAt(0);
     var file = File('$from/$moveTarget').absolute;
@@ -97,5 +97,5 @@ Future<void> copyFiles(String from, String to, [List<String> targets = const [''
     }
   }
 
-  await Future.wait(moves);
+  await moves.wait;
 }

--- a/packages/jaspr_cli/lib/src/helpers/proxy_helper.dart
+++ b/packages/jaspr_cli/lib/src/helpers/proxy_helper.dart
@@ -110,8 +110,8 @@ Handler _sseProxyHandler(http.Client client, String webPort, Logger logger) {
           '\r\n',
         );
 
-      StreamSubscription? serverSseSub;
-      StreamSubscription? reqChannelSub;
+      StreamSubscription<void>? serverSseSub;
+      StreamSubscription<void>? reqChannelSub;
 
       serverSseSub = utf8.decoder
           .bind(serverResponse.stream)

--- a/packages/jaspr_cli/test/commands_test.dart
+++ b/packages/jaspr_cli/test/commands_test.dart
@@ -34,13 +34,13 @@ void main() {
         var serveResult = runner.run('serve -v', dir: dirs.app, checkExitCode: false);
 
         // Wait until server is started.
-        await Future.delayed(Duration(seconds: 10));
+        await Future<void>.delayed(Duration(seconds: 10));
         while (true) {
           try {
             await http.head(Uri.parse('http://localhost:8080'));
             break;
           } on SocketException catch (_) {}
-          await Future.delayed(Duration(seconds: 5));
+          await Future<void>.delayed(Duration(seconds: 5));
         }
 
         var paths = variant.resources;
@@ -58,7 +58,7 @@ void main() {
         // Wait for the server to be stopped.
         await runner.runner.commands.values.whereType<ServeCommand>().firstOrNull?.stop();
         await serveResult;
-        await Future.delayed(Duration(seconds: 5));
+        await Future<void>.delayed(Duration(seconds: 5));
 
         await runner.run('build -v', dir: dirs.app);
 

--- a/packages/jaspr_cli/test/domains/scopes_test.dart
+++ b/packages/jaspr_cli/test/domains/scopes_test.dart
@@ -39,7 +39,11 @@ void main() {
   Future<void> expectScopesResult(Object? data) async {
     await untilCalled(
       () => daemon.send(
-        any(that: predicate<Map>((map) => map['event'] == 'scopes.status' && map['params'][projectPath] == false)),
+        any(
+          that: predicate<Map<String, Object?>>(
+            (map) => map['event'] == 'scopes.status' && (map['params'] as Map<String, Object?>)[projectPath] == false,
+          ),
+        ),
       ),
     );
 


### PR DESCRIPTION
This updates the analysis to be stricter similar to jaspr_content as I work towards making analysis consistent across packages.