### PR TITLE
Support latest `riverpod` version

### DIFF
--- a/packages/jaspr_riverpod/CHANGELOG.md
+++ b/packages/jaspr_riverpod/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased patch
+
+- Support `riverpod` version `3.3.2`.
+
 ## 0.4.5
 
 - `jaspr` upgraded to `0.23.0`

--- a/packages/jaspr_riverpod/lib/src/core/provider_scope.dart
+++ b/packages/jaspr_riverpod/lib/src/core/provider_scope.dart
@@ -273,7 +273,7 @@ class UncontrolledProviderScope extends InheritedComponent {
 }
 
 @sealed
-class _UncontrolledProviderScopeElement extends InheritedElement {
+class _UncontrolledProviderScopeElement extends InheritedElement implements Vsync {
   _UncontrolledProviderScopeElement(UncontrolledProviderScope super.component);
 
   Task? _task;
@@ -312,7 +312,7 @@ class _UncontrolledProviderScopeElement extends InheritedElement {
       debugCanModifyProviders ??= _debugCanModifyProviders;
     }
 
-    component.container.scheduler.flutterVsyncs.add(_jasprVsync);
+    component.container.scheduler.flutterVsyncs.add(this);
     super.mount(parent, newSlot);
   }
 
@@ -321,7 +321,17 @@ class _UncontrolledProviderScopeElement extends InheritedElement {
     setDependencies(dependent, getDependencies(dependent) ?? ProviderDependencies(dependent, this));
   }
 
-  void _jasprVsync(Task task) {
+  @override
+  void Function()? scheduleDispose(Task task) {
+    return _jasprVsync(task);
+  }
+
+  @override
+  void Function()? scheduleRefresh(Task task) {
+    return _jasprVsync(task);
+  }
+
+  void Function() _jasprVsync(Task task) {
     assert(
       _task == null ||
           // Checks for race conditions where a task has been completed in a different scope.
@@ -333,12 +343,19 @@ class _UncontrolledProviderScopeElement extends InheritedElement {
     );
     _task = task;
 
+    var cancelled = false;
     Future.microtask(() async {
-      while (owner.isFirstBuild) {
+      while (owner.isFirstBuild && !cancelled) {
         await Future(() {});
       }
-      if (_mounted) markNeedsBuild();
+      if (_mounted && !cancelled) markNeedsBuild();
     });
+    return () {
+      cancelled = true;
+      if (identical(_task, task)) {
+        _task = null;
+      }
+    };
   }
 
   void _debugCanModifyProviders() {
@@ -376,7 +393,7 @@ class _UncontrolledProviderScopeElement extends InheritedElement {
       debugCanModifyProviders = null;
     }
 
-    component.container.scheduler.flutterVsyncs.remove(_jasprVsync);
+    component.container.scheduler.flutterVsyncs.remove(this);
     super.unmount();
   }
 

--- a/packages/jaspr_riverpod/pubspec.yaml
+++ b/packages/jaspr_riverpod/pubspec.yaml
@@ -19,7 +19,7 @@ resolution: workspace
 dependencies:
   jaspr: ^0.23.0
   meta: ^1.9.1
-  riverpod: ^3.0.2
+  riverpod: ^3.3.2
 
 dev_dependencies:
   jaspr_test: ">=0.1.0 <1.0.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -169,14 +169,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.1"
-  build_modules:
-    dependency: transitive
-    description:
-      name: build_modules
-      sha256: "6c5c9fde95400b9a1102fad2de007027e58c787514d5368115c13b5b32f46798"
-      url: "https://pub.dev"
-    source: hosted
-    version: "5.1.8"
   build_runner:
     dependency: transitive
     description:
@@ -197,10 +189,10 @@ packages:
     dependency: transitive
     description:
       name: build_web_compilers
-      sha256: f7020628ddf67db7619025ff64b1d3e890419410c4356a28757907db6e61a1f8
+      sha256: c8be4b48f09289d145c7eaa3240f1e7776c529ea1cecddf483218edd3129de3f
       url: "https://pub.dev"
     source: hosted
-    version: "4.4.15"
+    version: "4.8.0"
   built_collection:
     dependency: transitive
     description:
@@ -721,10 +713,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_riverpod
-      sha256: e2026c72738a925a60db30258ff1f29974e40716749f3c9850aabf34ffc1a14c
+      sha256: "9255e1e3ad6e38906a1b4f8287678f95f378744c5b46b1985588543f3f19046e"
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.1"
+    version: "3.3.2"
   flutter_test:
     dependency: transitive
     description: flutter
@@ -1171,10 +1163,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -1451,10 +1443,10 @@ packages:
     dependency: transitive
     description:
       name: riverpod
-      sha256: "8c22216be8ad3ef2b44af3a329693558c98eca7b8bd4ef495c92db0bba279f83"
+      sha256: "17100416c51db7810c71a7bb2c34d1f881faa0074fd452afb0c4db6f8f126c76"
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.1"
+    version: "3.3.2"
   rxdart:
     dependency: transitive
     description:
@@ -1467,10 +1459,10 @@ packages:
     dependency: transitive
     description:
       name: scratch_space
-      sha256: "3417e014d20b12cebc5bfb1c0b1f63806054177158596cc31cc4d9aaca767a60"
+      sha256: "564e4d0cef547454171ce97b1ea3ec70fa9bc5b3b9db896a620dd5930dc5e8b8"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   serverpod:
     dependency: transitive
     description:
@@ -1824,26 +1816,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.31.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.17"
   test_reflective_loader:
     dependency: transitive
     description:
@@ -2013,5 +2005,5 @@ packages:
     source: hosted
     version: "2.2.4"
 sdks:
-  dart: ">=3.11.0 <3.12.0-z"
+  dart: ">=3.11.0 <3.13.0-z"
   flutter: ">=3.38.4"


### PR DESCRIPTION
## Description

Jaspr uses riverpod implementation details around scheduling provider tasks, which have changed in https://github.com/rrousselGit/riverpod/commit/89d000efae968c3019d21e971394f13f89054526#diff-85ac54a7c0caffac5a3e57f9d919cdbd595a2e79fae5b6e2626032bf49b281f3. This implements the new `Vsync` interface from riverpod with the existing logic in `jaspr_riverpod` to fix compilation errors with the latest `riverpod` version.

## Type of Change

🗑️ Chore

## Ready Checklist

I have done no manual testing on this, and I don't understand riverpod internals enough to know whether this fix is correct. Existing tests pass though.