### PR TITLE
Avoid empty classes in `Component.apply`

### DIFF
--- a/packages/jaspr/lib/src/framework/components.dart
+++ b/packages/jaspr/lib/src/framework/components.dart
@@ -30,6 +30,19 @@ class DomComponent extends Component {
 
 typedef EventCallback = void Function(web.Event event);
 
+/// Matches one or more HTML ASCII whitespace characters that can separate class names.
+final RegExp _htmlClassWhitespace = RegExp(r'[ \t\n\f\r]+');
+
+/// Splits [classes] into individual class names, omitting empty entries.
+///
+/// Returns `null` when [classes] is `null` or contains no class names.
+List<String>? _splitClasses(String? classes) {
+  if (classes == null) return null;
+
+  final classNames = classes.split(_htmlClassWhitespace).where((className) => className.isNotEmpty).toList();
+  return classNames.isEmpty ? null : classNames;
+}
+
 class DomElement extends DomRenderObjectElement {
   DomElement(DomComponent super.component);
 
@@ -79,7 +92,7 @@ class DomElement extends DomRenderObjectElement {
     var events = component.events;
 
     if (inheritedDomParams case final inheritedDomParams?) {
-      final classesSet = classes?.split(' ').toSet() ?? {};
+      final classesSet = {...?_splitClasses(classes)};
       styles = Map.of(styles ?? {});
       attributes = Map.of(attributes ?? {});
       events = Map.of(events ?? {});
@@ -161,7 +174,7 @@ class _ApplyDomComponent extends StatelessComponent implements DomComponent {
       params: ApplyParams(
         target: target,
         id: id,
-        classes: classes?.split(' '),
+        classes: _splitClasses(classes),
         styles: styles?.properties,
         attributes: attributes,
         events: events,

--- a/packages/jaspr/test/client/slotted_child_view_test.dart
+++ b/packages/jaspr/test/client/slotted_child_view_test.dart
@@ -70,6 +70,22 @@ void main() {
       );
     });
 
+    testClient('ignores whitespace between applied class names', (tester) async {
+      window.document.body!.innerHTML = '<div>Content</div>'.toJS;
+
+      tester.pumpComponent(
+        Component.apply(
+          classes: '  outer\tselected\n ',
+          child: SlottedChildView(slots: const []),
+        ),
+      );
+
+      final element = window.document.querySelector('body > div')!;
+      expect(element.classList.contains('outer'), isTrue);
+      expect(element.classList.contains('selected'), isTrue);
+      expect(element.classList.length, 2);
+    });
+
     testClient('cleans up applied params and events on unmount', (tester) async {
       window.document.body!.innerHTML = '<div><p>Hello World</p></div>'.toJS;
 

--- a/packages/jaspr/test/server/inherited_dom_wrapper_test.dart
+++ b/packages/jaspr/test/server/inherited_dom_wrapper_test.dart
@@ -31,6 +31,21 @@ void main() {
       );
     });
 
+    test('normalizes whitespace between applied class names', () async {
+      final result = await renderComponent(
+        Component.apply(
+          classes: '  first\tsecond\n ',
+          child: div([]),
+        ),
+        standalone: true,
+      );
+
+      expect(
+        result.body,
+        decodedMatches('<div class="first second"></div>\n'),
+      );
+    });
+
     test('merges component props with inherited props', () async {
       final result = await renderComponent(
         Component.apply(


### PR DESCRIPTION
Update class string splitting to handle extra middle or trailing whitespace (of different types).

Optionally we can still only split by normal spaces and still remove the empty entries. Let me know what you think!