### PR TITLE
Add build port option

### DIFF
--- a/packages/jaspr/CHANGELOG.md
+++ b/packages/jaspr/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased minor
+## Unreleased patch
 
 - Added a `--port` option to `jaspr build` for configuring the server port used during static generation.
 

--- a/packages/jaspr/CHANGELOG.md
+++ b/packages/jaspr/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased minor
+
+- Added a `--port` option to `jaspr build` for configuring the server port used during static generation.
+
 ## 0.23.1
 
 - Fixed expression compilation when debugging a client-side application with an AOT installed CLI.

--- a/packages/jaspr_cli/lib/src/commands/build_command.dart
+++ b/packages/jaspr_cli/lib/src/commands/build_command.dart
@@ -50,6 +50,13 @@ class BuildCommand extends BaseCommand with ProxyHelper, FlutterHelper {
       help: 'Compile to a specific target architecture (only in server mode)',
       allowed: ['arm', 'arm64', 'riscv64', 'x64'],
     );
+    argParser.addOption(
+      'port',
+      abbr: 'p',
+      help:
+          'Specify a port to run the server on during static generation. '
+          'Defaults to {jaspr.port} from pubspec.yaml or "$defaultServePort".',
+    );
     argParser.addFlag('experimental-wasm', help: 'Compile to wasm', negatable: false);
     argParser.addMultiOption(
       'extra-js-compiler-option',
@@ -223,7 +230,7 @@ class BuildCommand extends BaseCommand with ProxyHelper, FlutterHelper {
       final List<String> queuedRoutes = [];
 
       final serverStartedCompleter = Completer<void>();
-      final serverPort = project.port ?? defaultServePort;
+      final serverPort = argResults!.option('port') ?? project.port ?? defaultServePort;
 
       await startProxy(
         serverProxyPort,

--- a/packages/jaspr_cli/test/src/commands/build_command_test.dart
+++ b/packages/jaspr_cli/test/src/commands/build_command_test.dart
@@ -186,6 +186,87 @@ void main() {
       });
     });
 
+    test('builds static project with custom port', () async {
+      await io.runZoned(() async {
+        io.setupFakeProject('myapp', mode: 'static');
+        io.stubDartSDK();
+
+        final buildDaemon = io.setupFakeBuildDaemon(verifyArgs: buildRunnerBuildArgs);
+
+        FakeProcess? serverProcess;
+        when(
+          () => io.process.start(
+            '/fake/bin/dart',
+            any(that: contains('-Djaspr.flags.generate=true')),
+            workingDirectory: '/root/myapp',
+            environment: any(named: 'environment'),
+          ),
+        ).thenAnswer((inv) async {
+          expect(
+            inv.namedArguments[#environment],
+            equals({'PORT': '8181', 'JASPR_PROXY_PORT': serverProxyPort}),
+          );
+
+          return serverProcess = FakeProcess();
+        });
+
+        final buildResult = runner.run(['build', '--port', '8181', '--verbose']);
+
+        await expectLater(
+          io.stdout.queue,
+          emitsInOrder([
+            'Building jaspr for static rendering mode.',
+            'Using server entry point: lib/main.server.dart',
+          ]),
+        );
+
+        await io.runReleaseBuild(buildDaemon);
+
+        await expectLater(
+          io.stdout.queue,
+          emitsInOrder([
+            'Preparing static rendering...',
+            '[SERVER] Starting server app...',
+          ]),
+        );
+
+        expect(serverProcess, isNotNull);
+
+        final proxyConnection = await io.connectToProxy();
+
+        final fakeServer = io.setupFakeServer(8181);
+
+        fakeServer.onRequest('/abc', (request) async {
+          request.response.write('FAKE HTML RESPONSE');
+          await request.response.close();
+        });
+
+        await proxyConnection.sendFakeRequest(r'$jasprMessageHandler', jsonEncode({'route': '/abc'}));
+
+        await expectLater(
+          io.stdout.queue,
+          emitsInOrder([
+            'Server started',
+            'Generating routes...',
+            '(1/1) Generating route "/abc" ...',
+          ]),
+        );
+
+        expect(io.fs.file('/root/myapp/build/jaspr/abc/index.html').existsSync(), isTrue);
+        expect(io.fs.file('/root/myapp/build/jaspr/abc/index.html').readAsStringSync(), equals('FAKE HTML RESPONSE'));
+
+        await expectLater(
+          io.stdout.queue,
+          emitsInOrder([
+            'Completed building project to /build/jaspr.',
+            'Terminating server...',
+          ]),
+        );
+
+        expect(await buildResult, equals(0));
+      });
+    });
+
     test('builds project with flutter embedding', () async {
       await io.runZoned(() async {
         io.setupFakeProject('myapp', mode: 'client', flutterEmbedding: true);


### PR DESCRIPTION
Adds `--port` to `jaspr build` so static generation can use a custom server port.

Closes #750.

Runtime check:

```text
$ dart run jaspr_cli:jaspr build --port 8181 --verbose
[SERVER] Serving at http://0.0.0.0:8181
Server started
Generating routes...
Completed building project to /build/jaspr.
Terminating server...
```

Tests:
- `dart format --set-exit-if-changed packages/jaspr_cli/lib/src/commands/build_command.dart packages/jaspr_cli/test/src/commands/build_command_test.dart`
- `dart analyze . --fatal-infos --no-use-aot-snapshot` in `packages/jaspr_cli`
- `dart test test/src/commands/build_command_test.dart` in `packages/jaspr_cli`
