### PR TITLE
[next] Update to analyzer v13 and allow v14

### DIFF
--- a/packages/jaspr/CHANGELOG.md
+++ b/packages/jaspr/CHANGELOG.md
@@ -5,6 +5,7 @@
 - **Breaking**: Removed support for `attachBetween` parameter in `ClientAppBinding.attachRootComponent()`, as it is no longer needed.
 - Added stateful server-side reload feature.
 - Require Dart 3.13 or later.
+- Update `package:analyzer` requirement to `>=13.3.0 <15.0.0`.
 
 - Added hot-reloading of generated stylesheets in `standalone` mode.
 - Style generation in `standalone` mode now also works when importing web libraries like `package:web` or `dart:js_interop`.

--- a/packages/jaspr_builder/lib/src/client/client_module_builder.dart
+++ b/packages/jaspr_builder/lib/src/client/client_module_builder.dart
@@ -170,7 +170,7 @@ List<ClientParam> getParamsFor(ClassElement e, Codecs codecs) {
   final params = constr.formalParameters.where((e) => !keyChecker.isAssignableFromType(e.type)).toList();
 
   for (final param in params) {
-    if (!param.isInitializingFormal) {
+    if (param is! FieldFormalParameterElement) {
       throw UnsupportedError(
         'Client components only support initializing formal constructor parameters.\n'
         'Failing element: ${e.name}.${constr.name}($param)',

--- a/packages/jaspr_builder/pubspec.yaml
+++ b/packages/jaspr_builder/pubspec.yaml
@@ -20,7 +20,7 @@ topics:
   - build-runner
 
 dependencies:
-  analyzer: ^12.1.0
+  analyzer: '>=13.3.0 <15.0.0'
   build: ^4.0.0
   collection: ^1.15.0
   dart_style: ^3.0.0

--- a/packages/jaspr_cli/lib/src/migrations/build_method_migration.dart
+++ b/packages/jaspr_cli/lib/src/migrations/build_method_migration.dart
@@ -1,6 +1,7 @@
 import 'dart:math';
 
 import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:io/ansi.dart';
 
@@ -282,37 +283,33 @@ class BuilderVisitor extends RecursiveAstVisitor<void> {
 
   @override
   void visitBlockFunctionBody(BlockFunctionBody node) {
-    if (node.parent
-        case FunctionExpression(
-          parent: NamedArgument(
-            name: final name,
-            parent: ArgumentList(
-              parent: MethodInvocation(
-                methodName: SimpleIdentifier(
-                  name: 'Builder' ||
-                      'StatefulBuilder' ||
-                      'AsyncBuilder' ||
-                      'ListenableBuilder' ||
-                      'StreamBuilder' ||
-                      'FutureBuilder',
-                ),
-              ),
+    if (node.parent case FunctionExpression(
+      parent: NamedArgument(
+        name: Token(lexeme: 'builder'),
+        parent: ArgumentList(
+          parent: MethodInvocation(
+            methodName: SimpleIdentifier(
+              name: 'Builder' ||
+                  'StatefulBuilder' ||
+                  'AsyncBuilder' ||
+                  'ListenableBuilder' ||
+                  'StreamBuilder' ||
+                  'FutureBuilder',
             ),
           ),
-        )
-        when name.lexeme == 'builder') {
+        ),
+      ),
+    )) {
       onBuilderFunction(node);
       return;
     }
 
-    if (node.parent
-        case FunctionExpression(
-          parent: NamedArgument(
-            name: final name,
-            parent: ArgumentList(parent: final MethodInvocation m),
-          ),
-        )
-        when name.lexeme == 'builder') {
+    if (node.parent case FunctionExpression(
+      parent: NamedArgument(
+        name: Token(lexeme: 'builder'),
+        parent: ArgumentList(parent: final MethodInvocation m),
+      ),
+    )) {
       if (m case MethodInvocation(
         methodName: SimpleIdentifier(name: 'single'),
         target: SimpleIdentifier(name: 'Builder'),

--- a/packages/jaspr_cli/lib/src/migrations/build_method_migration.dart
+++ b/packages/jaspr_cli/lib/src/migrations/build_method_migration.dart
@@ -282,33 +282,37 @@ class BuilderVisitor extends RecursiveAstVisitor<void> {
 
   @override
   void visitBlockFunctionBody(BlockFunctionBody node) {
-    if (node.parent case FunctionExpression(
-      parent: NamedExpression(
-        name: Label(label: SimpleIdentifier(name: 'builder')),
-        parent: ArgumentList(
-          parent: MethodInvocation(
-            methodName: SimpleIdentifier(
-              name: 'Builder' ||
-                  'StatefulBuilder' ||
-                  'AsyncBuilder' ||
-                  'ListenableBuilder' ||
-                  'StreamBuilder' ||
-                  'FutureBuilder',
+    if (node.parent
+        case FunctionExpression(
+          parent: NamedArgument(
+            name: final name,
+            parent: ArgumentList(
+              parent: MethodInvocation(
+                methodName: SimpleIdentifier(
+                  name: 'Builder' ||
+                      'StatefulBuilder' ||
+                      'AsyncBuilder' ||
+                      'ListenableBuilder' ||
+                      'StreamBuilder' ||
+                      'FutureBuilder',
+                ),
+              ),
             ),
           ),
-        ),
-      ),
-    )) {
+        )
+        when name.lexeme == 'builder') {
       onBuilderFunction(node);
       return;
     }
 
-    if (node.parent case FunctionExpression(
-      parent: NamedExpression(
-        name: Label(label: SimpleIdentifier(name: 'builder')),
-        parent: ArgumentList(parent: final MethodInvocation m),
-      ),
-    )) {
+    if (node.parent
+        case FunctionExpression(
+          parent: NamedArgument(
+            name: final name,
+            parent: ArgumentList(parent: final MethodInvocation m),
+          ),
+        )
+        when name.lexeme == 'builder') {
       if (m case MethodInvocation(
         methodName: SimpleIdentifier(name: 'single'),
         target: SimpleIdentifier(name: 'Builder'),

--- a/packages/jaspr_cli/lib/src/migrations/build_method_migration.dart
+++ b/packages/jaspr_cli/lib/src/migrations/build_method_migration.dart
@@ -286,36 +286,28 @@ class BuilderVisitor extends RecursiveAstVisitor<void> {
     if (node.parent case FunctionExpression(
       parent: NamedArgument(
         name: Token(lexeme: 'builder'),
-        parent: ArgumentList(
-          parent: MethodInvocation(
-            methodName: SimpleIdentifier(
-              name: 'Builder' ||
-                  'StatefulBuilder' ||
-                  'AsyncBuilder' ||
-                  'ListenableBuilder' ||
-                  'StreamBuilder' ||
-                  'FutureBuilder',
-            ),
+        parent: ArgumentList(parent: final MethodInvocation invocation),
+      ),
+    )) {
+      switch (invocation) {
+        case MethodInvocation(
+          methodName: SimpleIdentifier(
+            name: 'Builder' ||
+                'StatefulBuilder' ||
+                'AsyncBuilder' ||
+                'ListenableBuilder' ||
+                'StreamBuilder' ||
+                'FutureBuilder',
           ),
-        ),
-      ),
-    )) {
-      onBuilderFunction(node);
-      return;
-    }
-
-    if (node.parent case FunctionExpression(
-      parent: NamedArgument(
-        name: Token(lexeme: 'builder'),
-        parent: ArgumentList(parent: final MethodInvocation m),
-      ),
-    )) {
-      if (m case MethodInvocation(
-        methodName: SimpleIdentifier(name: 'single'),
-        target: SimpleIdentifier(name: 'Builder'),
-      )) {
-        onSingleBuilder(m);
-        return;
+        ):
+          onBuilderFunction(node);
+          return;
+        case MethodInvocation(
+          methodName: SimpleIdentifier(name: 'single'),
+          target: SimpleIdentifier(name: 'Builder'),
+        ):
+          onSingleBuilder(invocation);
+          return;
       }
     }
 

--- a/packages/jaspr_cli/lib/src/migrations/component_factory_migration.dart
+++ b/packages/jaspr_cli/lib/src/migrations/component_factory_migration.dart
@@ -80,13 +80,12 @@ class ComponentFactoryMigration implements Migration {
       context.reporter.createMigration('Replaced Fragment() with Component.fragment()', (builder) {
         for (final (node, arguments) in fragments) {
           builder.replace(node.offset, node.length, 'Component.fragment');
-          final childrenArg =
-              arguments.arguments
-                      .where((arg) => arg is NamedExpression && arg.name.label.name == 'children')
-                      .firstOrNull
-                  as NamedExpression?;
+          final childrenArg = arguments.arguments
+              .whereType<NamedArgument>()
+              .where((arg) => arg.name.lexeme == 'children')
+              .firstOrNull;
           if (childrenArg != null) {
-            final end = childrenArg.expression.offset;
+            final end = childrenArg.argumentExpression.offset;
             builder.delete(childrenArg.name.offset, end - childrenArg.name.offset);
           }
         }

--- a/packages/jaspr_cli/lib/src/migrations/html_helper_migration.dart
+++ b/packages/jaspr_cli/lib/src/migrations/html_helper_migration.dart
@@ -104,8 +104,8 @@ class HelperVisitor extends RecursiveAstVisitor<void> {
     if (args.arguments.isEmpty) return false;
     if (args.arguments.length == 1) return true;
     if (args.arguments.length == 2) {
-      final named = args.arguments.whereType<NamedExpression>().toList();
-      return named.length == 1 && named.first.name.label.name == 'key';
+      final named = args.arguments.whereType<NamedArgument>().toList();
+      return named.length == 1 && named.first.name.lexeme == 'key';
     }
     return false;
   }

--- a/packages/jaspr_cli/lib/src/migrations/html_helper_migration.dart
+++ b/packages/jaspr_cli/lib/src/migrations/html_helper_migration.dart
@@ -1,4 +1,5 @@
 import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/source/source_range.dart';
 import 'package:io/ansi.dart';
@@ -90,23 +91,21 @@ class HelperVisitor extends RecursiveAstVisitor<void> {
 
   @override
   void visitMethodInvocation(MethodInvocation node) {
-    if (node.methodName.name == 'text' && node.target == null && isSingleOrKey(node.argumentList)) {
-      onText(SourceRange(node.methodName.offset, node.methodName.length));
-    } else if (node.methodName.name == 'fragment' && node.target == null && isSingleOrKey(node.argumentList)) {
-      onFragment(SourceRange(node.methodName.offset, node.methodName.length));
-    } else if (node.methodName.name == 'raw' && node.target == null && isSingleOrKey(node.argumentList)) {
-      onRaw(SourceRange(node.methodName.offset, node.methodName.length));
+    final onHelper = switch (node.methodName.name) {
+      'text' => onText,
+      'fragment' => onFragment,
+      'raw' => onRaw,
+      _ => null,
+    };
+    if (onHelper != null && node.target == null && _isSingleOrKey(node.argumentList)) {
+      onHelper(SourceRange(node.methodName.offset, node.methodName.length));
     }
     super.visitMethodInvocation(node);
   }
 
-  bool isSingleOrKey(ArgumentList args) {
-    if (args.arguments.isEmpty) return false;
-    if (args.arguments.length == 1) return true;
-    if (args.arguments.length == 2) {
-      final named = args.arguments.whereType<NamedArgument>().toList();
-      return named.length == 1 && named.first.name.lexeme == 'key';
-    }
-    return false;
-  }
+  /// Whether [args] consists of one positional argument and an optional named 'key' argument.
+  static bool _isSingleOrKey(ArgumentList args) => switch (args.arguments) {
+    [_] || [Expression(), NamedArgument(name: Token(lexeme: 'key'))] => true,
+    _ => false,
+  };
 }

--- a/packages/jaspr_cli/pubspec.yaml
+++ b/packages/jaspr_cli/pubspec.yaml
@@ -22,7 +22,7 @@ executables:
   jaspr:
 
 dependencies:
-  analyzer: ^12.1.0
+  analyzer: '>=13.3.0 <15.0.0'
   ansi_styles: ^0.3.2
   args: ^2.3.0
   async: ^2.13.0

--- a/packages/jaspr_lints/CHANGELOG.md
+++ b/packages/jaspr_lints/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased minor
 
 - Update `unsafe_imports` rule to properly handle standalone style mode.
+- Update `package:analyzer` requirement to `>=13.3.0 <15.0.0`.
 
 ## 0.7.2
 

--- a/packages/jaspr_lints/lib/src/assists/css_assist.dart
+++ b/packages/jaspr_lints/lib/src/assists/css_assist.dart
@@ -41,18 +41,17 @@ class AddStyles extends ResolvedCorrectionProducer {
       return;
     }
 
-    final idArg = argumentList.arguments
-        .whereType<NamedExpression>()
-        .where((e) => e.name.label.name == 'id')
-        .firstOrNull;
-    final idVal = idArg?.expression is StringLiteral ? (idArg!.expression as StringLiteral).stringValue : null;
+    final idArg = argumentList.arguments.whereType<NamedArgument>().where((e) => e.name.lexeme == 'id').firstOrNull;
+    final idArgExpression = idArg?.argumentExpression;
+    final idVal = idArgExpression is StringLiteral ? idArgExpression.stringValue : null;
 
     final classesArg = argumentList.arguments
-        .whereType<NamedExpression>()
-        .where((e) => e.name.label.name == 'classes')
+        .whereType<NamedArgument>()
+        .where((e) => e.name.lexeme == 'classes')
         .firstOrNull;
-    final classesVal = classesArg?.expression is StringLiteral
-        ? (classesArg!.expression as StringLiteral).stringValue?.split(' ').first
+    final classesArgExpression = classesArg?.argumentExpression;
+    final classesVal = classesArgExpression is StringLiteral
+        ? classesArgExpression.stringValue?.split(' ').first
         : null;
 
     final styles = comp.$1.body.childEntities
@@ -98,12 +97,12 @@ class AddStyles extends ResolvedCorrectionProducer {
 
       if (idVal == null && classesVal == null) {
         if (classesArg != null) {
-          builder.addInsertion(classesArg.expression.offset, (edit) {
+          builder.addInsertion(classesArg.argumentExpression.offset, (edit) {
             edit.write("'");
             edit.addSimpleLinkedEdit('className', 'myclass');
             edit.write(' \${');
           });
-          builder.addInsertion(classesArg.expression.end, (edit) {
+          builder.addInsertion(classesArg.argumentExpression.end, (edit) {
             edit.write("}'");
           });
         } else {

--- a/packages/jaspr_lints/lib/src/assists/css_assist.dart
+++ b/packages/jaspr_lints/lib/src/assists/css_assist.dart
@@ -41,18 +41,17 @@ class AddStyles extends ResolvedCorrectionProducer {
       return;
     }
 
-    final idArg = argumentList.arguments.whereType<NamedArgument>().where((e) => e.name.lexeme == 'id').firstOrNull;
-    final idArgExpression = idArg?.argumentExpression;
-    final idVal = idArgExpression is StringLiteral ? idArgExpression.stringValue : null;
+    final idArg = argumentList.namedArgument('id');
+    final idVal = switch (idArg?.argumentExpression) {
+      StringLiteral(:final stringValue) => stringValue,
+      _ => null,
+    };
 
-    final classesArg = argumentList.arguments
-        .whereType<NamedArgument>()
-        .where((e) => e.name.lexeme == 'classes')
-        .firstOrNull;
-    final classesArgExpression = classesArg?.argumentExpression;
-    final classesVal = classesArgExpression is StringLiteral
-        ? classesArgExpression.stringValue?.split(' ').first
-        : null;
+    final classesArg = argumentList.namedArgument('classes');
+    final classesVal = switch (classesArg?.argumentExpression) {
+      StringLiteral(:final stringValue) => stringValue?.split(' ').first,
+      _ => null,
+    };
 
     final styles = comp.$1.body.childEntities
         .whereType<ClassMember>()

--- a/packages/jaspr_lints/lib/src/assists/tree_assist.dart
+++ b/packages/jaspr_lints/lib/src/assists/tree_assist.dart
@@ -109,11 +109,11 @@ class RemoveComponent extends ResolvedCorrectionProducer {
 
       final children = <AstNode>[
         for (final arg in node.argumentList.arguments)
-          if (arg is NamedExpression)
-            if (arg.name.label.name == 'child' && isComponentType(arg.staticType))
-              arg.expression
-            else if (arg.name.label.name == 'children' && arg.expression is ListLiteral)
-              ...(arg.expression as ListLiteral).elements
+          if (arg is NamedArgument)
+            if (arg.name.lexeme == 'child' && isComponentType(arg.argumentExpression.staticType))
+              arg.argumentExpression
+            else if (arg.name.lexeme == 'children' && arg.argumentExpression is ListLiteral)
+              ...(arg.argumentExpression as ListLiteral).elements
             else
               ...[]
           else if (arg is ListLiteral)

--- a/packages/jaspr_lints/lib/src/assists/tree_assist.dart
+++ b/packages/jaspr_lints/lib/src/assists/tree_assist.dart
@@ -1,5 +1,6 @@
 import 'package:analysis_server_plugin/edit/dart/correction_producer.dart';
 import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer_plugin/protocol/protocol_common.dart' show LinkedEditSuggestionKind;
 
 import '../assist.dart';
@@ -109,15 +110,15 @@ class RemoveComponent extends ResolvedCorrectionProducer {
 
       final children = <AstNode>[
         for (final arg in node.argumentList.arguments)
-          if (arg is NamedArgument)
-            if (arg.name.lexeme == 'child' && isComponentType(arg.argumentExpression.staticType))
-              arg.argumentExpression
-            else if (arg.name.lexeme == 'children' && arg.argumentExpression is ListLiteral)
-              ...(arg.argumentExpression as ListLiteral).elements
-            else
-              ...[]
-          else if (arg is ListLiteral)
-            ...arg.elements,
+          ...switch (arg) {
+            NamedArgument(name: Token(lexeme: 'child'), :final argumentExpression)
+                when isComponentType(argumentExpression.staticType) =>
+              <AstNode>[argumentExpression],
+            NamedArgument(name: Token(lexeme: 'children'), argumentExpression: ListLiteral(:final elements)) =>
+              elements,
+            ListLiteral(:final elements) => elements,
+            _ => const <AstNode>[],
+          },
       ];
 
       if (children.isEmpty) {

--- a/packages/jaspr_lints/lib/src/rules/prefer_html_components_rule.dart
+++ b/packages/jaspr_lints/lib/src/rules/prefer_html_components_rule.dart
@@ -4,7 +4,6 @@ import 'package:analyzer/analysis_rule/rule_context.dart';
 import 'package:analyzer/analysis_rule/rule_visitor_registry.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
-import 'package:analyzer/source/source_range.dart';
 
 import '../all_html_tags.dart';
 import '../utils.dart';
@@ -52,13 +51,7 @@ class _HtmlComponentVisitor extends SimpleAstVisitor<void> {
       return;
     }
     if (node.constructorName.name?.name == 'element') {
-      final tag = node.argumentList.arguments
-          .whereType<NamedArgument>()
-          .where((n) => n.name.lexeme == 'tag')
-          .map((n) => n.argumentExpression)
-          .whereType<SimpleStringLiteral>()
-          .firstOrNull
-          ?.value;
+      final tag = _tagArgumentValue(node.argumentList);
       if (tag == null || !allHtmlTags.contains(tag)) {
         return;
       }
@@ -90,13 +83,7 @@ class ConvertHtmlComponentFix extends ResolvedCorrectionProducer {
   @override
   Future<void> compute(ChangeBuilder builder) async {
     if (node case ConstructorName(parent: final InstanceCreationExpression node)) {
-      final tag = node.argumentList.arguments
-          .whereType<NamedArgument>()
-          .where((n) => n.name.lexeme == 'tag')
-          .map((n) => n.argumentExpression)
-          .whereType<SimpleStringLiteral>()
-          .firstOrNull
-          ?.value;
+      final tag = _tagArgumentValue(node.argumentList);
       if (tag == null) {
         return;
       }
@@ -113,16 +100,24 @@ class ConvertHtmlComponentFix extends ResolvedCorrectionProducer {
               } else {
                 end = argument.endToken.next?.offset ?? argument.end;
               }
-              builder.addDeletion(SourceRange(argument.offset, end - argument.offset));
+              builder.addDeletion(range.startOffsetEndOffset(argument.offset, end));
             } else if (name == 'children') {
-              final end = argument.argumentExpression.offset;
-              builder.addDeletion(SourceRange(argument.name.offset, end - argument.name.offset));
+              builder.addDeletion(range.startStart(argument.name, argument.argumentExpression));
             }
           }
         }
 
-        builder.addSimpleReplacement(SourceRange(node.constructorName.offset, node.constructorName.length), tag);
+        builder.addSimpleReplacement(range.node(node.constructorName), tag);
       });
     }
   }
+}
+
+/// Returns the value of the named 'tag' argument when it is a string literal.
+String? _tagArgumentValue(ArgumentList argumentList) {
+  if (argumentList.namedArgument('tag')?.argumentExpression case SimpleStringLiteral(:final value)) {
+    return value;
+  }
+
+  return null;
 }

--- a/packages/jaspr_lints/lib/src/rules/prefer_html_components_rule.dart
+++ b/packages/jaspr_lints/lib/src/rules/prefer_html_components_rule.dart
@@ -53,9 +53,9 @@ class _HtmlComponentVisitor extends SimpleAstVisitor<void> {
     }
     if (node.constructorName.name?.name == 'element') {
       final tag = node.argumentList.arguments
-          .whereType<NamedExpression>()
-          .where((n) => n.name.label.name == 'tag')
-          .map((n) => n.expression)
+          .whereType<NamedArgument>()
+          .where((n) => n.name.lexeme == 'tag')
+          .map((n) => n.argumentExpression)
           .whereType<SimpleStringLiteral>()
           .firstOrNull
           ?.value;
@@ -91,9 +91,9 @@ class ConvertHtmlComponentFix extends ResolvedCorrectionProducer {
   Future<void> compute(ChangeBuilder builder) async {
     if (node case ConstructorName(parent: final InstanceCreationExpression node)) {
       final tag = node.argumentList.arguments
-          .whereType<NamedExpression>()
-          .where((n) => n.name.label.name == 'tag')
-          .map((n) => n.expression)
+          .whereType<NamedArgument>()
+          .where((n) => n.name.lexeme == 'tag')
+          .map((n) => n.argumentExpression)
           .whereType<SimpleStringLiteral>()
           .firstOrNull
           ?.value;
@@ -104,8 +104,8 @@ class ConvertHtmlComponentFix extends ResolvedCorrectionProducer {
 
       await builder.addDartFileEdit(file, (builder) {
         for (final argument in node.argumentList.arguments) {
-          if (argument is NamedExpression) {
-            final name = argument.name.label.name;
+          if (argument is NamedArgument) {
+            final name = argument.name.lexeme;
             if (name == 'tag') {
               int end;
               if (argument.endToken.next case final next? when next.lexeme == ',') {
@@ -115,7 +115,7 @@ class ConvertHtmlComponentFix extends ResolvedCorrectionProducer {
               }
               builder.addDeletion(SourceRange(argument.offset, end - argument.offset));
             } else if (name == 'children') {
-              final end = argument.name.endToken.next?.offset ?? argument.end;
+              final end = argument.argumentExpression.offset;
               builder.addDeletion(SourceRange(argument.name.offset, end - argument.name.offset));
             }
           }

--- a/packages/jaspr_lints/lib/src/rules/sort_children_last_rule.dart
+++ b/packages/jaspr_lints/lib/src/rules/sort_children_last_rule.dart
@@ -46,7 +46,7 @@ class _HtmlComponentVisitor extends SimpleAstVisitor<void> {
     for (final argument in node.argumentList.arguments) {
       if (argument is ListLiteral && isComponentListType(argument.staticType)) {
         childrenArg = argument;
-      } else if (childrenArg != null && argument is NamedExpression) {
+      } else if (childrenArg != null && argument is NamedArgument) {
         violatesLint = true;
       }
     }

--- a/packages/jaspr_lints/lib/src/rules/styles_ordering_rule.dart
+++ b/packages/jaspr_lints/lib/src/rules/styles_ordering_rule.dart
@@ -82,14 +82,14 @@ class _StylesVisitor extends SimpleAstVisitor<void> {
     }
   }
 
-  static Expression? checkOrder(NodeList<Expression> args, List<String?> params) {
+  static Argument? checkOrder(NodeList<Argument> args, List<String?> params) {
     int lastSeenParam = -1;
 
     for (final argument in args) {
-      if (argument is! NamedExpression) {
+      if (argument is! NamedArgument) {
         continue;
       }
-      final paramIndex = params.indexOf(argument.name.label.name);
+      final paramIndex = params.indexOf(argument.name.lexeme);
       if (paramIndex == -1) {
         continue;
       }
@@ -119,7 +119,7 @@ class OrderStylesFix extends ResolvedCorrectionProducer {
 
   @override
   Future<void> compute(ChangeBuilder builder) async {
-    if (node case NamedExpression(parent: final ArgumentList arguments)) {
+    if (node case NamedArgument(parent: final ArgumentList arguments)) {
       if (arguments.parent case final InstanceCreationExpression node) {
         final constructor = node.constructorName.element;
         if (constructor == null) {
@@ -148,7 +148,7 @@ class OrderStylesFix extends ResolvedCorrectionProducer {
     }
   }
 
-  Future<void> _sortStyles(ChangeBuilder builder, NodeList<Expression> arguments, List<String?> params) async {
+  Future<void> _sortStyles(ChangeBuilder builder, NodeList<Argument> arguments, List<String?> params) async {
     await builder.addDartFileEdit(file, (builder) {
       final start = arguments.beginToken!.offset;
       final end = arguments.endToken!.end;
@@ -161,8 +161,8 @@ class OrderStylesFix extends ResolvedCorrectionProducer {
 
       final args = [...arguments]
         ..sort((a, b) {
-          if (a is NamedExpression && b is NamedExpression) {
-            return params.indexOf(a.name.label.name).compareTo(params.indexOf(b.name.label.name));
+          if (a is NamedArgument && b is NamedArgument) {
+            return params.indexOf(a.name.lexeme).compareTo(params.indexOf(b.name.lexeme));
           }
           return 0;
         });

--- a/packages/jaspr_lints/lib/src/rules/styles_ordering_rule.dart
+++ b/packages/jaspr_lints/lib/src/rules/styles_ordering_rule.dart
@@ -82,7 +82,7 @@ class _StylesVisitor extends SimpleAstVisitor<void> {
     }
   }
 
-  static Argument? checkOrder(NodeList<Argument> args, List<String?> params) {
+  static NamedArgument? checkOrder(NodeList<Argument> args, List<String?> params) {
     int lastSeenParam = -1;
 
     for (final argument in args) {

--- a/packages/jaspr_lints/lib/src/rules/unsafe_imports_rule.dart
+++ b/packages/jaspr_lints/lib/src/rules/unsafe_imports_rule.dart
@@ -69,7 +69,7 @@ class UnsafeImportsRule extends AnalysisRule {
     final packageRoot = context.package?.root;
     if (packageRoot == null) return;
 
-    final pubspecFile = packageRoot.getChildAssumingFile('pubspec.yaml');
+    final pubspecFile = packageRoot.getFile('pubspec.yaml');
     final digest = pubspecFile.lengthSync ^ pubspecFile.modificationStamp;
     if (digest == pubspecDigest) return;
     pubspecDigest = digest;

--- a/packages/jaspr_lints/lib/src/utils.dart
+++ b/packages/jaspr_lints/lib/src/utils.dart
@@ -100,6 +100,18 @@ extension Indent on String {
   }
 }
 
+extension ArgumentListNamedArgument on ArgumentList {
+  /// The named argument called [name], or `null` if there is none.
+  NamedArgument? namedArgument(String name) {
+    for (final argument in arguments) {
+      if (argument is NamedArgument && argument.name.lexeme == name) {
+        return argument;
+      }
+    }
+    return null;
+  }
+}
+
 extension AstSourceRange on AstNode {
   SourceRange get sourceRange => SourceRange(offset, length);
 }

--- a/packages/jaspr_lints/pubspec.yaml
+++ b/packages/jaspr_lints/pubspec.yaml
@@ -19,7 +19,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  analysis_server_plugin: ^0.3.0
+  analysis_server_plugin: ^0.3.17
   analyzer: '>=13.3.0 <15.0.0'
   analyzer_plugin: any
   dart_data_home: ^0.1.0

--- a/packages/jaspr_lints/pubspec.yaml
+++ b/packages/jaspr_lints/pubspec.yaml
@@ -20,13 +20,13 @@ resolution: workspace
 
 dependencies:
   analysis_server_plugin: ^0.3.0
-  analyzer: ^12.1.0
+  analyzer: '>=13.3.0 <15.0.0'
   analyzer_plugin: any
   dart_data_home: ^0.1.0
   path: ^1.9.0
   yaml: ^3.1.2
 
 dev_dependencies:
-  analyzer_testing: ^0.2.5
+  analyzer_testing: ^0.3.2
   test: ^1.29.0
   test_reflective_loader: ^0.4.0

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: a49d6cf99e8d8e7a8e93668d09ced0bbdb954d0b4fccc2f5f9241c6b87fad95c
+      sha256: "1b0e6a07425a3e460666e88bf1c949ccc7bb0116ad562ce94a1eca60fe820725"
       url: "https://pub.dev"
     source: hosted
-    version: "99.0.0"
+    version: "103.0.0"
   _flutterfire_internals:
     dependency: transitive
     description:
@@ -37,34 +37,34 @@ packages:
     dependency: transitive
     description:
       name: analysis_server_plugin
-      sha256: "3960b28ee740004df39f85d5ebfc91785f7a90e51fd7c9a185e86a36b2f581b4"
+      sha256: c58b2a05b260a023eefd0848496ff6b113a318c6c95dad4215165a4bd54ae600
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.14"
+    version: "0.3.18"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "663efa951fb8a45e06f491223a604c93820598f20e6a99c25617a1576065e8b7"
+      sha256: "61c04d0c1bfed555c681ea079519933f071a5a026578ff73c4ff0df2d3462e5e"
       url: "https://pub.dev"
     source: hosted
-    version: "12.1.0"
+    version: "13.3.0"
   analyzer_plugin:
     dependency: transitive
     description:
       name: analyzer_plugin
-      sha256: "0057a98d64d7bb872b0c87dff6e73d2c2d80c77156e7a03f127a26f8aa240649"
+      sha256: c2a75baf1657171cc7872db96a12b07e385873cf7a73f2b4f7638e9d0701ee53
       url: "https://pub.dev"
     source: hosted
-    version: "0.14.8"
+    version: "0.14.12"
   analyzer_testing:
     dependency: transitive
     description:
       name: analyzer_testing
-      sha256: df9a63ae68657f2b04b26f9811124d19b06b129961d9573574dbb7971bc4ac22
+      sha256: "33ec8a3138134e9048969a70a670ac04a37e28337982c3ed6d04a3d28ac87665"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.5"
+    version: "0.3.2"
   ansi_styles:
     dependency: transitive
     description:
@@ -149,10 +149,10 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: "45d14a0fb23e018d8287c32fc98d726ce466b231928ed9b9200f29bd3ccd39ae"
+      sha256: b94f5da9ed3d081fd4ecc426c260998b5f4f4eb2f6d89b7e5472edef0b2b2a1b
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.7"
+    version: "4.0.10"
   build_config:
     dependency: transitive
     description:
@@ -173,26 +173,26 @@ packages:
     dependency: transitive
     description:
       name: build_runner
-      sha256: "5367e521935b102bdf1e735d2aab461e36b2edca6517662d088dd04cc39f8d16"
+      sha256: "90363d438bd9f84a4d5bbb83352251f57d2d9d771bc95a44e6a33fe25fa52774"
       url: "https://pub.dev"
     source: hosted
-    version: "2.15.1"
+    version: "2.16.0"
   build_test:
     dependency: transitive
     description:
       name: build_test
-      sha256: "8f503824b72d049b21daaebe27de9b51aaf1937b74ab369a11290e53eff20538"
+      sha256: ec07292e84b54cbbf06b9c7f09c156338f651e2146ccd57d6c98cb93ee28128d
       url: "https://pub.dev"
     source: hosted
-    version: "3.5.16"
+    version: "3.5.19"
   build_web_compilers:
     dependency: transitive
     description:
       name: build_web_compilers
-      sha256: ef4bc35e0e335f8520692a333b872446697adce0618cf23c3084715ace641721
+      sha256: "4db806793ebe5ce9679fb6c7bb102790a2b2e76d1ba1c5fff98d098442d85c7e"
       url: "https://pub.dev"
     source: hosted
-    version: "4.8.5"
+    version: "4.8.9"
   built_collection:
     dependency: transitive
     description:
@@ -477,10 +477,10 @@ packages:
     dependency: transitive
     description:
       name: dart_mappable_builder
-      sha256: eb89efebad96bae52333ae4bd6b8fdcfb44c921f8a38f44893f2c72ed15c860c
+      sha256: "0119cde33841f4fa57574381bb1324bed017ff7592594afa220a59b6c04f3ea5"
       url: "https://pub.dev"
     source: hosted
-    version: "4.8.0"
+    version: "4.9.0"
   dart_quotes_client:
     dependency: transitive
     description:
@@ -500,10 +500,10 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: a4c1ccfee44c7e75ed80484071a5c142a385345e658fd8bd7c4b5c97e7198f98
+      sha256: "3f88fc9c96c568d631356507355a2d1e983ee000c9ac008bdcb39b5bf53ce777"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.8"
+    version: "3.1.12"
   dds:
     dependency: transitive
     description:
@@ -1468,10 +1468,10 @@ packages:
     dependency: transitive
     description:
       name: record_use
-      sha256: af37186ff9ede46fa32f152526c48f46c5b3ad7d3d5a566140cb5df3dc4ed737
+      sha256: "3b4ab682aff40175afca6ff090cc5aa7ce9dafe8dfbae1537a6c678e6678baee"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0"
   redis:
     dependency: transitive
     description:


### PR DESCRIPTION
This bump is necessary to pull in the latest versions of `package:build_web_compilers` with relevant fixes. We can require v13 and allow v14 as v14 only removes previously deprecated members we don't rely on after this migration.

Supersedes and closes https://github.com/schultek/jaspr/pull/823