### PR TITLE
Replace use of `from` factory constructors

### DIFF
--- a/packages/jaspr/lib/src/framework/components.dart
+++ b/packages/jaspr/lib/src/framework/components.dart
@@ -44,10 +44,14 @@ class DomElement extends MultiChildRenderObjectElement {
   @override
   void _updateInheritance() {
     super._updateInheritance();
-    if (_inheritedElements != null && _inheritedElements!.containsKey(_WrappingDomComponent)) {
-      _inheritedElements = HashMap<Type, InheritedElement>.from(_inheritedElements!);
+    if (_inheritedElements case final originalInheritedElements?
+        when originalInheritedElements.containsKey(_WrappingDomComponent)) {
+      final updatedInheritedElements = HashMap<Type, InheritedElement>.of(originalInheritedElements);
+      _wrappingElement = updatedInheritedElements.remove(_WrappingDomComponent);
+      _inheritedElements = updatedInheritedElements;
+      return;
     }
-    _wrappingElement = _inheritedElements?.remove(_WrappingDomComponent);
+    _wrappingElement = null;
   }
 
   @override

--- a/packages/jaspr/lib/src/framework/inherited_component.dart
+++ b/packages/jaspr/lib/src/framework/inherited_component.dart
@@ -75,13 +75,11 @@ class InheritedElement extends BuildableElement {
   @override
   void _updateInheritance() {
     assert(_lifecycleState == _ElementLifecycle.active);
-    final Map<Type, InheritedElement>? incomingElements = _parent?._inheritedElements;
-    if (incomingElements != null) {
-      _inheritedElements = HashMap<Type, InheritedElement>.from(incomingElements);
-    } else {
-      _inheritedElements = HashMap<Type, InheritedElement>();
-    }
-    _inheritedElements![component.runtimeType] = this;
+    final incomingElements = _parent?._inheritedElements;
+    final inheritedElements = _inheritedElements = incomingElements != null
+        ? HashMap<Type, InheritedElement>.of(incomingElements)
+        : HashMap<Type, InheritedElement>();
+    inheritedElements[component.runtimeType] = this;
   }
 
   /// Returns the dependencies value recorded for [dependent]

--- a/packages/jaspr/lib/src/framework/observer_component.dart
+++ b/packages/jaspr/lib/src/framework/observer_component.dart
@@ -48,12 +48,10 @@ abstract class ObserverElement extends BuildableElement {
   @override
   void _updateObservers() {
     assert(_lifecycleState == _ElementLifecycle.active);
-    final List<ObserverElement>? incomingElements = _parent?._observerElements;
-    if (incomingElements != null) {
-      _observerElements = List<ObserverElement>.from(incomingElements);
-    } else {
-      _observerElements = <ObserverElement>[];
-    }
-    _observerElements!.add(this);
+    final incomingElements = _parent?._observerElements;
+    _observerElements = [
+      ...?incomingElements,
+      this,
+    ];
   }
 }


### PR DESCRIPTION
Move away from the `.from` factory constructors that are dynamically typed in favor of `.of` and list elements which are properly typed.

Also restructure each usage to avoid not-null assertions where unnecessary.