### PR TITLE
[cli] Use cli_util to locate Dart executable

### DIFF
--- a/packages/jaspr_cli/lib/src/project.dart
+++ b/packages/jaspr_cli/lib/src/project.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:cli_util/cli_util.dart' as cli_util;
 import 'package:file/file.dart' hide FileSystemEntity;
 import 'package:file/local.dart';
 import 'package:path/path.dart' as path;
@@ -298,49 +299,13 @@ const defaultServePort = '8080';
 const serverProxyPort = '5567';
 const flutterProxyPort = '5678';
 
-// The path to the Dart executable in either the Dart or Flutter SDK.
-final dartExecutable = () {
-  String? executable;
-  if (Platform.isWindows) {
-    // Use 'where.exe' to support powershell as well
-    final result = (ProcessRunner.instance.runSync('where.exe', ['dart.bat', 'dart.exe'])).stdout.toString();
-    executable = result.split(RegExp('(\r\n|\r|\n)')).where((s) => !s.contains('Could not find')).firstOrNull?.trim();
-  } else {
-    executable = (ProcessRunner.instance.runSync('which', ['dart'])).stdout.toString().trim();
-  }
-
-  if (executable == null || executable.isEmpty) {
-    throw Exception('Could not find Dart executable. Make sure Dart is installed and added to your PATH.');
-  }
-
-  executable = path.canonicalize(executable);
-
-  bool isSdkExecutable(String executable) {
-    final maybeSdkDir = path.dirname(path.dirname(executable));
-    return FileSystemEntity.isFileSync(path.join(maybeSdkDir, 'version')) &&
-        path.basename(path.dirname(executable)) == 'bin';
-  }
-
-  if (isSdkExecutable(executable)) {
-    return executable;
-  }
-
-  final maybeFlutterDartExecutable = path.join(
-    path.dirname(executable),
-    'cache',
-    'dart-sdk',
-    'bin',
-    Platform.isWindows ? 'dart.exe' : 'dart',
-  );
-  if (isSdkExecutable(maybeFlutterDartExecutable)) {
-    return maybeFlutterDartExecutable;
-  }
-
-  throw Exception(
-    'Found Dart executable at "$executable", but failed to verify the surrounding Dart SDK.\n'
-    'Make sure "${Platform.isWindows ? 'where.exe dart.bat dart.exe' : 'which dart'}" resolves to the Dart executable inside the Dart or Flutter SDK directory.',
-  );
-}();
+/// The path to the Dart executable in either the Dart or Flutter SDK.
+final String dartExecutable =
+    cli_util.dartExecutable ??
+    (throw Exception(
+      'Could not find Dart executable. '
+      'Make sure Dart is installed and added to your PATH.',
+    ));
 
 /// The path to the root directory of the SDK.
 final String dartSdkDir = path.dirname(path.dirname(dartExecutable));

--- a/packages/jaspr_cli/lib/src/project.dart
+++ b/packages/jaspr_cli/lib/src/project.dart
@@ -307,8 +307,13 @@ final String dartExecutable =
       'Make sure Dart is installed and added to your PATH.',
     ));
 
-/// The path to the root directory of the SDK.
-final String dartSdkDir = path.dirname(path.dirname(dartExecutable));
+/// The path to the root directory of the Dart SDK.
+final String dartSdkDir =
+    cli_util.sdkPath ??
+    (throw Exception(
+      'Could not find Dart SDK. '
+      'Make sure Dart is installed and added to your PATH.',
+    ));
 
 final dartSdkVersion = () {
   final result = ProcessRunner.instance.runSync(dartExecutable, ['--version']);

--- a/packages/jaspr_cli/pubspec.yaml
+++ b/packages/jaspr_cli/pubspec.yaml
@@ -58,6 +58,9 @@ dev_dependencies:
   test: ^1.22.0
 
 dependency_overrides:
+  # Some dependencies, such as `dart_data_home`, still require `cli_util: ^0.5.0`,
+  # but the CLI needs `0.6.0` for SDK discovery when AOT compiled.
+  # Remove once all dependencies `0.6.0` to resolve.
   cli_util: ^0.6.0
   frontend_server_client:
     git:

--- a/packages/jaspr_cli/pubspec.yaml
+++ b/packages/jaspr_cli/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
   browser_launcher: ^1.1.2
   build_daemon: ^4.1.4
   cli_completion: ^0.5.0
-  cli_util: ^0.5.0
+  cli_util: ^0.6.0
   collection: ^1.17.1
   dart_data_home: ^0.1.0
   dwds: ^27.0.3
@@ -58,6 +58,7 @@ dev_dependencies:
   test: ^1.22.0
 
 dependency_overrides:
+  cli_util: ^0.6.0
   frontend_server_client:
     git:
       url: https://github.com/schultek/webdev.git

--- a/packages/jaspr_cli/test/src/fakes/fake_io.dart
+++ b/packages/jaspr_cli/test/src/fakes/fake_io.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:io' as io;
 
 import 'package:async/async.dart';
+import 'package:cli_util/cli_util.dart' as cli_util;
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:jaspr_cli/src/process_runner.dart';
@@ -41,7 +42,13 @@ class FakeIO {
 
   T runZoned<T>(T Function() body) {
     return io.IOOverrides.runZoned(
-      () => ProcessRunner.runZoned(body, process),
+      () => Zone.current
+          .fork(
+            zoneValues: {
+              cli_util.environmentOverridesKey: {'DART_SDK': '/fake'},
+            },
+          )
+          .run(() => ProcessRunner.runZoned(body, process)),
       getCurrentDirectory: () => fs.currentDirectory,
       setCurrentDirectory: (path) => fs.currentDirectory = path,
       createFile: fs.file,

--- a/packages/jaspr_cli/test/src/fakes/fake_project.dart
+++ b/packages/jaspr_cli/test/src/fakes/fake_project.dart
@@ -28,14 +28,12 @@ extension FakeProject on FakeIO {
   }
 
   void stubDartSDK() {
-    when(() => process.runSync('which', ['dart'])).thenAnswer((_) => ProcessResult(0, 0, '/fake/bin/dart', null));
-    when(
-      () => process.runSync('where', ['dart.bat', 'dart.exe']),
-    ).thenAnswer((_) => ProcessResult(0, 0, '/fake/bin/dart', null));
     when(
       () => process.runSync('/fake/bin/dart', ['--version']),
     ).thenAnswer((_) => ProcessResult(0, 0, 'Dart SDK version: 3.14.0', null));
 
+    fs.file('/fake/bin/dart').createSync(recursive: true);
+    fs.file('/fake/lib/_internal/allowed_experiments.json').createSync(recursive: true);
     fs.file('/fake/version').createSync(recursive: true);
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -282,13 +282,13 @@ packages:
     source: hosted
     version: "0.3.3+2"
   cli_util:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       name: cli_util
-      sha256: "71e43f1976c3eae2d9468a5b4d6600bf8cae61508b87f27fa1799228935d48ab"
+      sha256: "89b8801ba49f8b593fbf2d3e59efd0f566c46cd4ba6837ae2610c72b52a0f899"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.2"
+    version: "0.6.0"
   clock:
     dependency: transitive
     description:


### PR DESCRIPTION
Takes advantage of the new top-level `dartExecutable` getter in the 0.6.0 release of `package:cli_util`: https://pub.dev/packages/cli_util/changelog#060
