### PR TITLE
[jaspr] Add child-list mutation and server-rendered hydration tests

### DIFF
--- a/packages/jaspr/lib/src/server/server_handler.dart
+++ b/packages/jaspr/lib/src/server/server_handler.dart
@@ -4,7 +4,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:http/http.dart' as http;
-import 'package:path/path.dart';
+import 'package:path/path.dart' as path;
 import 'package:shelf/shelf.dart';
 import 'package:shelf_gzip/shelf_gzip.dart';
 import 'package:shelf_proxy/shelf_proxy.dart';
@@ -19,17 +19,32 @@ import 'server_app.dart';
 final String? jasprProxyPort = Platform.environment['JASPR_PROXY_PORT'];
 const String kDevWeb = String.fromEnvironment('jaspr.dev.web');
 
-final String webDir = kDevWeb.isNotEmpty ? kDevWeb : join(_findRootProjectDir(), 'web');
+/// The directory that static web assets are served from.
+///
+/// Defaults to the `web` directory of the root project,
+/// unless overridden with the `jaspr.dev.web` environment declaration.
+final String webDir = kDevWeb.isNotEmpty ? kDevWeb : path.join(_findRootProjectDir(), 'web');
 
 String _findRootProjectDir() {
-  final executableDir = dirname(Platform.script.toFilePath());
-  final workingDir = Directory.current.path;
+  final script = Platform.script;
+  // The script has no file path when it's not a file,
+  // such as the data uri of a hybrid isolate spawned by `package:test`.
+  final scriptPath = script.scheme.isEmpty || script.isScheme('file') ? script.toFilePath() : null;
 
-  if (Platform.resolvedExecutable == Platform.script.toFilePath()) {
-    return executableDir;
+  // When running as a compiled executable,
+  // the script is the executable itself,
+  // so its directory is the project directory.
+  if (scriptPath != null && Platform.resolvedExecutable == scriptPath) {
+    return path.dirname(scriptPath);
   }
 
-  final foundDir = _tryFindRootProjectDir(executableDir) ?? _tryFindRootProjectDir(workingDir);
+  // Otherwise search upwards for a `pubspec.yaml`,
+  // starting from the script's directory when it has one,
+  // then fall back to looking from the current working directory.
+  final workingDir = Directory.current.path;
+  final foundDir = scriptPath != null
+      ? _tryFindRootProjectDir(path.dirname(scriptPath)) ?? _tryFindRootProjectDir(workingDir)
+      : _tryFindRootProjectDir(workingDir);
 
   if (foundDir == null) {
     throw Exception('Could not resolve project directory containing pubspec.yaml');
@@ -39,11 +54,11 @@ String _findRootProjectDir() {
 }
 
 String? _tryFindRootProjectDir(String startingDir) {
-  if (File(join(startingDir, 'pubspec.yaml')).existsSync()) {
+  if (File(path.join(startingDir, 'pubspec.yaml')).existsSync()) {
     return startingDir;
   }
 
-  final parentDir = dirname(startingDir);
+  final parentDir = path.dirname(startingDir);
   if (startingDir == parentDir) {
     return null;
   }

--- a/packages/jaspr/pubspec.yaml
+++ b/packages/jaspr/pubspec.yaml
@@ -40,6 +40,7 @@ dev_dependencies:
   dart_style: ^3.1.2
   jaspr_test: 0.23.4
   mocktail: ^1.0.4
+  stream_channel: ^2.1.4
   test: ^1.25.8
 
 screenshots:

--- a/packages/jaspr/test/client/hydration/server_rendered_app.dart
+++ b/packages/jaspr/test/client/hydration/server_rendered_app.dart
@@ -1,0 +1,46 @@
+import 'package:jaspr/dom.dart';
+import 'package:jaspr/jaspr.dart';
+
+class HydrationShell extends StatelessComponent {
+  const HydrationShell({required this.child});
+
+  final Component child;
+
+  @override
+  Component build(BuildContext context) => div(id: 'shell', [child]);
+}
+
+class HydrationCounter extends StatefulComponent {
+  const HydrationCounter({required this.id, required this.seed, super.key});
+
+  final int id;
+  final int seed;
+
+  @override
+  State<HydrationCounter> createState() => HydrationCounterState();
+}
+
+class HydrationCounterState extends State<HydrationCounter> with SyncStateMixin<HydrationCounter, int> {
+  int _count = 0;
+  int _clicks = 0;
+
+  @override
+  void initState() {
+    // Hydration must restore server state instead of reproducing it from parameters.
+    _count = kIsWeb ? -1 : component.seed + component.id;
+    super.initState();
+  }
+
+  @override
+  int getState() => _count;
+
+  @override
+  void updateState(int value) => _count = value;
+
+  @override
+  Component build(BuildContext context) => button(
+    id: 'counter-${component.id}',
+    onClick: () => setState(() => _clicks++),
+    [.text('${component.id}:$_count:$_clicks')],
+  );
+}

--- a/packages/jaspr/test/client/hydration/server_rendered_browser_test.dart
+++ b/packages/jaspr/test/client/hydration/server_rendered_browser_test.dart
@@ -1,0 +1,186 @@
+/// Browser integration tests for hydration and reloads using real server output.
+///
+/// `server_rendered_hybrid.dart` renders shared test components in a VM isolate
+/// and supplies initial HTML plus `X-Jaspr-Reload` responses.
+/// This exercises server-generated client/server boundaries, sync markers, and
+/// document normalization together with the browser's hydration and reload paths.
+///
+/// Checks DOM reuse, synchronized state, preservation or reset of local state
+/// depending on keys and positions, and event handlers after hydration and reload.
+@TestOn('browser')
+library;
+
+import 'dart:js_interop';
+
+import 'package:jaspr/client.dart';
+import 'package:jaspr/src/client/utils.dart';
+import 'package:jaspr/src/dom/validator.dart';
+import 'package:jaspr_test/client_test.dart';
+import 'package:universal_web/web.dart' as web;
+
+import 'server_rendered_app.dart';
+
+void main() {
+  late List<String> html;
+
+  // Render on the VM once and share the resulting markup across all tests.
+  setUpAll(() async {
+    final channel = spawnHybridUri('server_rendered_hybrid.dart');
+    html = (await channel.stream.first as List<Object?>).cast<String>();
+  });
+
+  testClient('hydrates server-rendered ranges and reloads their state and events', (tester) async {
+    final marker = DomValidator.clientMarkerPrefix;
+    final initialBody = _parseBody(html[0]);
+    final initialHtml = (initialBody.innerHTML as JSString).toDart;
+    expect(initialHtml, contains('<!--${marker}shell'));
+    expect(initialHtml, contains('<!--${marker}counter'));
+    web.document.body!.replaceWith(initialBody);
+    final initialButton = _button('counter-0');
+    final counterKey = GlobalStateKey<HydrationCounterState>();
+    final movingCounterKey = GlobalStateKey<HydrationCounterState>();
+
+    await _hydrate(tester, keys: {0: counterKey, 1: movingCounterKey});
+
+    expect(_button('counter-0'), same(initialButton));
+    expect(initialButton.textContent, '0:10:0');
+    final nestedButton = _button('counter-100');
+    await _clickAndExpectText(nestedButton, '100:110:1');
+    expect(_buttonIds(), List.generate(64, (i) => 'counter-$i'));
+    // The reload below covers each combination of key type and position change:
+    //
+    // | Counter | Key    | Position on reload                          |
+    // | ------- | ------ | ------------------------------------------- |
+    // | 0       | global | stays first                                 |
+    // | 1       | global | moves from second to second to last         |
+    // | 2       | value  | moves from third to third to last           |
+    // | 100     | value  | stays first in the nested server component  |
+    //
+    // Counter 0 is the control for counter 1: its state would survive through
+    // its positional anchor even without a global key.
+    final initialState = counterKey.currentState!;
+    await _clickAndExpectText(initialButton, '0:10:1');
+
+    final movingButton = _button('counter-1');
+    final movingState = movingCounterKey.currentState!;
+    movingButton.click();
+    await _clickAndExpectText(movingButton, '1:11:2');
+
+    final movingValueKeyedButton = _button('counter-2');
+    await _clickAndExpectText(movingValueKeyedButton, '2:12:1');
+
+    await _reload(tester, _parseBody(html[1]));
+
+    expect(_buttonIds(), [
+      'counter-0',
+      for (var id = 63; id > 0; id--) 'counter-$id',
+      'counter-64',
+    ]);
+    expect(web.document.querySelectorAll('#shell').length, 1);
+    expect(web.document.getElementById('before')!.textContent, 'Before');
+    expect(web.document.getElementById('after')!.textContent, 'After');
+    expect(counterKey.currentState, same(initialState));
+    final reloadedButton = _button('counter-0');
+    expect(reloadedButton.textContent, '0:100:1');
+    await _clickAndExpectText(reloadedButton, '0:100:2');
+    expect(movingCounterKey.currentState, same(movingState));
+    final movedButton = _button('counter-1');
+    expect(movedButton.textContent, '1:101:2');
+    await _clickAndExpectText(movedButton, '1:101:3');
+    // The anchor key of a client boundary is its position in the document,
+    // so a component that keeps its position keeps its state without needing a global key.
+    //
+    // TODO: Counter 100 is deliberately rendered with the same seed and
+    // not clicked after the reload, as nested reloads currently
+    // retain stale synced state and duplicate event handlers.
+    // The skipped tests below cover both of those bugs,
+    // so this assertion only verifies that its local click count survived.
+    expect(_button('counter-100').textContent, '100:110:1');
+
+    // Whereas one that moves is rebuilt against a different anchor,
+    // and only the synced count is restored from the server markup.
+    // Preserving the rest of its state across a move needs a global key,
+    // as counter 1 above has.
+    expect(_button('counter-2').textContent, '2:102:0');
+    await _clickAndExpectText(_button('counter-2'), '2:102:1');
+    expect(_button('counter-63').textContent, '63:163:0');
+    await _clickAndExpectText(_button('counter-63'), '63:163:1');
+    expect(_button('counter-64').textContent, '64:164:0');
+    await _clickAndExpectText(_button('counter-64'), '64:164:1');
+  });
+
+  testClient(
+    'reloads a nested counter without duplicating its click handler',
+    (tester) async {
+      web.document.body!.replaceWith(_parseBody(html[0]));
+      await _hydrate(tester);
+      await _clickAndExpectText(_button('counter-100'), '100:110:1');
+
+      await _reload(tester, _parseBody(html[1]));
+
+      expect(_button('counter-100').textContent, '100:110:1');
+      await _clickAndExpectText(_button('counter-100'), '100:110:2');
+    },
+    // TODO: Enable when nested reloads stop retaining duplicate event handlers.
+    // Currently the first click after reload increments the click count from 1 to 3.
+    skip: true,
+  );
+
+  testClient(
+    'reloads a nested counter with fresh synced state and preserves its local state',
+    (tester) async {
+      web.document.body!.replaceWith(_parseBody(html[0]));
+      await _hydrate(tester);
+      await _clickAndExpectText(_button('counter-100'), '100:110:1');
+
+      final newBody = _parseBody(html[2]);
+      expect(newBody.querySelector('#counter-100')!.textContent, '100:200:0');
+      await _reload(tester, newBody);
+
+      expect(_button('counter-100').textContent, '100:200:1');
+    },
+    // TODO: Enable when nested reloads apply the new server markup and synced state.
+    // Currently counter 100 keeps its old synced count of 110 instead of receiving 200.
+    skip: true,
+  );
+}
+
+web.HTMLElement _parseBody(String html) => web.DOMParser().parseFromString(html.toJS, 'text/html').body!;
+
+Future<void> _hydrate(ClientTester tester, {Map<int, Key> keys = const {}}) async {
+  Jaspr.initializeApp(
+    options: ClientOptions(
+      clients: {
+        'shell': ClientLoader((params) => HydrationShell(child: params.mount(params.get<String>('child')))),
+        'counter': ClientLoader((params) {
+          final id = params.get<int>('id');
+          return HydrationCounter(id: id, seed: params.get<int>('seed'), key: keys[id] ?? ValueKey(id));
+        }),
+      },
+    ),
+  );
+  tester.pumpComponent(const ClientApp());
+  await pumpEventQueue(times: 1);
+}
+
+Future<void> _reload(ClientTester tester, web.HTMLElement newBody) async {
+  // Use the same root replacement and performReload sequence as
+  // the client's reload handler, with actual `X-Jaspr-Reload` server output.
+  final root = tester.binding.rootElement!;
+  (root.renderObject as RootDomRenderObject).setRootNode(newBody);
+  root.owner.performReload(root);
+  web.document.body!.replaceWith(newBody);
+  await pumpEventQueue(times: 1);
+}
+
+web.HTMLButtonElement _button(String id) => web.document.getElementById(id)! as web.HTMLButtonElement;
+
+Future<void> _clickAndExpectText(web.HTMLButtonElement button, String expected) async {
+  button.click();
+  await pumpEventQueue(times: 1);
+  expect(button.textContent, expected);
+}
+
+List<String> _buttonIds() => [
+  for (final button in web.document.querySelectorAll('#counters button').toIterable()) (button as web.Element).id,
+];

--- a/packages/jaspr/test/client/hydration/server_rendered_hybrid.dart
+++ b/packages/jaspr/test/client/hydration/server_rendered_hybrid.dart
@@ -1,0 +1,55 @@
+import 'dart:convert';
+
+import 'package:jaspr/dom.dart';
+import 'package:jaspr/server.dart';
+import 'package:stream_channel/stream_channel.dart';
+
+import 'server_rendered_app.dart';
+
+// Called on the VM by the browser test, so the HTML exercises the real
+// server child lists, boundary adapters, sync markers, and document normalization.
+Future<void> hybridMain(StreamChannel<Object?> channel) async {
+  Jaspr.initializeApp(
+    options: ServerOptions(
+      clientId: 'test.clients.dart.js',
+      clients: {
+        HydrationShell: ClientTarget<HydrationShell>('shell', params: (app) => {'child': app.child}),
+        HydrationCounter: ClientTarget<HydrationCounter>('counter', params: (app) => {'id': app.id, 'seed': app.seed}),
+      },
+    ),
+  );
+
+  Component app(List<int> ids, int seed, int nestedSeed) => .fragment([
+    p(id: 'before', [.text('Before')]),
+    HydrationShell(
+      child: ul([
+        for (var id = 100; id < 103; id++) li([HydrationCounter(id: id, seed: nestedSeed)]),
+      ]),
+    ),
+    ul(id: 'counters', [
+      for (final id in ids) li(key: ValueKey(id), [HydrationCounter(id: id, seed: seed, key: ValueKey(id))]),
+    ]),
+    p(id: 'after', [.text('After')]),
+  ]);
+
+  // `X-Jaspr-Reload` makes the server respond with only the body, like a real client reload.
+  Future<String> render(List<int> ids, int seed, {int nestedSeed = 10, bool reload = false}) async {
+    final response = await renderComponent(
+      app(ids, seed, nestedSeed),
+      request: Request(
+        'GET',
+        Uri.http('localhost', '/'),
+        headers: {if (reload) 'X-Jaspr-Reload': 'true'},
+      ),
+    );
+    return utf8.decode(response.body);
+  }
+
+  final reloadedIds = [0, for (var id = 63; id > 0; id--) id, 64];
+  channel.sink.add([
+    await render([for (var id = 0; id < 64; id++) id], 10),
+    await render(reloadedIds, 100, reload: true),
+    // Change nested server state independently for its reload regression test.
+    await render(reloadedIds, 100, nestedSeed: 100, reload: true),
+  ]);
+}

--- a/packages/jaspr/test/server/child_list_mutation_test.dart
+++ b/packages/jaspr/test/server/child_list_mutation_test.dart
@@ -1,0 +1,218 @@
+@TestOn('vm')
+library;
+
+import 'dart:math';
+
+import 'package:jaspr/server.dart';
+import 'package:jaspr/src/server/child_nodes.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('child list mutations', () {
+    test('inserts, moves, and removes children with missing anchors', () {
+      final list = MarkupRenderFragment().children;
+      final a = MarkupRenderText('a', false);
+      final b = MarkupRenderText('b', false);
+      final c = MarkupRenderText('c', false);
+      final missing = MarkupRenderText('missing', false);
+
+      list.insertAfter(a);
+      list.insertAfter(b, after: a);
+      list.insertBefore(c, before: b);
+      _expectList(list, [a, c, b]);
+      list.insertAfter(b, after: missing);
+      _expectList(list, [b, a, c]);
+      list.insertBefore(b, before: missing);
+      _expectList(list, [a, c, b]);
+
+      // TODO: Decide how inserting a child relative to itself should behave, then test it here.
+      // The child is currently detached before its anchor is resolved,
+      // so it behaves like a missing anchor and is inserted at the start or end of the list.
+      // Other options are leaving the list unchanged or asserting against it.
+
+      final node = list.find(b)!;
+      node.remove();
+      node.remove();
+      list.remove(missing);
+      _expectList(list, [a, c]);
+      list.insertNodeBefore(node, before: c);
+      expect(list.find(b), same(node));
+      _expectList(list, [a, b, c]);
+    });
+
+    test('tracks membership separately when an object occurs in different lists', () {
+      final source = MarkupRenderFragment().children;
+      final target = MarkupRenderFragment().children;
+      final child = MarkupRenderText('child', false);
+      source.insertAfter(child);
+      target.insertAfter(child);
+      final targetNode = target.find(child)!;
+      source.remove(child);
+      expect(target.find(child), same(targetNode));
+      _expectList(source, []);
+      _expectList(target, [child]);
+    });
+
+    test('tracks low-level insertions and keeps insertion inside range boundaries', () {
+      final list = MarkupRenderFragment().children;
+      final a = MarkupRenderText('a', false);
+      final b = MarkupRenderText('b', false);
+      final start = ChildNodeData(MarkupRenderText('<!--start-->', true));
+      final end = ChildNodeData(MarkupRenderText('<!--end-->', true));
+      list.insertAfter(a);
+      final range = list.range();
+      range.start.insertNext(start);
+      range.end.insertPrev(end);
+      expect(list.find(start.node), same(start));
+      expect(list.find(end.node), same(end));
+
+      list.insertAfter(b, after: a);
+      expect(range.toList(), [start.node, a, b, end.node]);
+      _expectList(list, [start.node, a, b, end.node]);
+      start.remove();
+      end.remove();
+      _expectList(list, [a, b]);
+    });
+
+    test('transfers nested ranges and supports mutation while detached', () {
+      final parent = MarkupRenderFragment();
+      final source = parent.children;
+      final target = MarkupRenderFragment().children;
+      final children = List.generate(5, (i) => parent.createChildRenderText('$i'));
+      for (final child in children) {
+        source.insertBefore(child);
+      }
+      final range = source.range(startAfter: source.find(children[0]), endBefore: source.find(children[4]));
+      final nested = source.range(startAfter: source.find(children[1]), endBefore: source.find(children[3]));
+
+      target.insertNodeAfter(range);
+      _expectList(source, [children[0], children[4]]);
+      _expectList(target, children.sublist(1, 4));
+      // Transferring a range doesn't update the `parent` of the render objects it contains.
+      // That's the responsibility of `MarkupRenderObject.attach` and `remove`,
+      // so it isn't asserted here.
+
+      nested.remove();
+      expect(target.find(children[2]), isNull);
+      final marker = ChildNodeData(MarkupRenderText('<!--nested-->', true));
+      nested.start.insertNext(marker);
+      expect(target.find(marker.node), isNull);
+      source.insertNodeBefore(nested);
+      _expectList(source, [children[0], children[4], marker.node, children[2]]);
+      _expectList(target, [children[1], children[3]]);
+      expect(source.find(marker.node), same(marker));
+
+      // Nodes inserted through transferred boundaries must be found in the destination list.
+      final nextMarker = ChildNodeData(MarkupRenderText('<!--next-->', true));
+      nested.end.insertPrev(nextMarker);
+      expect(source.find(nextMarker.node), same(nextMarker));
+      expect(target.find(nextMarker.node), isNull);
+      source.insertNodeAfter(target.find(children[1])!, after: children[0]);
+      expect(target.find(children[1]), isNull);
+      _expectList(source, [children[0], children[1], children[4], marker.node, children[2], nextMarker.node]);
+      _expectList(target, [children[3]]);
+    });
+
+    test('moves ranges within a list', () {
+      final list = MarkupRenderFragment().children;
+      final children = List.generate(4, (i) => MarkupRenderText('$i', false));
+      for (final child in children) {
+        list.insertBefore(child);
+      }
+      final range = list.range(startAfter: list.find(children[0]), endBefore: list.find(children[3]));
+      list.insertNodeAfter(range, after: children[3]);
+      _expectList(list, [children[0], children[3], children[1], children[2]]);
+      list.insertNodeBefore(range, before: children[0]);
+      _expectList(list, [children[1], children[2], children[0], children[3]]);
+      list.insertNodeAfter(range, after: children[0]);
+      _expectList(list, children);
+
+      // TODO: Decide how moving a range relative to an anchor
+      // inside that range should behave, then test it here.
+      // The range is currently detached before its anchor is resolved,
+      // so it behaves like a missing anchor and is inserted at the start or end of the list.
+      // Other options are leaving the list unchanged or asserting against it.
+    });
+
+    test('transfers empty ranges and supports inserting children after transfer', () {
+      final source = MarkupRenderFragment().children;
+      final target = MarkupRenderFragment().children;
+      final range = source.range();
+      target.insertNodeAfter(range);
+      _expectList(source, []);
+      _expectList(target, []);
+
+      final a = ChildNodeData(MarkupRenderText('a', false));
+      final b = ChildNodeData(MarkupRenderText('b', false));
+      source.insertNodeAfter(a);
+      range.start.insertNext(b);
+      expect(source.find(a.node), same(a));
+      expect(target.find(b.node), same(b));
+      source.insertNodeAfter(range);
+      expect(source.find(a.node), same(a));
+      expect(source.find(b.node), same(b));
+      expect(target.find(b.node), isNull);
+      _expectList(source, [b.node, a.node]);
+      target.insertNodeBefore(range);
+      expect(source.find(a.node), same(a));
+      expect(target.find(b.node), same(b));
+      _expectList(source, [a.node]);
+      _expectList(target, [b.node]);
+    });
+
+    test('find remains shallow while findWhere visits fragments', () {
+      final list = MarkupRenderFragment().children;
+      final fragment = MarkupRenderFragment();
+      final child = MarkupRenderText('child', false);
+      fragment.children.insertAfter(child);
+      list.insertAfter(fragment);
+      expect(list.find(child), isNull);
+      expect(list.find(fragment)?.node, same(fragment));
+      expect(list.findWhere((node) => node == child)?.node, same(child));
+      expect(list.findWhere((node) => node == child, visitFragments: false), isNull);
+    });
+
+    test('matches a list model through repeated insertions, moves, and removals', () {
+      final random = Random(42);
+      final list = MarkupRenderFragment().children;
+      final objects = List.generate(32, (i) => MarkupRenderText('$i', false));
+      final expected = <MarkupRenderObject>[];
+      for (var step = 0; step < 1000; step++) {
+        final child = objects[random.nextInt(objects.length)];
+        final anchor = random.nextInt(4) == 0 ? null : objects[random.nextInt(objects.length)];
+        // TODO: Model inserting a child relative to itself once its behavior is decided.
+        // The child is currently detached before its anchor is resolved,
+        // so it behaves like a missing anchor and is inserted at the start or end of the list.
+        if (anchor == child) continue;
+        expected.remove(child);
+        final index = anchor == null ? -1 : expected.indexOf(anchor);
+        switch (random.nextInt(3)) {
+          case 0:
+            list.insertAfter(child, after: anchor);
+            expected.insert(index + 1, child);
+          case 1:
+            list.insertBefore(child, before: anchor);
+            expected.insert(index < 0 ? expected.length : index, child);
+          case 2:
+            list.remove(child);
+        }
+        _expectList(list, expected, reason: 'step $step');
+      }
+    });
+  });
+}
+
+void _expectList(ChildList list, List<MarkupRenderObject> expected, {String? reason}) {
+  final visited = Set<ChildNode>.identity();
+  ChildNode? previous;
+  ChildNode? current = list.firstNode;
+  while (current != null) {
+    expect(visited.add(current), isTrue, reason: 'linked list contains a cycle');
+    expect(current.prev, same(previous), reason: reason);
+    previous = current;
+    current = current.next;
+  }
+  expect(previous, same(list.lastNode), reason: reason);
+  // Render objects don't override `==`, so `equals` compares them by identity.
+  expect(list.toList(), equals(expected), reason: reason);
+}


### PR DESCRIPTION
These will serve as a useful reference while I work on some fixes and optimizations to relevant logic.

- Adds regression tests for hydration/reload behavior using real server-rendered HTML.
  - Identifies known nested reload failures as skipped regressions with TODO comments.
- Adds regression tests for child-list mutations.
  - Adds TODOs for behavior that isn't well specified or guaranteed.
- Handles non-file script URIs needed by hybrid tests.