### PR TITLE
Fail the render instead of hanging when an initial build step throws

### DIFF
--- a/packages/jaspr/CHANGELOG.md
+++ b/packages/jaspr/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased patch
+
+- Fixed static rendering hanging instead of failing when a step of the initial build throws outside of a component's
+  `build` method. Such an error left the task chain the render was waiting on uncompleted, so the HTTP response was
+  never produced and `jaspr build` waited indefinitely. The failure is now reported through
+  `AppBinding.reportBuildError` and the render completes.
+
 ## 0.23.3
 
 - Added `detachRootComponent()` to `ComponentsBinding` to cleanly unmount the root component.

--- a/packages/jaspr/lib/src/server/async_build_owner.dart
+++ b/packages/jaspr/lib/src/server/async_build_owner.dart
@@ -13,7 +13,17 @@ extension AsyncElement on Element {
 class AsyncBuildOwner extends BuildOwner {
   @override
   void completeInitialBuild(Element element, void Function() buildCallback) async {
-    await element._asyncBuildLock?.asFuture;
+    final lock = element._asyncBuildLock;
+    await lock?.asFuture;
+
+    // A step that threw is reported here rather than left to unwind, and the
+    // build is completed either way. Skipping [buildCallback] would leave the
+    // frame -- and on the server the HTTP response waiting on it -- pending
+    // forever.
+    if (lock?._failure case final failure?) {
+      element.binding.reportBuildError(element, failure.error, failure.stackTrace);
+    }
+
     super.completeInitialBuild(element, buildCallback);
   }
 
@@ -43,11 +53,17 @@ class TaskChain {
   bool _done;
   final Set<void Function()> _listeners = {};
 
-  void _complete() {
+  /// The failure this chain completed with, if any.
+  ({Object error, StackTrace stackTrace})? _failure;
+
+  void _complete([({Object error, StackTrace stackTrace})? failure]) {
+    if (_done) return;
     _done = true;
+    _failure = failure;
     for (final l in _listeners) {
       l();
     }
+    _listeners.clear();
   }
 
   void _then(void Function() fn) {
@@ -61,15 +77,29 @@ class TaskChain {
   TaskChain then(Object? Function() fn) {
     final c = TaskChain._();
     _then(() {
-      final r = fn();
+      // Skip this step if an earlier one failed, and carry the failure down the
+      // chain, so that whoever awaits the end of it is told instead of waiting
+      // on a chain that can never complete.
+      if (_failure case final failure?) {
+        c._complete(failure);
+        return;
+      }
+
+      final Object? r;
+      try {
+        r = fn();
+      } catch (e, st) {
+        c._complete((error: e, stackTrace: st));
+        return;
+      }
+
       if (r is Future) {
-        r.then((_) {
-          c._complete();
-        });
-      } else if (r is TaskChain) {
-        r._then(() {
-          c._complete();
-        });
+        r.then(
+          (_) => c._complete(),
+          onError: (Object e, StackTrace st) => c._complete((error: e, stackTrace: st)),
+        );
+      } else if (r case final TaskChain chain) {
+        chain._then(() => c._complete(chain._failure));
       } else {
         c._complete();
       }

--- a/packages/jaspr/test/server/build_error_test.dart
+++ b/packages/jaspr/test/server/build_error_test.dart
@@ -1,0 +1,84 @@
+@TestOn('vm')
+library;
+
+import 'package:jaspr/dom.dart';
+import 'package:jaspr/server.dart';
+import 'package:jaspr_test/server_test.dart';
+
+import 'render_test.dart';
+
+void main() {
+  group('build error', () {
+    setUpAll(() {
+      Jaspr.initializeApp();
+    });
+
+    test('completes the render when a build step throws outside build()', () async {
+      final result = await renderComponent(const ThrowsInDidRebuild()).timeout(
+        const Duration(seconds: 30),
+        onTimeout: () => fail('render never completed'),
+      );
+
+      expect(result.statusCode, 500);
+    });
+
+    test('completes the render when the throwing element has an async ancestor', () async {
+      final result = await renderComponent(const Preloading(child: ThrowsInDidRebuild())).timeout(
+        const Duration(seconds: 30),
+        onTimeout: () => fail('render never completed'),
+      );
+
+      expect(result.statusCode, 500);
+    });
+
+    test('renders normally when nothing throws', () async {
+      final result = await renderComponent(const Preloading(child: Component.text('ok')), standalone: true);
+
+      expect(result.statusCode, 200);
+      expect(result.body, decodedMatches(contains('ok')));
+    });
+  });
+}
+
+/// Throws from [Element.didRebuild], which [AsyncBuildOwner] invokes from inside
+/// a [TaskChain] step rather than from the guarded [BuildableElement.performRebuild]
+/// path, so the throw is not caught by the usual build error handling.
+class ThrowsInDidRebuild extends StatelessComponent {
+  const ThrowsInDidRebuild({super.key});
+
+  @override
+  Element createElement() => _ThrowsInDidRebuildElement(this);
+
+  @override
+  Component build(BuildContext context) => div([]);
+}
+
+class _ThrowsInDidRebuildElement extends StatelessElement {
+  _ThrowsInDidRebuildElement(super.component);
+
+  @override
+  void didRebuild() {
+    throw StateError('build step failed');
+  }
+}
+
+/// Suspends the build with [PreloadStateMixin], so its subtree is built from an
+/// asynchronous continuation.
+class Preloading extends StatefulComponent {
+  const Preloading({super.key, required this.child});
+
+  final Component child;
+
+  @override
+  State<Preloading> createState() => _PreloadingState();
+}
+
+class _PreloadingState extends State<Preloading> with PreloadStateMixin {
+  @override
+  Future<void> preloadState() async {
+    await Future<void>.delayed(Duration.zero);
+  }
+
+  @override
+  Component build(BuildContext context) => div([span([]), component.child, span([])]);
+}

--- a/packages/jaspr/test/server/build_error_test.dart
+++ b/packages/jaspr/test/server/build_error_test.dart
@@ -1,3 +1,4 @@
+/// @docImport 'package:jaspr/src/server/async_build_owner.dart';
 @TestOn('vm')
 library;
 


### PR DESCRIPTION
## Description

If a step of the initial build throws from anywhere other than a component's `build` method, static rendering **hangs forever** instead of failing.

`AsyncBuildOwner.performRebuildOn` runs each step inside a `TaskChain`:

```dart
final chain = TaskChain.start()
    .then(() => child.performRebuild())
    .then(() => child._asyncBuildLock)
    .then(() => parentAsyncBuildLock)
    .then(() => child.didRebuild());
```

Nothing catches a throw from those callbacks. When one escapes, `c._complete()` is never reached, so that chain stays uncompleted forever. `completeInitialBuild` is awaiting `asFuture` on it, so it never calls `buildCallback`, the post-frame callback never fires, `ServerAppBinding.render` never returns, and no HTTP response is ever produced.

Since `jaspr build` has no timeout of its own, the consequence is not a failed build but a stuck one. In our case a release job sat on the build step for 30+ minutes before we cancelled it, and it would otherwise have run to the CI provider's 6-hour job limit:

```plaintext
✓ Completed building web assets. (62.4s)
Preparing static rendering...
✓ Server started (7.0s)
Generating routes...
(1/1) Generating route "/" ...
(2/14) Generating route "/schedule" ...      <- never returns
```

Errors thrown *inside* `build` are already handled — the `onError` handlers in `StatelessElement`/`StatefulElement.performRebuild` call `failRebuild`, which reports the error and yields a 500. I verified that path still behaves correctly. This PR closes the gap for everything else.

### Change

`TaskChain` records a failure, skips its remaining steps, and carries the failure to the end of the chain. `completeInitialBuild` then reports it through `AppBinding.reportBuildError` and completes the build regardless. The result is a reported error and a 500 response rather than a hang.

`asFuture` deliberately still completes normally in both cases. Completing it with an error would convert an uncaught build failure into an unhandled asynchronous error, which is precisely how this failure mode stayed invisible.

I also added a `if (_done) return;` guard to `_complete`, so a chain cannot be completed twice and have its listeners run twice.

### Tests

`packages/jaspr/test/server/build_error_test.dart` covers three cases, using an element that throws from `didRebuild` to fail a step outside the guarded `build` path:

| Case | Before | After |
|---|---|---|
| build step throws | **hangs** (test times out) | 500 |
| build step throws under a `PreloadStateMixin` ancestor | 500 | 500 |
| nothing throws | 200 | 200 |

Confirmed the first test times out with `render never completed` when the fix is reverted, and passes with it. Full suite: **212 passing** (209 pre-existing + 3 new), on VM and Chrome.

### Relationship to #867

#867 touches the same file and is independent — it swaps `TaskChain._listeners` from a `Set` to a `List` to work around a Dart VM soundness fault (a non-nullable `int` observed as null inside `_LinkedHashSetMixin.add`). They will conflict textually; happy to rebase whichever lands second.

The two are worth having separately: that VM fault is what threw inside the chain machinery for us, and *this* bug is why it cost us a stuck 6-hour job instead of a red build.

## Type of Change

- 🛠️ Bug fix

## Ready Checklist

- [x] I've read the [Contribution Guide](https://github.com/schultek/jaspr/blob/main/CONTRIBUTING.md).
- [x] In case this PR changes one of the core packages, I've modified the respective **CHANGELOG.md** file using the [semantic_changelog](https://github.com/rrousselGit/semantic_changelog) format.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added myself to the AUTHORS file (optional, if you want to).