### PR TITLE
add serve code-lense

### DIFF
--- a/modules/jaspr-code/CHANGELOG.md
+++ b/modules/jaspr-code/CHANGELOG.md
@@ -1,6 +1,10 @@
+## 0.3.0
+
+- Added the `Serve` code-lens to `main` functions for launching Jaspr, and hide the default `Run / Debug` code lenses.
+
 ## 0.2.3
 
-- Improve stability of component scope analysis.
+- Improved stability of component scope analysis.
 
 ## 0.2.2
 

--- a/modules/jaspr-code/package.json
+++ b/modules/jaspr-code/package.json
@@ -2,7 +2,7 @@
   "name": "jaspr-code",
   "displayName": "Jaspr",
   "description": "Jaspr framework support for Visual Studio Code",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "repository": {
     "url": "https://github.com/schultek/jaspr",
     "directory": "modules/jaspr-code"

--- a/modules/jaspr-code/src/api.ts
+++ b/modules/jaspr-code/src/api.ts
@@ -18,8 +18,8 @@ function getDartExtensionApi(): PublicDartExtensionApi {
   }
 
   const dartExtensionApi = dartCode.exports as PublicDartExtensionApi;
-  if (dartExtensionApi.version !== 2) {
-    throw new Error(`Incompatible Dart extension version. Make sure you switch to the pre-release version of the Dart extension.`);
+  if (dartExtensionApi.version < 2) {
+    throw new Error(`Incompatible Dart extension version. Make sure you have the latest version of the Dart extension installed.`);
   }
 
   return dartExtensionApi;

--- a/modules/jaspr-code/src/code_lenses/component_code_lens.ts
+++ b/modules/jaspr-code/src/code_lenses/component_code_lens.ts
@@ -1,20 +1,16 @@
+import { lspToRange } from "../helpers/object_helper";
 import * as vs from "vscode";
-import { dartExtensionApi } from "./api";
+import { ScopeResults, ScopesDomain, ScopeTarget } from "../jaspr/scopes_domain";
+import { dartExtensionApi } from "../api";
 import { PublicOutline } from "dart-code/src/extension/api/interfaces";
-import { ScopeResults, ScopesDomain, ScopeTarget } from "./jaspr/scopes_domain";
 
-export class ComponentCodeLensProvider
-  implements vs.CodeLensProvider, vs.Disposable
-{
+export class ComponentCodeLensProvider implements vs.CodeLensProvider, vs.Disposable {
   private scopesDomain: ScopesDomain;
 
-  private _onDidChangeCodeLenses: vs.EventEmitter<void> =
-    new vs.EventEmitter<void>();
-  public readonly onDidChangeCodeLenses: vs.Event<void> =
-    this._onDidChangeCodeLenses.event;
+  private _onDidChangeCodeLenses: vs.EventEmitter<void> = new vs.EventEmitter<void>();
+  public readonly onDidChangeCodeLenses: vs.Event<void> = this._onDidChangeCodeLenses.event;
 
   private hintCommand: vs.Disposable;
-
   private scopeResults: ScopeResults = {};
 
   constructor(scopesDomain: ScopesDomain) {
@@ -148,12 +144,4 @@ function targetToLocation(target: ScopeTarget): vs.Location {
     vs.Uri.file(target.path),
     new vs.Position(target.line - 1, target.character)
   );
-}
-
-export function lspToRange(range: any): vs.Range {
-  return new vs.Range(lspToPosition(range.start), lspToPosition(range.end));
-}
-
-export function lspToPosition(position: any): vs.Position {
-  return new vs.Position(position.line, position.character);
 }

--- a/modules/jaspr-code/src/code_lenses/serve_code_lens.ts
+++ b/modules/jaspr-code/src/code_lenses/serve_code_lens.ts
@@ -1,0 +1,101 @@
+import * as vs from "vscode";
+import { findJasprProjectFolders } from "../helpers/project_helper";
+import path from "path";
+import * as yaml from "yaml";
+import { dartExtensionApi } from "../api";
+import { lspToRange } from "../helpers/object_helper";
+
+export class ServeCodeLensProvider implements vs.CodeLensProvider, vs.Disposable {
+
+  private _onDidChangeCodeLenses: vs.EventEmitter<void> = new vs.EventEmitter<void>();
+  public readonly onDidChangeCodeLenses: vs.Event<void> = this._onDidChangeCodeLenses.event;
+
+  private folders: string[] = [];
+  private targets: string[] = [];
+  private suppressions: vs.Disposable[] = [];
+
+  constructor() {
+    this.loadTargets();
+    vs.workspace.onDidChangeWorkspaceFolders(async () => {
+      await this.loadTargets();
+      this._onDidChangeCodeLenses.fire();
+    });
+    vs.workspace.onDidChangeTextDocument(async (e) => {
+      if (e.document.languageId === "yaml" && e.document.fileName.endsWith("pubspec.yaml")) {
+        await this.loadTargets();
+        this._onDidChangeCodeLenses.fire();
+      }
+    });
+  }
+
+  private async loadTargets() {
+    const folders = await findJasprProjectFolders();
+    const targets: string[] = [];
+
+    for (let project of folders) {
+      const pubspecPath = path.join(project, "pubspec.yaml");
+      const pubspecContent = await vs.workspace.fs.readFile(vs.Uri.file(pubspecPath));
+      const pubspec = await yaml.parse(Buffer.from(pubspecContent).toString("utf8"));
+
+      const target = pubspec?.jaspr?.target as string | string[] | undefined;
+      if (typeof target === "string") {
+        targets.push(path.join(project, target));
+      } else if (Array.isArray(target)) {
+        for (let t of target) {
+          targets.push(path.join(project, t));
+        }
+      } else {
+        targets.push(path.join(project, "lib", "main.dart"));
+      }
+    }
+
+    this.folders = folders;
+    this.targets = targets;
+
+    this.suppressions.forEach((s) => s.dispose());
+    this.suppressions = [];
+    this.suppressions.push(
+      dartExtensionApi.features.codeLens.suppress(this.targets.map((t) => vs.Uri.file(t)), { main: true })
+    );
+  }
+
+  public async provideCodeLenses(document: vs.TextDocument, token: vs.CancellationToken): Promise<vs.CodeLens[] | undefined> {
+    let isTarget = !!this.targets.find((t) => t === document.uri.fsPath);
+    if (!isTarget) {
+      return;
+    }
+
+    const outline = await dartExtensionApi.workspace.getOutline(
+      document,
+      token
+    );
+    if (!outline?.children?.length) {
+      return;
+    }
+
+    const main = outline.children.find((c) => c.element.name === "main");
+
+    if (!main) {
+      return;
+    }
+
+    const folder = this.folders.find((f) => document.uri.fsPath.startsWith(f));
+    if (!folder) {
+      return;
+    }
+
+    const input = document.uri.fsPath.substring(folder.length + 1);
+    const range = lspToRange(main.codeRange);
+    return [
+      new vs.CodeLens(range, {
+        command: "jaspr.serve",
+        title: "Serve",
+        arguments: [input, folder],
+      }),
+    ];
+  }
+
+  public dispose() {
+    this.suppressions.forEach((s) => s.dispose());
+  }
+}

--- a/modules/jaspr-code/src/helpers/object_helper.ts
+++ b/modules/jaspr-code/src/helpers/object_helper.ts
@@ -1,0 +1,9 @@
+import * as vs from "vscode";
+
+export function lspToRange(range: any): vs.Range {
+  return new vs.Range(lspToPosition(range.start), lspToPosition(range.end));
+}
+
+export function lspToPosition(position: any): vs.Position {
+  return new vs.Position(position.line, position.character);
+}


### PR DESCRIPTION
<!--
  Thanks for contributing! 💙

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

In the VSCode extension adds a `Serve` code-lens to `main` functions for launching Jaspr, and hides the default `Run / Debug` code lenses.

Enabled by https://github.com/Dart-Code/Dart-Code/issues/5703

## Type of Change

<!-- Uncomment all that apply: -->

<!-- - ❌ Breaking change -->
- ✨ New feature or improvement
<!-- - 🛠️ Bug fix -->
<!-- - 🧹 Code refactor -->
<!-- - 📝 Documentation -->
<!-- - 🗑️ Chore -->

## Ready Checklist

- [ ] I've read the [Contribution Guide](https://github.com/schultek/jaspr/blob/main/CONTRIBUTING.md).
- [ ] In case this PR changes one of the core packages, I've modified the respective **CHANGELOG.md** file using
      the [semantic_changelog](https://github.com/rrousselGit/semantic_changelog) format.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added myself to the AUTHORS file (optional, if you want to).

<!-- 
  Feel free to expand this list if you have additional todos before your PR is ready. 
-->

<!--
  If you need help, consider asking for advice on the *#contribute* channel on [Discord](https://discord.gg/XGXrGEk4c6).
-->
