### PR TITLE
fix: support RawText components in testComponents

### DIFF
--- a/packages/jaspr/CHANGELOG.md
+++ b/packages/jaspr/CHANGELOG.md
@@ -1,8 +1,9 @@
 ## Unreleased patch
 
 - Fixed `testComponents` failing with `RawText` components due to `MarkupRenderObject` cast error.
-  - Added optional `rawHtml` parameter to `RenderObject.createChildRenderText()` and `RenderText.update()` interfaces.
-  - Updated `TestRenderObject` and `TestRenderText` to support raw HTML text rendering in tests.
+  - Added `RawableRenderObject` and `RawableRenderText` interfaces for raw HTML text rendering support.
+  - `MarkupRenderObject` and `TestRenderObject` now implement `RawableRenderObject`.
+  - `MarkupRenderText` and `TestRenderText` now implement `RawableRenderText`.
 
 ## 0.22.1
 

--- a/packages/jaspr/lib/src/client/dom_render_object.dart
+++ b/packages/jaspr/lib/src/client/dom_render_object.dart
@@ -27,7 +27,7 @@ abstract class DomRenderObject implements RenderObject {
   }
 
   @override
-  RenderText createChildRenderText(String text, [bool rawHtml = false]) {
+  RenderText createChildRenderText(String text) {
     return DomRenderText(text, this);
   }
 
@@ -250,7 +250,7 @@ class DomRenderText extends DomRenderObject implements RenderText {
   }
 
   @override
-  void update(String text, [bool rawHtml = false]) {
+  void update(String text) {
     if (node.textContent != text) {
       node.textContent = text;
       if (kVerboseMode) {

--- a/packages/jaspr/lib/src/dom/raw_text/raw_text_vm.dart
+++ b/packages/jaspr/lib/src/dom/raw_text/raw_text_vm.dart
@@ -25,12 +25,12 @@ class _RawTextElement extends LeafRenderObjectElement {
 
   @override
   RenderObject createRenderObject() {
-    final parent = parentRenderObjectElement!.renderObject;
+    final parent = parentRenderObjectElement!.renderObject as RawableRenderObject;
     return parent.createChildRenderText((component as RawText).text, true);
   }
 
   @override
   void updateRenderObject(covariant RenderObject renderObject) {
-    (renderObject as RenderText).update((component as RawText).text, true);
+    (renderObject as RawableRenderText).update((component as RawText).text, true);
   }
 }

--- a/packages/jaspr/lib/src/framework/render_object.dart
+++ b/packages/jaspr/lib/src/framework/render_object.dart
@@ -5,7 +5,7 @@ abstract class RenderObject {
   web.Node? get node;
 
   RenderElement createChildRenderElement(String tag);
-  RenderText createChildRenderText(String text, [bool rawHtml = false]);
+  RenderText createChildRenderText(String text);
   RenderFragment createChildRenderFragment();
 
   void attach(covariant RenderObject child, {covariant RenderObject? after});
@@ -24,6 +24,16 @@ abstract class RenderElement implements RenderObject {
 }
 
 abstract class RenderText implements RenderObject {
+  void update(String text);
+}
+
+abstract class RawableRenderObject implements RenderObject {
+  @override
+  RenderText createChildRenderText(String text, [bool rawHtml = false]);
+}
+
+abstract class RawableRenderText implements RenderText {
+  @override
   void update(String text, [bool rawHtml = false]);
 }
 

--- a/packages/jaspr/lib/src/server/markup_render_object.dart
+++ b/packages/jaspr/lib/src/server/markup_render_object.dart
@@ -6,7 +6,7 @@ import '../../server.dart';
 import '../dom/validator.dart';
 import 'child_nodes.dart';
 
-abstract class MarkupRenderObject extends RenderObject {
+abstract class MarkupRenderObject extends RenderObject implements RawableRenderObject {
   @override
   MarkupRenderObject? parent;
   @override
@@ -234,7 +234,7 @@ class MarkupRenderElement extends MarkupRenderObject implements RenderElement {
   }
 }
 
-class MarkupRenderText extends MarkupRenderObject implements RenderText {
+class MarkupRenderText extends MarkupRenderObject implements RawableRenderText {
   MarkupRenderText(this.text, this.rawHtml);
 
   String text;

--- a/packages/jaspr_test/lib/src/testers/component_tester.dart
+++ b/packages/jaspr_test/lib/src/testers/component_tester.dart
@@ -139,7 +139,7 @@ class TestComponentsBinding extends AppBinding with ComponentsBinding {
   }
 }
 
-class TestRenderObject extends RenderObject {
+class TestRenderObject extends RenderObject implements RawableRenderObject {
   List<TestRenderObject> children = [];
 
   @override
@@ -209,7 +209,7 @@ class TestRenderElement extends TestRenderObject implements RenderElement {
   }
 }
 
-class TestRenderText extends TestRenderObject implements RenderText {
+class TestRenderText extends TestRenderObject implements RawableRenderText {
   TestRenderText(this.text, [this.rawHtml = false]);
 
   String text;


### PR DESCRIPTION
### Description

This PR fixes the `testComponents` test failure when testing components that contain `RawText` (typically used for inline SVG icons).

When using `testComponents` from `jaspr_test`, components with `RawText` fail with:

```
type 'TestRenderElement' is not a subtype of type 'MarkupRenderObject' in type cast
```

**Root cause:** The `_RawTextElement.createRenderObject()` method in `raw_text_vm.dart` was casting the parent render object to `MarkupRenderObject`, but in the test environment, `TestRenderObject` is used instead, causing the cast to fail.

**Solution:**

- Add optional rawHtml parameter to RenderObject.createChildRenderText()
- Add optional rawHtml parameter to RenderText.update()
- Remove MarkupRenderObject cast in raw_text_vm.dart
- Update TestRenderObject and TestRenderText for rawHtml support

Fixes #726 

### Type of Change

- [x] 🛠️ Bug fix

### Ready Checklist

- [x] I've read the [Contribution Guide](https://github.com/schultek/jaspr/blob/main/CONTRIBUTING.md).
- [x] In case this PR changes one of the core packages, I've modified the respective **CHANGELOG.md** file using the [semantic_changelog](https://github.com/rrousselGit/semantic_changelog) format.
- [x] All tests pass (`melos run test`)
- [x] No breaking changes