### PR TITLE
fix: update claude-code configuration path to .claude in install_skil…

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -17,3 +17,4 @@ Matej Bačo (Meldiron) - Contributor
 Simon Binder (simolus3) - Contributor
 Mahdi Khodadadifard (xclud) - Contributor
 Jamiu Okanlawon (developerjamiu) - Contributor
+Harish Anbalagan (harishwarrior) - Contributor

--- a/packages/jaspr_cli/lib/src/commands/install_skills_command.dart
+++ b/packages/jaspr_cli/lib/src/commands/install_skills_command.dart
@@ -12,7 +12,7 @@ import 'base_command.dart';
 const _agents = {
   'antigravity': '.agents',
   'cursor': '.cursor',
-  'claude-code': '.claude-code',
+  'claude-code': '.claude',
   'cline': '.cline',
   'codex': '.agents',
   'copilot': '.github',


### PR DESCRIPTION
## Description

Fixes the `install-skills` command to install skills to `.claude/skills` instead of `.claude-code/skills` when Claude Code is detected.

## Type of Change

- 🛠️ Bug fix

## Ready Checklist

- [x] I've read the [Contribution Guide](https://github.com/schultek/jaspr/blob/main/CONTRIBUTING.md).
- [ ] In case this PR changes one of the core packages, I've modified the respective **CHANGELOG.md** file using the [semantic_changelog](https://github.com/rrousselGit/semantic_changelog) format.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added myself to the AUTHORS file (optional, if you want to).