### PR TITLE
Work around a VM fault when hashing closures in TaskChain

### DIFF
--- a/packages/jaspr/CHANGELOG.md
+++ b/packages/jaspr/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased patch
+
+- Worked around a Dart VM fault that crashed static rendering on `linux_x64` with
+  `NoSuchMethodError: The method '&' was called on null`, raised from `_LinkedHashSetMixin.add` while `TaskChain`
+  registered a continuation. `TaskChain` no longer hashes those callbacks.
+
 ## 0.23.3
 
 - Added `detachRootComponent()` to `ComponentsBinding` to cleanly unmount the root component.

--- a/packages/jaspr/lib/src/server/async_build_owner.dart
+++ b/packages/jaspr/lib/src/server/async_build_owner.dart
@@ -41,7 +41,9 @@ class TaskChain {
   TaskChain.start() : _done = true;
 
   bool _done;
-  final Set<void Function()> _listeners = {};
+
+  /// Callbacks waiting on this chain, run in insertion order once it completes.
+  final List<void Function()> _listeners = [];
 
   void _complete() {
     _done = true;


### PR DESCRIPTION
## Description

`TaskChain._listeners` is a `Set<void Function()>`. On `linux_x64`, adding to it during static rendering can fail with an impossible error:

```plaintext
[SERVER] [ERROR] Asynchronous error
[SERVER] [ERROR] NoSuchMethodError: The method '&' was called on null.
[SERVER] [ERROR] Receiver: null
[SERVER] [ERROR] Tried calling: &(0)
#0  Object.noSuchMethod (dart:core-patch/object_patch.dart:38:5)
#1  _HashBase._hashPattern (dart:_compact_hash:224:37)
#2  _LinkedHashSetMixin._add (dart:_compact_hash:1043:39)
#3  _LinkedHashSetMixin.add (dart:_compact_hash:1036:12)
#4  TaskChain._then (package:jaspr/src/server/async_build_owner.dart:57:18)
#5  TaskChain.then (package:jaspr/src/server/async_build_owner.dart:63:5)
#6  AsyncBuildOwner.performRebuildOn (package:jaspr/src/server/async_build_owner.dart:30:10)
...
#57 StatefulElement.performRebuild.<anonymous closure> (.../stateful_component.dart:679:19)
<asynchronous suspension>
#60 TaskChain.then.<anonymous closure>.<anonymous closure> (.../async_build_owner.dart:66:16)
<asynchronous suspension>
```

**This is not a bug in Jaspr — it is a Dart VM soundness violation.** From the SDK source:

```dart
static int _hashPattern(int fullHash, int hashMask, int size) {
  final int maskedHash = fullHash & hashMask;      // <- the '&' that threw
  ...
}

bool add(E key) {
  final int fullHash = _hashCode(key);             // <- became null
  return _add(key, fullHash);
}

int _hashCode(Object? e) => e.hashCode;
```

`Tried calling: &(0)` means the receiver `fullHash` was null. It is a non-nullable `int` local, initialized from a method declared to return `int`, so no legal Dart program can make it null. In effect **`closure.hashCode` returned null**. (The `0` argument is `_hashMask`, which is simply `_UNINITIALIZED_HASH_MASK` — the normal state of a freshly created set, and consistent with this being the first insertion into one.)

Notably this is the **JIT** VM, not AOT: for `mode: static`, `jaspr_cli` runs the server entrypoint via `dart --enable-asserts -Djaspr.flags.release=true … lib/main.server.dart` and only uses `dart compile` for the non-static server mode. ("Running server in release mode" in the log is Jaspr's own flag.)

I am filing this against `dart-lang/sdk` separately and will link it here. There was no existing issue as of 2026-08-12.

### Why this PR anyway

The workaround is free, so it seems worth not waiting on a VM fix. `_listeners` is only ever appended to and iterated in insertion order, and every callback reaching `_then` is a freshly allocated closure created inside `then()`/`asFuture()` — so the set's deduplication can never fire, and a `List` is behaviourally equivalent while avoiding hashing closures at all.

Entirely your call whether you want a VM workaround carried in Jaspr; feel free to close this if you would rather wait for the SDK fix.

### Reproduction

The fault is sensitive to the size of the rendered payload, which makes it look flaky. In our repo one commit built clean **7 consecutive times** on `ubuntu-latest`; a content edit adding **22 bytes** to one page's `@client` props then made it fail **3 out of 3**, including all 3 attempts of a retry loop. It never reproduced on macOS arm64. I do not have a minimal reproduction — only a full release-mode static build of a real site.

With this patch applied via `dependency_overrides`, the commit that failed 3/3 renders all 14 routes on the first attempt on `ubuntu-latest`.

Environment: `jaspr` 0.23.3, `jaspr_cli` 0.23.1, Dart 3.12.2 stable, `ubuntu-latest`, `mode: static`.

### Related

**#868** fixes a separate, genuinely-Jaspr bug that this fault exposed: because the error surfaced from inside the chain machinery, the route request was never answered and `jaspr build` hung indefinitely rather than failing. That one is reproducible without any VM weirdness and has a regression test. The two PRs touch the same file and will conflict textually — happy to rebase whichever lands second.

## Type of Change

- 🛠️ Bug fix

## Ready Checklist

- [x] I've read the [Contribution Guide](https://github.com/schultek/jaspr/blob/main/CONTRIBUTING.md).
- [x] In case this PR changes one of the core packages, I've modified the respective **CHANGELOG.md** file using the [semantic_changelog](https://github.com/rrousselGit/semantic_changelog) format.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added myself to the AUTHORS file (optional, if you want to).