### PR TITLE
Minor core package cleanup

### DIFF
--- a/packages/jaspr/lib/src/client/client_app.dart
+++ b/packages/jaspr/lib/src/client/client_app.dart
@@ -11,12 +11,12 @@ import 'slotted_child_view.dart';
 /// Locates and initializes @client components during hydration.
 ///
 /// Each @client component will be mounted as a direct child of this component,
-/// independent of the actual position of that component in the DOM tree. It
-/// allows client components to share a root subtree, which can be useful for
+/// independent of the actual position of that component in the DOM tree.
+/// It allows client components to share a root subtree, which can be useful for
 /// sharing state by wrapping this component with one or more [InheritedComponent]s.
 ///
 /// Beware that wrapping this component with components that render DOM objects
-/// may prevent @client components to be properly hydrated.
+/// might prevent @client components to be properly hydrated.
 ///
 /// Requires [Jaspr.initializeApp] to be called with the generated [ClientOptions]
 /// before being used.

--- a/packages/jaspr/lib/src/client/client_binding.dart
+++ b/packages/jaspr/lib/src/client/client_binding.dart
@@ -30,22 +30,22 @@ class ClientAppBinding extends AppBinding with ComponentsBinding {
     return pathWithoutOrigin;
   }
 
-  late String attachTarget;
-  late (web.Node, web.Node)? attachBetween;
+  late String _attachTarget;
+  (web.Node, web.Node)? _attachBetween;
 
   @override
   void attachRootComponent(Component app, {String attachTo = 'body', (web.Node, web.Node)? attachBetween}) {
-    attachTarget = attachTo;
-    this.attachBetween = attachBetween;
+    _attachTarget = attachTo;
+    _attachBetween = attachBetween;
     super.attachRootComponent(app);
   }
 
   @override
   RenderObject createRootRenderObject() {
-    if (attachBetween case (final start, final end)) {
+    if (_attachBetween case (final start, final end)) {
       return RootDomRenderObject.between(start, end);
     } else {
-      return RootDomRenderObject(web.document.querySelector(attachTarget)!);
+      return RootDomRenderObject(web.document.querySelector(_attachTarget)!);
     }
   }
 

--- a/packages/jaspr/lib/src/client/options.dart
+++ b/packages/jaspr/lib/src/client/options.dart
@@ -48,13 +48,18 @@ final class ClientLoader {
   /// The returned [Future] is cached for future calls, so the [loader] is only called once.
   /// Once loaded, the [builder] is returned directly on subsequent calls.
   FutureOr<ClientBuilder> get loadedBuilder {
-    _loadedBuilder ??= loader != null
-        ? loader!().then((_) {
-            _loadedBuilder = builder;
-            return builder;
-          })
-        : builder;
-    return _loadedBuilder!;
+    if (_loadedBuilder case final alreadyLoadedBuilder?) {
+      return alreadyLoadedBuilder;
+    }
+
+    final FutureOr<ClientBuilder>? newLoadedBuilder;
+    if (loader case final loader?) {
+      newLoadedBuilder = loader().then((_) => _loadedBuilder = builder);
+    } else {
+      newLoadedBuilder = builder;
+    }
+
+    return _loadedBuilder = newLoadedBuilder;
   }
 }
 

--- a/packages/jaspr/lib/src/client/run_app.dart
+++ b/packages/jaspr/lib/src/client/run_app.dart
@@ -1,7 +1,7 @@
 import '../framework/framework.dart';
 import 'client_binding.dart';
 
-/// Main entry point for the browser app
+/// Main entry point for the browser app.
 ClientAppBinding runApp(Component app, {String attachTo = 'body'}) {
   return ClientAppBinding()..attachRootComponent(app, attachTo: attachTo);
 }

--- a/packages/jaspr/lib/src/dom/events.dart
+++ b/packages/jaspr/lib/src/dom/events.dart
@@ -9,11 +9,15 @@ import 'type_checks.dart';
 Map<String, EventCallback> events<V>({
   /// Listens to the 'click' event.
   ///
-  /// If the target element is an anchor (<a>) element, this will override the default behavior of the link and not
-  /// visit the specified `href` when clicked.
+  /// If the target element is an anchor (`<a>`) element,
+  /// this overrides the default behavior of the link and
+  /// doesn't visit the specified `href` when clicked.
   VoidCallback? onClick,
 
-  /// Listens to the 'input' event. When providing a generic type for [V], it must be according to the target element:
+  /// Listens to the 'input' event.
+  ///
+  /// When providing a generic type for [V], it must be according to the target element:
+  ///
   /// - `bool?` for checkbox or radio input elements
   /// - `num?` for number input elements
   /// - `DateTime` for date input elements
@@ -23,7 +27,10 @@ Map<String, EventCallback> events<V>({
   /// - `Null` for all other elements
   ValueChanged<V>? onInput,
 
-  /// Listens to the 'change' event. When providing a generic type for [V], it must be according to the target element:
+  /// Listens to the 'change' event.
+  ///
+  /// When providing a generic type for [V], it must be according to the target element:
+  ///
   /// - `bool?` for checkbox or radio input elements
   /// - `num?` for number input elements
   /// - `DateTime` for date input elements

--- a/packages/jaspr/lib/src/dom/html/html.dart
+++ b/packages/jaspr/lib/src/dom/html/html.dart
@@ -19,7 +19,7 @@ final _events = events;
 
 /// Renders a text node.
 ///
-/// Convenience method for `Component.text()`.
+/// Migrate to use [Component.text] directly instead.
 @Deprecated('Use Component.text() instead.')
 Component text(String text, {Key? key}) {
   return Component.text(text, key: key);
@@ -31,15 +31,15 @@ Component text(String text, {Key? key}) {
 /// [cross-site scripting (XSS) attacks](https://owasp.org/www-community/attacks/xss/).
 /// Make sure to sanitize any user input when using this component.
 ///
-/// Convenience method for `RawText()`.
+/// Migrate to use [RawText] directly instead.
 @Deprecated('Use RawText() instead.')
 Component raw(String text, {Key? key}) {
   return RawText(text, key: key);
 }
 
-/// Renders a list of children without any wrapping element.
+/// Renders a list of [children] without any wrapping element.
 ///
-/// Convenience method for `Component.fragment()`.
+/// Migrate to use [Component.fragment] directly instead.
 @Deprecated('Use Component.fragment() instead.')
 Component fragment(List<Component> children, {Key? key}) {
   return Component.fragment(children, key: key);

--- a/packages/jaspr/lib/src/dom/styles.dart
+++ b/packages/jaspr/lib/src/dom/styles.dart
@@ -7,8 +7,8 @@ export 'styles/rules.dart' show StyleRule, MediaQuery, Orientation, ColorScheme,
 export 'styles/selector.dart' show Selector, SelectorMixin, AttrCheck, Combinator;
 export 'styles/styles.dart';
 
-/// Renders the provided [StyleRule]s into css and wraps them
-/// with a &lt;style&gt; element.
+/// Renders the provided list of [styles] into css and wraps them
+/// with a `<style>` element.
 class Style extends StatelessComponent {
   final List<StyleRule> styles;
 

--- a/packages/jaspr/lib/src/server/app_context.dart
+++ b/packages/jaspr/lib/src/server/app_context.dart
@@ -39,8 +39,8 @@ extension AppContext on BuildContext {
 
   /// Sets the cookie with the given name and value in the response.
   ///
-  /// [name] and [value] must be composed of valid characters according to RFC
-  /// 6265.
+  /// [name] and [value] must be composed of valid characters according to
+  /// RFC 6265.
   void setCookie(
     /// The name of the cookie.
     String name,


### PR DESCRIPTION
- Update `htmlns` and `xmlns` top-level variables to be private as implementation details since they're not essential to Jaspr's public API.
- Updates a few API docs for improved formatting and migration guidelines.
- Adjusts some code to avoid a few duplicate type checks, late initialization checks, and non-null checks.