### PR TITLE
[jaspr_cli] Don't ignore errors when web or flutter build fails

### DIFF
--- a/packages/jaspr_cli/lib/src/commands/build_command.dart
+++ b/packages/jaspr_cli/lib/src/commands/build_command.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: depend_on_referenced_packages, implementation_imports
+// ignore_for_file: implementation_imports
 
 import 'dart:async';
 import 'dart:convert';
@@ -152,16 +152,14 @@ class BuildCommand extends BaseCommand with ProxyHelper, FlutterHelper {
       });
     }
 
-    final webResult = _buildWeb();
-    var flutterResult = Future<void>.value();
+    var hasBuildError = (await _buildWeb()) != 0;
 
-    await webResult;
-
+    final Future<int>? flutterResult;
     if (project.flutterMode == FlutterMode.embedded) {
       flutterResult = buildFlutter(useWasm);
+    } else {
+      flutterResult = null;
     }
-
-    bool hasBuildError = false;
 
     final serverDefines = getServerDartDefines();
 
@@ -404,7 +402,9 @@ class BuildCommand extends BaseCommand with ProxyHelper, FlutterHelper {
       dummyTargetIndex &= !(generatedRoutes.containsKey('/') || generatedRoutes.containsKey('/index'));
     }
 
-    await flutterResult;
+    if (flutterResult != null) {
+      hasBuildError |= (await flutterResult) != 0;
+    }
 
     if (dummyIndex) {
       if (indexHtml.existsSync()) indexHtml.deleteSync();

--- a/packages/jaspr_cli/lib/src/helpers/flutter_helpers.dart
+++ b/packages/jaspr_cli/lib/src/helpers/flutter_helpers.dart
@@ -42,7 +42,7 @@ mixin FlutterHelper on BaseCommand {
     return flutterProcess;
   }
 
-  Future<void> buildFlutter(bool wasm) async {
+  Future<int> buildFlutter(bool wasm) async {
     await _ensureTarget();
 
     final flutterProcess = await Process.start(
@@ -63,9 +63,11 @@ mixin FlutterHelper on BaseCommand {
 
     final moveTargets = ['version.json', 'flutter_service_worker.js', 'flutter_bootstrap.js', 'assets/', 'canvaskit/'];
 
-    await watchProcess('flutter build', flutterProcess, tag: Tag.flutter);
+    final exitCode = await watchProcess('flutter build', flutterProcess, tag: Tag.flutter);
 
     await copyFiles('./build/flutter', target, moveTargets);
+
+    return exitCode;
   }
 
   Future<void> _ensureTarget() async {


### PR DESCRIPTION
The `_buildWeb` was already returning an `int` representing its `exitCode` but it was ignored. As far as I can tell, that wasn't intentional as this function is the only caller.