### PR TITLE
feat: make sitemap priority optional (#785)

### DIFF
--- a/packages/jaspr/CHANGELOG.md
+++ b/packages/jaspr/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased patch
+
+- The sitemap `priority` tag is now omitted when a route has no priority set, instead of always defaulting to `0.5`.
+
 ## 0.23.2
 
 - Added `basePath` property to `AppBinding` to support hosting applications under a sub-path.

--- a/packages/jaspr_cli/lib/src/commands/build_command.dart
+++ b/packages/jaspr_cli/lib/src/commands/build_command.dart
@@ -401,7 +401,9 @@ class BuildCommand extends BaseCommand with ProxyHelper, FlutterHelper {
           if (sitemapData.changefreq != null) {
             content.writeln('    <changefreq>${sitemapData.changefreq}</changefreq>');
           }
-          content.writeln('    <priority>${sitemapData.priority ?? 0.5}</priority>');
+          if (sitemapData.priority != null) {
+            content.writeln('    <priority>${sitemapData.priority}</priority>');
+          }
           content.writeln('  </url>');
         }
         content.writeln('</urlset>');

--- a/packages/jaspr_cli/test/src/commands/build_command_test.dart
+++ b/packages/jaspr_cli/test/src/commands/build_command_test.dart
@@ -381,7 +381,6 @@ void main() {
             jsonEncode({
               'lastmod': '2026-01-01T12:34:56.789Z',
               'changefreq': 'daily',
-              'priority': 0.3,
             }),
           );
           request.response.write('FAKE HTML RESPONSE 2');
@@ -430,7 +429,6 @@ void main() {
             '    <loc>https://example.com/abc2</loc>\n'
             '    <lastmod>2026-01-01T12:34:56Z</lastmod>\n'
             '    <changefreq>daily</changefreq>\n'
-            '    <priority>0.3</priority>\n'
             '  </url>\n'
             '</urlset>\n'
             '',

--- a/packages/jaspr_router/CHANGELOG.md
+++ b/packages/jaspr_router/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased minor
+
+- Made `RouteSettings.priority` nullable and default to `null` instead of `0.5`, so the sitemap `priority` tag can be omitted (consistent with `changeFreq`).
+
 ## 0.8.3
 
 - Fixed routing and redirect bug to respect the `<base href="...">` configuration by prepending `basePath` on client history operations, server redirect headers, and `Link` hrefs.

--- a/packages/jaspr_router/lib/src/route.dart
+++ b/packages/jaspr_router/lib/src/route.dart
@@ -126,7 +126,7 @@ mixin LazyRouteBase on RouteBase {
 
 /// Settings for a route.
 class RouteSettings {
-  const RouteSettings({this.lastMod, this.changeFreq, this.priority = 0.5});
+  const RouteSettings({this.lastMod, this.changeFreq, this.priority});
 
   /// The date of last modification of the page.
   final DateTime? lastMod;
@@ -135,10 +135,11 @@ class RouteSettings {
   final ChangeFreq? changeFreq;
 
   /// The priority of this URL relative to other pages on the site.
-  /// Valid values are between 0.0 and 1.0, with 0.5 being the default.
+  /// Valid values are between 0.0 and 1.0.
   ///
-  /// Search engines may use this value to prioritize crawling.
-  final double priority;
+  /// When null, the `priority` tag is omitted from the sitemap. Note that
+  /// Google no longer uses this value.
+  final double? priority;
 }
 
 /// How frequently the page is likely to change. This value provides general information to search engines and may not correlate exactly to how often they crawl the page.


### PR DESCRIPTION
As discussed in #785, `priority` isn't used by search engines anymore, so it makes sense to be able to leave it out of the sitemap like `changefreq` already can be.

`RouteSettings.priority` now defaults to `null` instead of `0.5`, and the sitemap generator only writes the `<priority>` tag when it's set. Went with the default-null direction from the thread to keep it consistent with `changeFreq`.

Small heads-up: this makes `RouteSettings.priority` nullable, so it's technically breaking for anyone reading it as non-null. Updated the existing sitemap test to cover the omit case, and it passes.

Closes #785