### PR TITLE
Fix repeated lines during jaspr create rendering mode prompt

### DIFF
--- a/packages/jaspr/CHANGELOG.md
+++ b/packages/jaspr/CHANGELOG.md
@@ -7,6 +7,7 @@
 - The sitemap `priority` tag is now omitted when a route has no priority set, instead of always defaulting to `0.5`.
 - Fixed a misconfiguration of server hotreload that caused `jaspr serve` consuming excessive CPU.
 - Require `build_daemon ^4.1.4` to fix build error due to version mismatch.
+- Fixed repeated lines during `jaspr create` rendering mode prompt
 
 ## 0.23.2
 

--- a/packages/jaspr_cli/lib/src/commands/create_command.dart
+++ b/packages/jaspr_cli/lib/src/commands/create_command.dart
@@ -292,12 +292,22 @@ class CreateCommand extends BaseCommand {
       [final m] => RenderingMode.values.byName(m),
 
       _ => () {
-        if (!stdout.hasTerminal) {
+        final choices = RenderingMode.values;
+
+        // mason_logger's chooseOne redraws the list on every key press, however if the terminal
+        // scrolls, the entire list is re-printed. THe workaround below prints the rows to
+        // scroll before and moves back up
+        // Related to mason_logger issue #1356 https://github.com/felangel/mason/issues/1356
+        if (stdin.hasTerminal && stdout.hasTerminal && stdout.supportsAnsiEscapes) {
+          stdout.write('\n' * (choices.length + 1));
+          stdout.write('\x1b[${choices.length + 1}A'); // move back up
+        } else {
           throw usageException('No rendering mode specified.');
         }
+        
         final mode = logger.logger!.chooseOne(
           'Select a rendering mode:',
-          choices: RenderingMode.values,
+          choices: choices,
           display: (o) => '${o.name}: ${o.help}.',
         );
         return mode;

--- a/packages/jaspr_cli/lib/src/commands/create_command.dart
+++ b/packages/jaspr_cli/lib/src/commands/create_command.dart
@@ -304,7 +304,7 @@ class CreateCommand extends BaseCommand {
         } else {
           throw usageException('No rendering mode specified.');
         }
-        
+
         final mode = logger.logger!.chooseOne(
           'Select a rendering mode:',
           choices: choices,


### PR DESCRIPTION
## Description

This fixes a rendering bug when using `jaspr create` where the rendering mode prompt would be re-printed on every key press. This is due to a bug in `mason_logger` (see https://github.com/felangel/mason/issues/1356) that causes the list of choices to be reprinted to the terminal if the terminal has scrolled. A workaround is to clear the entire terminal, however this is not the behavior expected by users. The workaround here scrolls down enough to make space for the choices, then moves back up. 

Before (pressed down arrow twice): 
<img width="400"  alt="CleanShot 2026-08-04 at 12  36 28@2x" src="https://github.com/user-attachments/assets/774ce3ce-3dce-4a8f-acce-4a06268a46a1" />
After (pressed down arrow twice):
<img width="400" alt="CleanShot 2026-08-04 at 12  37 01@2x" src="https://github.com/user-attachments/assets/51b6f02d-4d60-4170-ac89-f27657111bdb" />



## Type of Change

<!-- Uncomment all that apply: -->

<!-- - ❌ Breaking change -->
<!-- - ✨ New feature or improvement -->
- 🛠️ Bug fix
<!-- - 🧹 Code refactor -->
<!-- - 📝 Documentation -->
<!-- - 🗑️ Chore -->

## Ready Checklist

- [x] I've read the [Contribution Guide](https://github.com/schultek/jaspr/blob/main/CONTRIBUTING.md).
- [x] In case this PR changes one of the core packages, I've modified the respective **CHANGELOG.md** file using
      the [semantic_changelog](https://github.com/rrousselGit/semantic_changelog) format.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added myself to the AUTHORS file (optional, if you want to).

<!-- 
  Feel free to expand this list if you have additional todos before your PR is ready. 
-->

<!--
  If you need help, consider asking for advice on the *#contribute* channel on [Discord](https://discord.gg/XGXrGEk4c6).
-->
