### PR TITLE
[next] Remove unnecessary version checks

### DIFF
--- a/packages/jaspr_cli/lib/src/commands/build_command.dart
+++ b/packages/jaspr_cli/lib/src/commands/build_command.dart
@@ -487,11 +487,7 @@ class BuildCommand extends BaseCommand with ProxyHelper, FlutterHelper {
 
     List<String> additionalFlutterBuildArgs() {
       final librariesPath = p.join(webSdkDir, 'libraries.json');
-      final sdkJsPath = p.join(
-        webSdkDir,
-        'kernel',
-        flutterVersion.compareTo('3.32.0') >= 0 ? 'amd-canvaskit' : 'amd-canvaskit-sound',
-      );
+      final sdkJsPath = p.join(webSdkDir, 'kernel', 'amd-canvaskit');
       return [
         '--define=build_web_compilers:entrypoint=use-ui-libraries=true',
         '--define=build_web_compilers:entrypoint_marker=use-ui-libraries=true',

--- a/packages/jaspr_cli/lib/src/commands/dev_command.dart
+++ b/packages/jaspr_cli/lib/src/commands/dev_command.dart
@@ -381,16 +381,9 @@ abstract class DevCommand extends BaseCommand with ProxyHelper, FlutterHelper {
     ];
 
     List<String> additionalFlutterBuildArgs() {
-      final sdkKernelPath = p.url.join(
-        'kernel',
-        flutterVersion.compareTo('3.32.0') >= 0 ? 'ddc_outline.dill' : 'ddc_outline_sound.dill',
-      );
+      final sdkKernelPath = p.url.join('kernel', 'ddc_outline.dill');
       final librariesPath = p.join(webSdkDir, 'libraries.json');
-      final sdkJsPath = p.join(
-        webSdkDir,
-        'kernel',
-        flutterVersion.compareTo('3.32.0') >= 0 ? 'amd-canvaskit' : 'amd-canvaskit-sound',
-      );
+      final sdkJsPath = p.join(webSdkDir, 'kernel', 'amd-canvaskit');
       return [
         '--define=build_web_compilers:entrypoint=use-ui-libraries=true',
         '--define=build_web_compilers:entrypoint_marker=use-ui-libraries=true',

--- a/packages/jaspr_cli/lib/src/helpers/css_helper.dart
+++ b/packages/jaspr_cli/lib/src/helpers/css_helper.dart
@@ -8,8 +8,7 @@ import 'package:frontend_server_client/frontend_server_client.dart';
 import 'package:glob/glob.dart';
 import 'package:glob/list_local_fs.dart';
 import 'package:path/path.dart' as p;
-import 'package:pub_semver/pub_semver.dart';
-import 'package:vm_service/vm_service.dart' hide Version;
+import 'package:vm_service/vm_service.dart';
 import 'package:vm_service/vm_service_io.dart';
 
 import '../commands/base_command.dart';
@@ -111,24 +110,20 @@ class CssRunner {
     if (!defaultLibrariesJson.existsSync()) return;
 
     final librariesJsonStr = defaultLibrariesJson.readAsStringSync();
-    final libraries = jsonDecode(librariesJsonStr) as Map<String, dynamic>;
+    final libraries = jsonDecode(librariesJsonStr) as Map<String, Object?>;
 
-    if (libraries['vm_common'] case {'libraries': final Map<String, dynamic> libs}) {
-      final versionFile = File(p.join(dartSdkDir, 'version'));
-      final dartVersion = Version.parse(versionFile.readAsStringSync().trim().split(' ').first);
-      final isDart311OrHigher = dartVersion >= Version(3, 11, 0);
-      final supportedFlag = isDart311OrHigher ? 'support_conditional_import' : 'supported';
-
+    if (libraries['vm_common'] case {'libraries': final Map<String, Object?> libs}) {
+      const supportConditionalImportKey = 'support_conditional_import';
       if (project.modeOrNull == JasprMode.client) {
         libs['js_interop'] = {'uri': mockJSInteropUri};
         libs['js_interop_unsafe'] = {'uri': mockJSInteropUnsafeUri};
 
-        if (libs['io'] case final Map<String, dynamic> io) io[supportedFlag] = false;
-        if (libs['ffi'] case final Map<String, dynamic> ffi) ffi[supportedFlag] = false;
-        if (libs['isolate'] case final Map<String, dynamic> isolate) isolate[supportedFlag] = false;
+        if (libs['io'] case final Map<String, Object?> io) io[supportConditionalImportKey] = false;
+        if (libs['ffi'] case final Map<String, Object?> ffi) ffi[supportConditionalImportKey] = false;
+        if (libs['isolate'] case final Map<String, Object?> isolate) isolate[supportConditionalImportKey] = false;
       } else {
-        libs['js_interop'] = {'uri': mockJSInteropUri, supportedFlag: false};
-        libs['js_interop_unsafe'] = {'uri': mockJSInteropUnsafeUri, supportedFlag: false};
+        libs['js_interop'] = {'uri': mockJSInteropUri, supportConditionalImportKey: false};
+        libs['js_interop_unsafe'] = {'uri': mockJSInteropUnsafeUri, supportConditionalImportKey: false};
       }
     }
 

--- a/packages/jaspr_cli/lib/src/helpers/flutter_helpers.dart
+++ b/packages/jaspr_cli/lib/src/helpers/flutter_helpers.dart
@@ -121,5 +121,3 @@ final webSdkDir = (() {
   }
   return webSdkPath;
 })();
-
-final flutterVersion = flutterInfo['flutterVersion'] as String;

--- a/packages/jaspr_cli/test/src/fakes/fake_project.dart
+++ b/packages/jaspr_cli/test/src/fakes/fake_project.dart
@@ -42,7 +42,7 @@ extension FakeProject on FakeIO {
   void stubFlutterSDK() {
     when(
       () => process.runSync('flutter', ['doctor', '--version', '--machine'], runInShell: true, stdoutEncoding: utf8),
-    ).thenAnswer((_) => ProcessResult(0, 0, '{"flutterRoot":"/fake/flutter","flutterVersion":"3.35.0"}', null));
+    ).thenAnswer((_) => ProcessResult(0, 0, '{"flutterRoot":"/fake/flutter"}', null));
     when(
       () => process.runSync('flutter', ['precache', '--web'], runInShell: true),
     ).thenAnswer((_) => ProcessResult(0, 0, null, null));


### PR DESCRIPTION
Remove unnecessary version checks now that Dart 3.13 or later is required.