### PR TITLE
fixes custom body responses having a html extension

### DIFF
--- a/packages/jaspr_cli/lib/src/commands/build_command.dart
+++ b/packages/jaspr_cli/lib/src/commands/build_command.dart
@@ -282,11 +282,14 @@ class BuildCommand extends BaseCommand with ProxyHelper, FlutterHelper {
           continue;
         }
 
+        // Try to naively get the file extension, or fallback to html
+        final ext = response.headers['content-type']?.split('/').lastOrNull ?? 'html';
+
         var file = File(
           p.url.join(
             'build/jaspr',
             route.startsWith('/') ? route.substring(1) : route,
-            p.url.extension(route).isEmpty ? 'index.html' : null,
+            p.url.extension(route).isEmpty ? 'index.$ext' : null,
           ),
         ).absolute;
 


### PR DESCRIPTION
## Description

This is a followup on #597 that sets an approximate extension when using a custom body response.

## Type of Change

<!-- Uncomment all that apply: -->

<!-- - ❌ Breaking change -->
<!-- - ✨ New feature or improvement -->
- 🛠️ Bug fix
<!-- - 🧹 Code refactor -->
<!-- - 📝 Documentation -->
<!-- - 🗑️ Chore -->

## Ready Checklist

- [x] I've read the [Contribution Guide](https://github.com/schultek/jaspr/blob/main/CONTRIBUTING.md).
- [ ] In case this PR changes one of the core packages, I've modified the respective **CHANGELOG.md** file using
      the [semantic_changelog](https://github.com/rrousselGit/semantic_changelog) format.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added myself to the AUTHORS file (optional, if you want to).
