### PR TITLE
Fix: Initialize flutter engine before registering flutter web plugins

### DIFF
--- a/packages/jaspr/CHANGELOG.md
+++ b/packages/jaspr/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased patch
+
+- Fixed uninitialized `assetManager` when using Flutter plugins.
+
 ## 0.23.3
 
 - Added `detachRootComponent()` to `ComponentsBinding` to cleanly unmount the root component.

--- a/packages/jaspr_builder/lib/src/options/client_options_builder.dart
+++ b/packages/jaspr_builder/lib/src/options/client_options_builder.dart
@@ -65,7 +65,7 @@ class ClientOptionsBuilder implements Builder {
     var source =
         '''
       import 'package:jaspr/client.dart';
-      ${plugins.isNotEmpty ? "import 'package:flutter_web_plugins/flutter_web_plugins.dart';" : ''}
+      ${plugins.isNotEmpty ? "import 'package:flutter_web_plugins/flutter_web_plugins.dart';\nimport 'package:jaspr_flutter_embed/jaspr_flutter_embed.dart';" : ''}
       [[/]]
 
       /// Default [ClientOptions] for use with your Jaspr project.
@@ -75,12 +75,12 @@ class ClientOptionsBuilder implements Builder {
       /// Example:
       /// ```dart
       /// import '${outputId.path.split('/').last}';
-      /// 
+      ///
       /// void main() {
       ///   Jaspr.initializeApp(
       ///     options: defaultClientOptions,
       ///   );
-      ///   
+      ///
       ///   runApp(...);
       /// }
       /// ```
@@ -99,9 +99,11 @@ class ClientOptionsBuilder implements Builder {
 
     return '''
       initialize: () {
-        final Registrar registrar = webPluginRegistrar;
-        ${plugins.map((p) => '[[${p.import}]].${p.pluginClass}.registerWith(registrar);').join('\n')}
-        registrar.registerMessageHandler();
+        FlutterEmbedView.preload().then((_) {
+          final Registrar registrar = webPluginRegistrar;
+          ${plugins.map((p) => '[[${p.import}]].${p.pluginClass}.registerWith(registrar);').join('\n')}
+          registrar.registerMessageHandler();
+        });
       },''';
   }
 


### PR DESCRIPTION
<!--
  Thanks for contributing! 💙

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Flutter web plugins were registered before the flutter engine was initialized. As a result, if a plugin made use of instances of classes setup by the engine (`AssetManager` for example), then the plugin registration would fail (as shown in the error log in #723).

The fix for this is to initializes the engine before registering the plugins by using `FlutterEmbedView.preloadEngine`. Fixes #723.

Issue + fix reproduction steps:
- Clone [https://github.com/zeykafx/jaspr_preload_flutter_engine_repro](https://github.com/zeykafx/jaspr_preload_flutter_engine_repro) (project from the issue linked earlier)
- Run the app as is with `jaspr serve` and notice the error in the console
- Change the dependency overrides to point to this PR's branch code (maybe not the best way to do this, if you know of a better way to do this, please lmk)
- Re-run the app, the flutter app loads succesfully when navigating to the `/test` page

## Type of Change

<!-- Uncomment all that apply: -->

<!-- - ❌ Breaking change -->
<!-- - ✨ New feature or improvement -->
- 🛠️ Bug fix
<!-- - 🧹 Code refactor -->
<!-- - 📝 Documentation -->
<!-- - 🗑️ Chore -->

## Ready Checklist

- [x] I've read the [Contribution Guide](https://github.com/schultek/jaspr/blob/main/CONTRIBUTING.md).
- [x] In case this PR changes one of the core packages, I've modified the respective **CHANGELOG.md** file using
      the [semantic_changelog](https://github.com/rrousselGit/semantic_changelog) format.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added myself to the AUTHORS file (optional, if you want to).

<!-- 
  Feel free to expand this list if you have additional todos before your PR is ready. 
-->

<!--
  If you need help, consider asking for advice on the *#contribute* channel on [Discord](https://discord.gg/XGXrGEk4c6).
-->
