### PR TITLE
[cli] Fix instance of new unawaited_return_in_try_block diagnostic

### DIFF
--- a/packages/jaspr/CHANGELOG.md
+++ b/packages/jaspr/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased patch
+
+- Fixed asynchronous errors escaping the development proxy when falling back to the app root.
+
 ## 0.23.2
 
 - Added `basePath` property to `AppBinding` to support hosting applications under a sub-path.

--- a/packages/jaspr_cli/lib/src/helpers/proxy_helper.dart
+++ b/packages/jaspr_cli/lib/src/helpers/proxy_helper.dart
@@ -75,7 +75,7 @@ mixin ProxyHelper on BaseCommand {
         }
 
         if (res.statusCode == 404 && redirectNotFound && path.extension(req.url.path).isEmpty) {
-          return webdevHandler(
+          return await webdevHandler(
             Request(
               req.method,
               req.requestedUri.replace(path: '/'),


### PR DESCRIPTION
This snippet was hitting the new [`unawaited_return_in_try_block`](https://dart.dev/tools/diagnostics/unawaited_return_in_try_block) diagnostic.