### PR TITLE
Enable lints from v6 of `package:lints`

### DIFF
--- a/apps/website/lib/components/link_button.dart
+++ b/apps/website/lib/components/link_button.dart
@@ -44,7 +44,7 @@ class LinkButton extends StatelessComponent {
       classes: 'link-button link-button-$style',
       href: to,
       target: target,
-      attributes: {if (ariaLabel != null) 'aria-label': ariaLabel!},
+      attributes: {'aria-label': ?ariaLabel},
       [child],
     );
   }

--- a/packages/jaspr/lib/src/components/document/document_server.dart
+++ b/packages/jaspr/lib/src/components/document/document_server.dart
@@ -141,14 +141,14 @@ class BaseDocument extends StatelessComponent implements Document {
   Component build(BuildContext context) {
     return Component.element(
       tag: 'html',
-      attributes: {if (lang != null) 'lang': lang!},
+      attributes: {'lang': ?lang},
       children: [
         Component.element(
           tag: 'head',
           children: [
             if (base != null) Component.element(tag: 'base', attributes: {'href': _normalizedBase!}),
             if (charset != null) Component.element(tag: 'meta', attributes: {'charset': charset!}),
-            HeadDocument(title: title, meta: {if (viewport != null) 'viewport': viewport!, ...meta}),
+            HeadDocument(title: title, meta: {'viewport': ?viewport, ...meta}),
             if (styles.isNotEmpty) //
               Style(styles: styles),
             ...head,

--- a/packages/jaspr/lib/src/foundation/sync.dart
+++ b/packages/jaspr/lib/src/foundation/sync.dart
@@ -28,7 +28,7 @@ mixin SyncStateMixin<T extends StatefulComponent, U> on State<T> {
     initSyncState(this);
   }
 
-  static initSyncState(SyncStateMixin mixin) => s.initSyncState(mixin);
+  static void initSyncState(SyncStateMixin mixin) => s.initSyncState(mixin);
 }
 
 const sync = SyncAnnotation._();

--- a/packages/jaspr/lib/src/framework/framework.dart
+++ b/packages/jaspr/lib/src/framework/framework.dart
@@ -496,7 +496,7 @@ abstract class Element implements BuildContext {
     if (oldChildren.length <= 1 && newComponents.length <= 1) {
       final Element? oldChild = replaceWithNullIfForgotten(oldChildren.firstOrNull);
       var newChild = updateChild(oldChild, newComponents.firstOrNull, ElementSlot(0, null));
-      return [if (newChild != null) newChild];
+      return [?newChild];
     }
 
     int newChildrenTop = 0;

--- a/packages/jaspr_cli/lib/src/helpers/analytics.dart
+++ b/packages/jaspr_cli/lib/src/helpers/analytics.dart
@@ -70,7 +70,7 @@ Future<void> trackEvent(String command, {String? projectName, String? projectMod
             'command': command,
             'mode': projectMode,
             'cli_version': jasprCliVersion,
-            if (projectHash != null) 'project_id': projectHash,
+            'project_id': ?projectHash,
             'os': Platform.operatingSystem,
             'ci': isCI,
           },

--- a/packages/jaspr_flutter_embed/lib/src/flutter_embed_view_fallback.dart
+++ b/packages/jaspr_flutter_embed/lib/src/flutter_embed_view_fallback.dart
@@ -44,9 +44,9 @@ class FlutterEmbedView extends StatelessComponent {
             minHeight: c.minHeight != double.infinity ? c.minHeight?.px : null,
             maxHeight: c.maxHeight != double.infinity ? c.maxHeight?.px : null,
           ),
-        if (styles != null) styles!,
+        ?styles,
       ]),
-      [if (loader != null) loader!],
+      [?loader],
     );
   }
 }

--- a/packages/jaspr_repo/lib/app.yaml
+++ b/packages/jaspr_repo/lib/app.yaml
@@ -10,7 +10,9 @@ linter:
     directives_ordering: true
     prefer_relative_imports: true
     sort_pub_dependencies: true
+    strict_top_level_inference: true
     unnecessary_underscores: true
+    use_null_aware_elements: true
 
 formatter:
   page_width: 120

--- a/packages/jaspr_repo/lib/flutter_app.yaml
+++ b/packages/jaspr_repo/lib/flutter_app.yaml
@@ -10,7 +10,9 @@ linter:
     directives_ordering: true
     prefer_relative_imports: true
     sort_pub_dependencies: true
+    strict_top_level_inference: true
     unnecessary_underscores: true
+    use_null_aware_elements: true
 
 formatter:
   page_width: 120

--- a/packages/jaspr_repo/lib/package.yaml
+++ b/packages/jaspr_repo/lib/package.yaml
@@ -5,7 +5,9 @@ linter:
     directives_ordering: true
     prefer_relative_imports: true
     sort_pub_dependencies: true
+    strict_top_level_inference: true
     unnecessary_underscores: true
+    use_null_aware_elements: true
 
 formatter:
   page_width: 120

--- a/packages/jaspr_router/lib/src/link.dart
+++ b/packages/jaspr_router/lib/src/link.dart
@@ -90,7 +90,7 @@ class Link extends StatelessComponent {
           }
         },
       },
-      [if (child != null) child!, ...?children],
+      [?child, ...?children],
     );
   }
 }


### PR DESCRIPTION
These lints are enabled in the v6 release of `package:lints`. Due to dependency conflicts we can't update yet, but we can enable these lints in preparation.