### PR TITLE
[cli] Fix repeated copying of nested build assets

### DIFF
--- a/packages/jaspr/CHANGELOG.md
+++ b/packages/jaspr/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased patch
+
+- Fixed repeated copying of nested build assets.
+
 ## 0.23.2
 
 - Added `basePath` property to `AppBinding` to support hosting applications under a sub-path.

--- a/packages/jaspr_cli/lib/src/commands/base_command.dart
+++ b/packages/jaspr_cli/lib/src/commands/base_command.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:collection';
 import 'dart:convert';
 import 'dart:io';
 
@@ -238,13 +239,13 @@ abstract class BaseCommand extends Command<int> {
   Future<void> copyToBuildDir(String from, [List<String> targets = const ['']]) async {
     final to = project.requireMode != JasprMode.server ? 'build/jaspr' : 'build/jaspr/web';
 
-    // Pending relative paths to copy or inspect while traversing the source tree.
-    final moveTargets = [...targets];
+    // Pending relative paths to copy or inspect in discovery order.
+    final moveTargets = ListQueue<String>.of(targets);
     final visitedTargets = <String>{};
 
     final moves = <Future<void>>[];
     while (moveTargets.isNotEmpty) {
-      final moveTarget = p.normalize(moveTargets.removeLast());
+      final moveTarget = p.normalize(moveTargets.removeFirst());
 
       // Explicit targets could overlap with paths discovered while traversing directories.
       if (!visitedTargets.add(moveTarget)) {

--- a/packages/jaspr_cli/lib/src/commands/base_command.dart
+++ b/packages/jaspr_cli/lib/src/commands/base_command.dart
@@ -237,11 +237,20 @@ abstract class BaseCommand extends Command<int> {
 
   Future<void> copyToBuildDir(String from, [List<String> targets = const ['']]) async {
     final to = project.requireMode != JasprMode.server ? 'build/jaspr' : 'build/jaspr/web';
+
+    // Pending relative paths to copy or inspect while traversing the source tree.
     final moveTargets = [...targets];
+    final visitedTargets = <String>{};
 
     final moves = <Future<void>>[];
     while (moveTargets.isNotEmpty) {
-      final moveTarget = moveTargets.removeAt(0);
+      final moveTarget = p.normalize(moveTargets.removeLast());
+
+      // Explicit targets could overlap with paths discovered while traversing directories.
+      if (!visitedTargets.add(moveTarget)) {
+        continue;
+      }
+
       final file = File('$from/$moveTarget').absolute;
       final directory = Directory('$from/$moveTarget').absolute;
       if (file.existsSync()) {
@@ -249,9 +258,11 @@ abstract class BaseCommand extends Command<int> {
       } else if (directory.existsSync()) {
         await Directory('$to/$moveTarget').absolute.create(recursive: true);
 
-        final files = Directory('$from/$moveTarget').absolute.list(recursive: true);
-        await for (final file in files) {
-          final path = p.relative(file.absolute.path, from: p.join(Directory.current.absolute.path, from));
+        // Queue only direct children.
+        // Recursive listing here would enqueue descendants again
+        // each time one of their parent directories is processed.
+        await for (final entity in directory.list(recursive: false)) {
+          final path = p.relative(entity.absolute.path, from: p.join(Directory.current.absolute.path, from));
           moveTargets.add(path);
         }
       }

--- a/packages/jaspr_cli/test/src/commands/base_command_test.dart
+++ b/packages/jaspr_cli/test/src/commands/base_command_test.dart
@@ -1,0 +1,91 @@
+import 'package:file/memory.dart';
+import 'package:jaspr_cli/src/commands/base_command.dart';
+import 'package:test/test.dart';
+
+import '../fakes/fake_io.dart';
+import '../fakes/fake_project.dart';
+
+void main() {
+  group('copyToBuildDir', () {
+    const sourceRoot = '/root/myapp/generated';
+    const outputRoot = '/root/myapp/build/jaspr';
+
+    late FakeIO io;
+    late _TestCommand command;
+    late List<String> copiedPaths;
+
+    void writeFiles(Map<String, String> files) {
+      for (final file in files.entries) {
+        io.fs.file('$sourceRoot/${file.key}')
+          ..createSync(recursive: true)
+          ..writeAsStringSync(file.value);
+      }
+    }
+
+    void expectFilesCopiedOnce(Map<String, String> files) {
+      expect(copiedPaths, unorderedEquals(files.keys.map((path) => '$sourceRoot/$path')));
+      for (final file in files.entries) {
+        expect(io.fs.file('$outputRoot/${file.key}').readAsStringSync(), file.value);
+      }
+    }
+
+    setUp(() {
+      copiedPaths = [];
+      io = FakeIO(
+        fileSystemOpHandler: (context, operation) {
+          if (operation == FileSystemOp.copy) {
+            copiedPaths.add(context);
+          }
+        },
+      );
+      io.setupFakeProject('myapp');
+      command = _TestCommand();
+    });
+
+    test('copies each file in nested directories exactly once', () async {
+      await io.runZoned(() async {
+        const files = {
+          'root.txt': 'root',
+          'assets/nested/deep.txt': 'deep',
+          'assets/other.txt': 'other',
+        };
+        writeFiles(files);
+        io.fs.directory('$sourceRoot/empty').createSync(recursive: true);
+
+        await command.copy('generated');
+
+        expectFilesCopiedOnce(files);
+        expect(io.fs.directory('$outputRoot/empty').existsSync(), isTrue);
+      });
+    });
+
+    test('does not recopy descendants selected by overlapping targets', () async {
+      await io.runZoned(() async {
+        const files = {
+          'assets/nested/deep.txt': 'deep',
+          'assets/other.txt': 'other',
+        };
+        writeFiles(files);
+
+        await command.copy('generated', ['assets', 'assets/nested']);
+
+        expectFilesCopiedOnce(files);
+      });
+    });
+  });
+}
+
+class _TestCommand extends BaseCommand {
+  @override
+  String get description => 'Test command';
+
+  @override
+  String get name => 'test';
+
+  @override
+  Future<int> runCommand() async => 0;
+
+  Future<void> copy(String from, [List<String> targets = const ['']]) {
+    return copyToBuildDir(from, targets);
+  }
+}

--- a/packages/jaspr_cli/test/src/fakes/fake_io.dart
+++ b/packages/jaspr_cli/test/src/fakes/fake_io.dart
@@ -11,8 +11,8 @@ import 'package:mocktail/mocktail.dart';
 import 'fake_socket.dart';
 
 class FakeIO {
-  FakeIO()
-    : fs = MemoryFileSystem(),
+  FakeIO({void Function(String context, FileSystemOp operation)? fileSystemOpHandler})
+    : fs = MemoryFileSystem(opHandle: fileSystemOpHandler ?? (_, _) {}),
       process = MockProcessRunner(),
       sockets = MockSockets(),
       stdin = FakeStdin(),


### PR DESCRIPTION
Before this change, every directory was listed recursively, and all descendants were added back to the pending list. When those subdirectories were processed, their descendants were recursively added again, potentially causing repeated copies.