### PR TITLE
fix base handling in jaspr_router

### DIFF
--- a/packages/jaspr/CHANGELOG.md
+++ b/packages/jaspr/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased patch
+
+- Added `basePath` property to `AppBinding` to support hosting applications under a sub-path.
+- Exposed `basePath` parameter in `testComponents` and `handlerPath` in `ServerTester.request` to support testing under custom base paths.
+
 ## 0.23.1
 
 - Fixed expression compilation when debugging a client-side application with an AOT installed CLI.

--- a/packages/jaspr/lib/src/client/client_binding.dart
+++ b/packages/jaspr/lib/src/client/client_binding.dart
@@ -14,9 +14,15 @@ class ClientAppBinding extends AppBinding with ComponentsBinding {
   bool get isClient => true;
 
   static final String _baseOrigin = () {
-    final base = web.document.querySelector('head>base') as web.HTMLBaseElement?;
-    return base?.href ?? web.window.location.origin;
+    final hasBase = web.document.querySelector('head>base') != null;
+    return hasBase ? web.document.baseURI : web.window.location.origin;
   }();
+
+  @override
+  String get basePath {
+    final path = Uri.parse(_baseOrigin).path;
+    return path.isEmpty ? '/' : path;
+  }
 
   @override
   String get currentUrl {

--- a/packages/jaspr/lib/src/foundation/binding.dart
+++ b/packages/jaspr/lib/src/foundation/binding.dart
@@ -14,6 +14,9 @@ abstract class AppBinding with SchedulerBinding {
   /// On the client, this is the currently visited url in the browser.
   String get currentUrl;
 
+  /// The base path of the application.
+  String get basePath => '/';
+
   /// The [Element] that is at the root of the hierarchy.
   ///
   /// This is initialized when `runApp` is called.

--- a/packages/jaspr/lib/src/server/render_functions.dart
+++ b/packages/jaspr/lib/src/server/render_functions.dart
@@ -13,7 +13,7 @@ import 'run_app.dart';
 import 'server_app.dart';
 import 'server_binding.dart';
 
-typedef RequestLike = ({String url, Headers headers});
+typedef RequestLike = ({String url, String basePath, Headers headers});
 
 /// Performs the rendering process and provides the created [AppBinding] to [setup].
 ///
@@ -24,7 +24,11 @@ Future<ResponseLike> render(SetupFunction setup, Request request, FileLoader loa
     url = '/$url';
   }
 
-  final RequestLike r = (url: url, headers: Headers.from(request.headersAll));
+  final RequestLike r = (
+    url: url,
+    basePath: request.handlerPath,
+    headers: Headers.from(request.headersAll),
+  );
 
   if (!Jaspr.useIsolates) {
     final binding = ServerAppBinding(r, loadFile: loadFile);

--- a/packages/jaspr/lib/src/server/server_binding.dart
+++ b/packages/jaspr/lib/src/server/server_binding.dart
@@ -28,6 +28,9 @@ class ServerAppBinding extends AppBinding with ComponentsBinding {
   bool get isClient => false;
 
   @override
+  String get basePath => request.basePath;
+
+  @override
   String get currentUrl => request.url;
 
   /// Unmodifiable view of the cookies sent with the [request].

--- a/packages/jaspr/test/server/child_list_test.dart
+++ b/packages/jaspr/test/server/child_list_test.dart
@@ -14,7 +14,11 @@ import 'package:shelf/src/headers.dart';
 void main() {
   group('child list', () {
     Future<RenderObjectElement> renderServerApp(Component app) async {
-      final binding = ServerAppBinding((url: '/', basePath: '/', headers: Headers.empty()), loadFile: (_) async => null);
+      final binding = ServerAppBinding((
+        url: '/',
+        basePath: '/',
+        headers: Headers.empty(),
+      ), loadFile: (_) async => null);
       binding.initializeOptions(ServerOptions());
       binding.attachRootComponent(app);
 

--- a/packages/jaspr/test/server/child_list_test.dart
+++ b/packages/jaspr/test/server/child_list_test.dart
@@ -14,7 +14,7 @@ import 'package:shelf/src/headers.dart';
 void main() {
   group('child list', () {
     Future<RenderObjectElement> renderServerApp(Component app) async {
-      final binding = ServerAppBinding((url: '/', headers: Headers.empty()), loadFile: (_) async => null);
+      final binding = ServerAppBinding((url: '/', basePath: '/', headers: Headers.empty()), loadFile: (_) async => null);
       binding.initializeOptions(ServerOptions());
       binding.attachRootComponent(app);
 

--- a/packages/jaspr_router/CHANGELOG.md
+++ b/packages/jaspr_router/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased patch
+
+- Fixed routing and redirect bug to respect the `<base href="...">` configuration by prepending `basePath` on client history operations, server redirect headers, and `Link` hrefs.
+
 ## 0.8.2
 
 - `jaspr` upgraded to `0.23.0`

--- a/packages/jaspr_router/lib/src/link.dart
+++ b/packages/jaspr_router/lib/src/link.dart
@@ -64,8 +64,17 @@ class Link extends StatelessComponent {
 
   @override
   Component build(BuildContext context) {
+    final resolvedUrl = () {
+      if (to.startsWith('/') && !to.startsWith('//')) {
+        final basePath = context.binding.basePath;
+        final prefix = basePath.endsWith('/') ? basePath.substring(0, basePath.length - 1) : basePath;
+        return prefix + to;
+      }
+      return to;
+    }();
+
     return a(
-      href: to,
+      href: resolvedUrl,
       target: target,
       referrerPolicy: referrer,
       classes: classes,

--- a/packages/jaspr_router/lib/src/redirection.dart
+++ b/packages/jaspr_router/lib/src/redirection.dart
@@ -211,7 +211,10 @@ void _addRedirect(List<RouteMatchList> redirects, RouteMatchList newMatch, Uri p
 }
 
 RouteMatchList _setRedirectHeader(BuildContext context, RouteMatchList matchList) {
-  PlatformRouter.instance.redirect(context, matchList.uri.path);
+  final basePath = context.binding.basePath;
+  final prefix = basePath.endsWith('/') ? basePath.substring(0, basePath.length - 1) : basePath;
+  final redirectUrl = prefix + matchList.uri.path;
+  PlatformRouter.instance.redirect(context, redirectUrl);
   return _redirectMatch(matchList.uri);
 }
 

--- a/packages/jaspr_router/lib/src/router.dart
+++ b/packages/jaspr_router/lib/src/router.dart
@@ -92,7 +92,7 @@ class RouterState extends State<Router> with PreloadStateMixin {
         setState(() {});
       }
       if (context.binding.isClient && match.uri.toString() != location) {
-        PlatformRouter.instance.history.replace(match.uri.toString(), title: match.title);
+        PlatformRouter.instance.history.replace(_normalizeUrl(match.uri.toString()), title: match.title);
       }
     });
   }
@@ -187,10 +187,11 @@ class RouterState extends State<Router> with PreloadStateMixin {
       setState(() {
         _matchList = match;
         if (updateHistory || location != match.uri.toString()) {
+          final historyUrl = _normalizeUrl(match.uri.toString());
           if (!replace) {
-            PlatformRouter.instance.history.push(match.uri.toString(), title: match.title, data: match.extra);
+            PlatformRouter.instance.history.push(historyUrl, title: match.title, data: match.extra);
           } else {
-            PlatformRouter.instance.history.replace(match.uri.toString(), title: match.title, data: match.extra);
+            PlatformRouter.instance.history.replace(historyUrl, title: match.title, data: match.extra);
           }
         }
       });
@@ -214,6 +215,12 @@ class RouterState extends State<Router> with PreloadStateMixin {
 
   Future<RouteMatchList> _matchRoute(String location, {Object? extra}) {
     return component._parser.parseRouteInformation(location, context, extra: extra);
+  }
+
+  String _normalizeUrl(String location) {
+    final basePath = context.binding.basePath;
+    final prefix = basePath.endsWith('/') ? basePath.substring(0, basePath.length - 1) : basePath;
+    return prefix + location;
   }
 
   @override

--- a/packages/jaspr_router/test/routing/routes_test.dart
+++ b/packages/jaspr_router/test/routing/routes_test.dart
@@ -1,7 +1,10 @@
 @TestOn('vm')
 library;
 
+import 'package:jaspr/dom.dart';
+import 'package:jaspr/jaspr.dart';
 import 'package:jaspr_router/jaspr_router.dart';
+import 'package:jaspr_router/src/platform/platform.dart';
 import 'package:jaspr_test/jaspr_test.dart';
 
 import '../utils.dart';
@@ -82,5 +85,27 @@ void main() {
       expect(find.text('b'), findsOneComponent);
       expect(find.text('a/c'), findsOneComponent);
     });
+
+    testComponents('should push route with basePath', (tester) async {
+      tester.pumpComponent(Router(routes: [homeRoute(), route('/a')]));
+
+      final mockHistory = PlatformRouter.instance.history as MockHistoryManager;
+      expect(mockHistory.history, equals(['/']));
+
+      await tester.router.push('/a');
+      await pumpEventQueue();
+
+      expect(find.text('a'), findsOneComponent);
+      expect(mockHistory.history, equals(['/', '/sub/path/a']));
+    }, basePath: '/sub/path/');
+
+    testComponents('should render Link with resolved basePath', (tester) async {
+      tester.pumpComponent(Link(to: '/a', child: span([Component.text('link')])));
+
+      final spanElement = find.text('link').evaluate().first.parent!;
+      final linkElement = spanElement.parent!.parent as DomElement;
+      final renderElement = linkElement.renderObject as TestRenderElement;
+      expect(renderElement.attributes?['href'], equals('/sub/path/a'));
+    }, basePath: '/sub/path/');
   });
 }

--- a/packages/jaspr_router/test/server/routing/redirect_test.dart
+++ b/packages/jaspr_router/test/server/routing/redirect_test.dart
@@ -1,10 +1,8 @@
 @TestOn('vm')
 library;
 
-import 'package:jaspr/server.dart';
 import 'package:jaspr_router/jaspr_router.dart';
 import 'package:jaspr_test/server_test.dart';
-import 'package:shelf/shelf.dart';
 
 import '../../utils.dart';
 

--- a/packages/jaspr_router/test/server/routing/redirect_test.dart
+++ b/packages/jaspr_router/test/server/routing/redirect_test.dart
@@ -1,8 +1,10 @@
 @TestOn('vm')
 library;
 
+import 'package:jaspr/server.dart';
 import 'package:jaspr_router/jaspr_router.dart';
 import 'package:jaspr_test/server_test.dart';
+import 'package:shelf/shelf.dart';
 
 import '../../utils.dart';
 
@@ -94,6 +96,28 @@ void main() {
       response = await tester.request('/a');
       expect(response.statusCode, equals(302));
       expect(response.headers['location'], equals('/'));
+    });
+
+    testServer('should redirect on server with basePath', (tester) async {
+      tester.pumpComponent(
+        Router(
+          routes: [
+            homeRoute(),
+            route('/a'),
+            route('/b', [], null, (_, s) {
+              if (s.location == '/b') {
+                return '/a';
+              }
+              return null;
+            }),
+          ],
+        ),
+      );
+
+      final response = await tester.request('/sub/path/b', handlerPath: '/sub/path/');
+
+      expect(response.statusCode, equals(302));
+      expect(response.headers['location'], equals('/sub/path/a'));
     });
   });
 }

--- a/packages/jaspr_test/lib/src/testers/component_tester.dart
+++ b/packages/jaspr_test/lib/src/testers/component_tester.dart
@@ -16,6 +16,7 @@ void testComponents(
   String description,
   FutureOr<void> Function(ComponentTester tester) callback, {
   String? url,
+  String basePath = '/',
   bool isClient = true,
   bool? skip,
   Timeout? timeout,
@@ -24,7 +25,7 @@ void testComponents(
   test(
     description,
     () async {
-      final binding = TestComponentsBinding(url ?? '/', isClient);
+      final binding = TestComponentsBinding(url ?? '/', isClient, basePath: basePath);
       final tester = ComponentTester._(binding);
 
       return binding.runTest(() async {
@@ -108,12 +109,14 @@ class ComponentTester {
 }
 
 class TestComponentsBinding extends AppBinding with ComponentsBinding {
-  TestComponentsBinding(this.currentUrl, this.isClient);
+  TestComponentsBinding(this.currentUrl, this.isClient, {this.basePath = '/'});
 
   @override
   final bool isClient;
   @override
   final String currentUrl;
+  @override
+  final String basePath;
 
   @override
   void scheduleFrame(VoidCallback frameCallback) {

--- a/packages/jaspr_test/lib/src/testers/server_tester.dart
+++ b/packages/jaspr_test/lib/src/testers/server_tester.dart
@@ -86,10 +86,10 @@ class ServerTester {
 
   /// Perform a virtual request to your app that renders the components and returns the
   /// resulting document.
-  Future<DocumentResponse> request(String location) async {
+  Future<DocumentResponse> request(String location, {String? handlerPath}) async {
     final uri = Uri.parse('http://test.server$location');
 
-    final response = await _handler(Request('GET', uri));
+    final response = await _handler(Request('GET', uri, handlerPath: handlerPath));
     final statusCode = response.statusCode;
     final headers = response.headers;
     final body = await response.readAsString();


### PR DESCRIPTION
<!--
  Thanks for contributing! 💙

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Fixed routing and redirect bug to respect the `<base href="...">` configuration by prepending `basePath` on client history operations, server redirect headers, and `Link` hrefs.

<!-- Describe your changes in detail -->

## Type of Change

<!-- Uncomment all that apply: -->

<!-- - ❌ Breaking change -->
<!-- - ✨ New feature or improvement -->
- 🛠️ Bug fix
<!-- - 🧹 Code refactor -->
<!-- - 📝 Documentation -->
<!-- - 🗑️ Chore -->

## Ready Checklist

- [ ] I've read the [Contribution Guide](https://github.com/schultek/jaspr/blob/main/CONTRIBUTING.md).
- [ ] In case this PR changes one of the core packages, I've modified the respective **CHANGELOG.md** file using
      the [semantic_changelog](https://github.com/rrousselGit/semantic_changelog) format.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added myself to the AUTHORS file (optional, if you want to).

<!-- 
  Feel free to expand this list if you have additional todos before your PR is ready. 
-->

<!--
  If you need help, consider asking for advice on the *#contribute* channel on [Discord](https://discord.gg/XGXrGEk4c6).
-->
