### PR TITLE
[jaspr_riverpod] Update to use stricter analysis

### DIFF
--- a/packages/jaspr_riverpod/analysis_options.yaml
+++ b/packages/jaspr_riverpod/analysis_options.yaml
@@ -1,5 +1,12 @@
 include: package:jaspr_repo/package.yaml
 
+analyzer:
+  language:
+    strict-casts: true
+    strict-inference: true
+    strict-raw-types: true
+
 linter:
   rules:
+    avoid_dynamic_calls: true
     avoid_types_as_parameter_names: false

--- a/packages/jaspr_riverpod/lib/src/core/jaspr/provider_dependencies.dart
+++ b/packages/jaspr_riverpod/lib/src/core/jaspr/provider_dependencies.dart
@@ -10,11 +10,11 @@ class ProviderDependencies {
 
   ProviderContainer? listenedContainer;
 
-  Map<ProviderListenable, ProviderSubscription> watchers = {};
-  Map<ProviderListenable, ProviderSubscription> listeners = {};
+  Map<ProviderListenable<Object?>, ProviderSubscription<Object?>> watchers = {};
+  Map<ProviderListenable<Object?>, ProviderSubscription<Object?>> listeners = {};
 
-  Map<ProviderListenable, ProviderSubscription> oldWatchers = {};
-  Map<ProviderListenable, ProviderSubscription> oldListeners = {};
+  Map<ProviderListenable<Object?>, ProviderSubscription<Object?>> oldWatchers = {};
+  Map<ProviderListenable<Object?>, ProviderSubscription<Object?>> oldListeners = {};
 
   void didRebuild() {
     var oldSubscriptions = [...oldWatchers.values, ...oldListeners.values];
@@ -52,15 +52,14 @@ class ProviderDependencies {
     var container = checkContainer();
 
     if (!watchers.containsKey(target)) {
-      if (oldWatchers.containsKey(target)) {
-        watchers[target] = oldWatchers.remove(target)!;
+      if (oldWatchers.remove(target) case final oldTargetWatcher?) {
+        watchers[target] = oldTargetWatcher;
       } else {
-        // create a new [ProviderSubscription] and add it to the dependencies
-
+        // Create a new [ProviderSubscription] and add it to the dependencies.
         var subscription = container.listen<T>(target, (_, v) {
           if (watchers[target] == null && oldWatchers[target] == null) return;
 
-          // trigger a rebuild for this dependent
+          // Trigger a rebuild for this dependent.
           dependent.markNeedsBuild();
         });
 
@@ -68,7 +67,7 @@ class ProviderDependencies {
       }
     }
 
-    return watchers[target]!.readSafe().valueOrProviderException;
+    return watchers[target]!.readSafe().valueOrProviderException as T;
   }
 
   void listen<T>(

--- a/packages/jaspr_riverpod/lib/src/core/jaspr/provider_sync.dart
+++ b/packages/jaspr_riverpod/lib/src/core/jaspr/provider_sync.dart
@@ -3,13 +3,13 @@ part of '../../core.dart';
 
 sealed class ProviderSync {}
 
-class _ProviderSync implements ProviderSync {
+class _ProviderSync<T> implements ProviderSync {
   _ProviderSync(this.provider, this.id, this.codec, this.fn);
 
-  final ProviderBase provider;
+  final ProviderBase<T> provider;
   final String id;
-  final Codec? codec;
-  final Override Function(dynamic value) fn;
+  final Codec<T, Object?>? codec;
+  final Override Function(Object? value) fn;
 }
 
 extension SyncNotifierExtension<NotifierT extends Notifier<T>, T> on NotifierProvider<NotifierT, T> {
@@ -61,7 +61,7 @@ extension SyncStateProviderExtension<T> on StateProvider<T> {
 }
 
 mixin SyncScopeMixin on State<ProviderScope>
-    implements PreloadStateMixin<ProviderScope>, SyncStateMixin<ProviderScope, Map<String, dynamic>?> {
+    implements PreloadStateMixin<ProviderScope>, SyncStateMixin<ProviderScope, Map<String, Object?>?> {
   ProviderContainer get container;
 
   final Map<String, Object?> _syncValues = {};
@@ -70,7 +70,7 @@ mixin SyncScopeMixin on State<ProviderScope>
     if (component.sync.isEmpty) {
       return Future.value();
     }
-    final futures = <Future>[];
+    final futures = <Future<void>>[];
     for (var s in component.sync) {
       final provider = (s as _ProviderSync).provider;
       final Object? value;
@@ -81,23 +81,23 @@ mixin SyncScopeMixin on State<ProviderScope>
       }
       if (value is Future) {
         futures.add(value);
-        value.then((v) => _syncValues[s.id] = s.codec != null ? s.codec!.encode(v) : v);
+        value.then((v) => _syncValues[s.id] = s.codec?.encode(v) ?? v);
       } else {
-        _syncValues[s.id] = s.codec != null ? s.codec!.encode(value) : value;
+        _syncValues[s.id] = s.codec?.encode(value) ?? value;
       }
     }
-    return Future.wait(futures);
+    return futures.wait;
   }
 
   @override
-  Map<String, dynamic>? getState() {
+  Map<String, Object?>? getState() {
     return _syncValues;
   }
 
   final List<Override> _syncOverrides = [];
 
   @override
-  void updateState(Map<String, dynamic>? value) {
+  void updateState(Map<String, Object?>? value) {
     if (value == null) {
       return;
     }
@@ -107,7 +107,12 @@ mixin SyncScopeMixin on State<ProviderScope>
       }
 
       final encodedValue = value[s.id];
-      final decodedValue = encodedValue != null && s.codec != null ? s.codec!.decode(encodedValue) : encodedValue;
+      final Object? decodedValue;
+      if (s.codec case final codec? when encodedValue != null) {
+        decodedValue = codec.encode(encodedValue);
+      } else {
+        decodedValue = encodedValue;
+      }
 
       _syncOverrides.add(s.fn(decodedValue));
     }

--- a/packages/jaspr_riverpod/test/sync/sync_server_test.dart
+++ b/packages/jaspr_riverpod/test/sync/sync_server_test.dart
@@ -45,7 +45,7 @@ void main() {
 
     testServer('preloads async provider values then outputs', (tester) async {
       final someFutureProvider = FutureProvider(
-        (_) async => Future.delayed(Duration(milliseconds: 100)).then((_) => 'value'),
+        (_) async => Future<void>.delayed(Duration(milliseconds: 100)).then((_) => 'value'),
       );
 
       dynamic providerValue;


### PR DESCRIPTION
Updates the analysis config for `package:jaspr_riverpod` to match the other packages on the road to using a shared, stricter config across all the packages.