### PR TITLE
[next] refactor Component.apply handling

### DIFF
--- a/packages/jaspr/lib/src/client/component_anchors.dart
+++ b/packages/jaspr/lib/src/client/component_anchors.dart
@@ -74,31 +74,12 @@ class ClientComponentAnchor extends ComponentAnchor {
   }
 
   ChildSlot createSlot() {
-    return _AnchorChildSlot(
+    return ChildSlot.between(
       key: UniqueKey(),
       start: startNode,
       end: endNode,
       child: build(),
     );
-  }
-}
-
-class _AnchorChildSlot extends ChildSlot {
-  _AnchorChildSlot({required this.start, required this.end, required this.child, super.key});
-
-  final web.Node start;
-  final web.Node end;
-  @override
-  final Component child;
-
-  @override
-  ChildSlotRenderObject createRenderObject(SlottedDomRenderObject parent) {
-    return ChildSlotRenderObject.between(parent, start, end);
-  }
-
-  @override
-  bool canUpdate(ChildSlot oldComponent) {
-    return oldComponent is _AnchorChildSlot && oldComponent.start == start && oldComponent.end == end;
   }
 }
 

--- a/packages/jaspr/lib/src/client/slotted_child_view.dart
+++ b/packages/jaspr/lib/src/client/slotted_child_view.dart
@@ -199,12 +199,6 @@ class SlottedChildViewElement extends DomRenderObjectElement {
   }
 
   @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    updateRenderObject(renderObject as SlottedDomRenderObject);
-  }
-
-  @override
   RenderObject createRenderObject() {
     final parent = parentRenderObjectElement!.renderObject;
     final renderObject = SlottedDomRenderObject.fromNodes(component.nodes, parent as DomRenderObject);

--- a/packages/jaspr/lib/src/client/slotted_child_view.dart
+++ b/packages/jaspr/lib/src/client/slotted_child_view.dart
@@ -12,6 +12,9 @@ abstract class ChildSlot extends Component {
 
   factory ChildSlot.fromQuery(String query, {required Component child, Key? key}) = QueryChildSlot;
 
+  factory ChildSlot.between({required web.Node start, required web.Node end, required Component child, Key? key}) =
+      RangeChildSlot;
+
   Component get child;
 
   ChildSlotRenderObject createRenderObject(SlottedDomRenderObject parent);
@@ -19,6 +22,26 @@ abstract class ChildSlot extends Component {
 
   @override
   Element createElement() => ChildSlotElement(this);
+}
+
+/// A [ChildSlot] that attaches its child between two given DOM [start] and [end] nodes.
+class RangeChildSlot extends ChildSlot {
+  const RangeChildSlot({required this.start, required this.end, required this.child, super.key});
+
+  final web.Node start;
+  final web.Node end;
+  @override
+  final Component child;
+
+  @override
+  ChildSlotRenderObject createRenderObject(SlottedDomRenderObject parent) {
+    return ChildSlotRenderObject.between(parent, start, end);
+  }
+
+  @override
+  bool canUpdate(ChildSlot oldComponent) {
+    return oldComponent is RangeChildSlot && oldComponent.start == start && oldComponent.end == end;
+  }
 }
 
 /// A [ChildSlot] that attaches its child to the first DOM element matching
@@ -123,6 +146,54 @@ class SlottedChildViewElement extends DomRenderObjectElement {
   }
 
   @override
+  List<Component> buildChildren() {
+    final parentResolver = inheritedDomResolver;
+    if (parentResolver == null) {
+      return buildOwnChildren();
+    }
+
+    final parentDomNode = SlottedDomRenderObject._realNodeOf(
+      (renderObject as SlottedDomRenderObject).parent!,
+    );
+
+    List<ApplyParams> getParams(RenderObject target) {
+      final parentParams = parentResolver(target);
+      if (parentParams.isEmpty) return const [];
+
+      if (!parentParams.any((p) => p.target.onlyChildren)) {
+        return parentParams;
+      }
+
+      // Find ChildSlotRenderObject in target's ancestor chain
+      ChildSlotRenderObject? slotRenderObject;
+      RenderObject? current = target;
+      while (current != null && current != renderObject) {
+        if (current is ChildSlotRenderObject) {
+          slotRenderObject = current;
+          break;
+        }
+        current = current.parent;
+      }
+
+      if (slotRenderObject != null && slotRenderObject.node == parentDomNode) {
+        // Direct child slot -> allow all params including onlyChildren: true
+        return parentParams;
+      } else {
+        // Nested slot -> allow only descendant params
+        return parentParams.where((p) => !p.target.onlyChildren).toList();
+      }
+    }
+
+    return [
+      for (final slot in buildOwnChildren())
+        wrapWithInheritedDomComponent(
+          getParams: getParams,
+          child: slot,
+        ),
+    ];
+  }
+
+  @override
   List<Component> buildOwnChildren() {
     return component.slots;
   }
@@ -150,9 +221,22 @@ class SlottedChildViewElement extends DomRenderObjectElement {
     }
     _appliedParams.clear();
 
-    if (inheritedDomParams case final inheritedDomParams?) {
+    if (inheritedDomParamsFor(renderObject) case final inheritedDomParams? when inheritedDomParams.isNotEmpty) {
+      final slotRanges = {
+        for (final slot in component.slots)
+          if (slot is RangeChildSlot) slot.start: slot.end,
+      };
+
       web.Node? current = renderObject.firstChildNode;
       while (current != null) {
+        if (slotRanges[current] case final endNode?) {
+          if (current == renderObject.lastChildNode) break;
+          current = endNode;
+          if (current == renderObject.lastChildNode) break;
+          current = current.nextSibling;
+          continue;
+        }
+
         if (current.isElement) {
           for (final param in inheritedDomParams.reversed) {
             final elements = findMatchingElements(current as web.Element, param.target);
@@ -399,7 +483,9 @@ class SlottedDomRenderObject extends DomRenderFragment {
   }
 }
 
-class ChildSlotRenderObject extends DomRenderObject with MultiChildDomRenderObject, HydratableDomRenderObject {
+class ChildSlotRenderObject extends DomRenderObject
+    with MultiChildDomRenderObject, HydratableDomRenderObject
+    implements RenderFragment {
   ChildSlotRenderObject(this.node, DomRenderObject parent, [List<web.Node>? nodes]) {
     this.parent = parent;
     toHydrate = [...nodes ?? node.childNodes.toIterable()];

--- a/packages/jaspr/lib/src/framework/components.dart
+++ b/packages/jaspr/lib/src/framework/components.dart
@@ -91,7 +91,7 @@ class DomElement extends DomRenderObjectElement {
     var attributes = component.attributes;
     var events = component.events;
 
-    if (inheritedDomParams case final inheritedDomParams?) {
+    if (inheritedDomParamsFor(renderObject) case final inheritedDomParams? when inheritedDomParams.isNotEmpty) {
       final classesSet = {...?_splitClasses(classes)};
       styles = Map.of(styles ?? {});
       attributes = Map.of(attributes ?? {});
@@ -227,57 +227,46 @@ abstract class DomRenderObjectElement extends MultiChildRenderObjectElement {
 
   InheritedElement? _inheritedDomElement;
 
-  List<ApplyParams>? get inheritedDomParams {
+  @override
+  void _updateInheritance() {
+    super._updateInheritance();
+    _inheritedDomElement = _inheritedElements?[_InheritedDomComponent];
+  }
+
+  @protected
+  DomParamsResolver? get inheritedDomResolver {
     if (_inheritedDomElement case final inheritedDomElement?) {
       final inheritedDomComponent = dependOnInheritedElement(inheritedDomElement) as _InheritedDomComponent;
-      return inheritedDomComponent.params;
+      return inheritedDomComponent.getParams;
     }
     return null;
+  }
+
+  List<ApplyParams>? get inheritedDomParams {
+    final target = _renderObject;
+    if (target != null) {
+      return inheritedDomParamsFor(target);
+    }
+    return null;
+  }
+
+  List<ApplyParams>? inheritedDomParamsFor(RenderObject target) {
+    return inheritedDomResolver?.call(target);
+  }
+
+  @protected
+  Component wrapWithInheritedDomComponent({
+    required DomParamsResolver getParams,
+    required Component child,
+  }) {
+    return _InheritedDomComponent(getParams: getParams, child: child);
   }
 
   List<Component> buildOwnChildren();
 
   @override
   List<Component> buildChildren() {
-    if (inheritedDomParams case final inheritedDomParams?) {
-      final List<ApplyParams> newParams = inheritedDomParams.where((p) => !p.target.onlyChildren).toList();
-
-      // If we either removed all selectors (or none), we can return the children as is.
-      // The inherited element was already removed (or kept) by the [_updateInheritance] method.
-      if (newParams.isEmpty || newParams.length == inheritedDomParams.length) {
-        return buildOwnChildren();
-      }
-
-      return [
-        for (final child in buildOwnChildren()) _InheritedDomComponent(params: newParams, child: child),
-      ];
-    }
     return buildOwnChildren();
-  }
-
-  @override
-  void _updateInheritance() {
-    super._updateInheritance();
-    if (_inheritedElements case final originalInheritedElements?) {
-      if (originalInheritedElements[_InheritedDomComponent] case final inheritedElement?) {
-        final updatedInheritedElements = HashMap<Type, InheritedElement>.of(originalInheritedElements);
-        _inheritedDomElement = inheritedElement;
-
-        // Removing this here when *some* selectors use child combinators allows us to short-circuit the build logic to
-        // not add a new [_InheritedDomComponent] when either:
-        //   - *all* selectors use child combinators, as then the inherited element is already removed, or
-        //   - *all* selectors use descendant combinators, as then the inherited element stays unchanged.
-        // Only when *some* selectors use descendant combinators and *some* selectors use child combinators do we need
-        // to create a new [_InheritedDomComponent] in the [buildChildren] method.
-        if ((inheritedElement.component as _InheritedDomComponent).params.any((p) => p.target.onlyChildren)) {
-          updatedInheritedElements.remove(_InheritedDomComponent);
-        }
-
-        _inheritedElements = updatedInheritedElements;
-        return;
-      }
-    }
-    _inheritedDomElement = null;
   }
 }
 
@@ -300,27 +289,55 @@ class ApplyParams {
   final Map<String, EventCallback>? events;
 }
 
-class _InheritedDomComponent extends InheritedComponent {
-  const _InheritedDomComponent({required this.params, required super.child});
+typedef DomParamsResolver = List<ApplyParams> Function(RenderObject target);
 
-  final List<ApplyParams> params;
+bool _isDirectDomChild(RenderObject target, RenderObject? applyParent) {
+  RenderObject? current = target;
+  while (current != null) {
+    if (current.parent == applyParent) {
+      return true;
+    }
+    if (current.parent case final parent? when parent is RenderFragment) {
+      current = parent;
+    } else {
+      break;
+    }
+  }
+  return false;
+}
+
+class _InheritedDomComponent extends InheritedComponent {
+  const _InheritedDomComponent({required this.getParams, required super.child});
+
+  final DomParamsResolver getParams;
 
   factory _InheritedDomComponent.merge(
     BuildContext context, {
     required ApplyParams params,
     required Component child,
   }) {
-    final current = context.dependOnInheritedComponentOfExactType<_InheritedDomComponent>();
-    if (current == null) {
-      return _InheritedDomComponent(params: [params], child: child);
+    final parentResolver = context.dependOnInheritedComponentOfExactType<_InheritedDomComponent>()?.getParams;
+
+    List<ApplyParams> getParams(RenderObject target) {
+      final parentParams = parentResolver?.call(target) ?? const [];
+      final applyParent = (context as Element)._parentRenderObjectElement?.renderObject;
+
+      if (params.target.onlyChildren && !_isDirectDomChild(target, applyParent)) {
+        return parentParams;
+      }
+
+      if (parentParams.isEmpty) {
+        return [params];
+      }
+
+      return [...parentParams, params];
     }
-    return _InheritedDomComponent(params: [...current.params, params], child: child);
+
+    return _InheritedDomComponent(getParams: getParams, child: child);
   }
 
   @override
   bool updateShouldNotify(_InheritedDomComponent oldComponent) {
-    if (identical(this, oldComponent)) return false;
-    if (params.isEmpty && oldComponent.params.isEmpty) return false;
     return true;
   }
 }

--- a/packages/jaspr/lib/src/framework/components.dart
+++ b/packages/jaspr/lib/src/framework/components.dart
@@ -55,12 +55,6 @@ class DomElement extends DomRenderObjectElement {
   }
 
   @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    updateRenderObject(renderObject as RenderElement);
-  }
-
-  @override
   void update(DomComponent newComponent) {
     assert(component.tag == newComponent.tag, 'Cannot update a DomComponent with a different tag.');
     super.update(newComponent);
@@ -146,6 +140,7 @@ class _ApplyDomComponent extends StatelessComponent implements DomComponent {
     this.attributes,
     this.events,
     required this.child,
+    super.key,
   });
 
   final ApplyTarget target;
@@ -229,15 +224,19 @@ abstract class DomRenderObjectElement extends MultiChildRenderObjectElement {
 
   @override
   void _updateInheritance() {
+    final oldInheritedDomElement = _inheritedDomElement;
     super._updateInheritance();
     _inheritedDomElement = _inheritedElements?[_InheritedDomComponent];
+    if (oldInheritedDomElement != _inheritedDomElement) {
+      markNeedsRender();
+    }
   }
 
   @protected
   DomParamsResolver? get inheritedDomResolver {
     if (_inheritedDomElement case final inheritedDomElement?) {
       final inheritedDomComponent = dependOnInheritedElement(inheritedDomElement) as _InheritedDomComponent;
-      return inheritedDomComponent.getParams;
+      return inheritedDomComponent.resolveParams;
     }
     return null;
   }
@@ -259,7 +258,11 @@ abstract class DomRenderObjectElement extends MultiChildRenderObjectElement {
     required DomParamsResolver getParams,
     required Component child,
   }) {
-    return _InheritedDomComponent(getParams: getParams, child: child);
+    return _InheritedDomComponent(
+      key: child.key == null ? null : ValueKey(child.key),
+      resolveParams: getParams,
+      child: child,
+    );
   }
 
   List<Component> buildOwnChildren();
@@ -307,18 +310,18 @@ bool _isDirectDomChild(RenderObject target, RenderObject? applyParent) {
 }
 
 class _InheritedDomComponent extends InheritedComponent {
-  const _InheritedDomComponent({required this.getParams, required super.child});
+  const _InheritedDomComponent({super.key, required this.resolveParams, required super.child});
 
-  final DomParamsResolver getParams;
+  final DomParamsResolver resolveParams;
 
   factory _InheritedDomComponent.merge(
     BuildContext context, {
     required ApplyParams params,
     required Component child,
   }) {
-    final parentResolver = context.dependOnInheritedComponentOfExactType<_InheritedDomComponent>()?.getParams;
+    final parentResolver = context.dependOnInheritedComponentOfExactType<_InheritedDomComponent>()?.resolveParams;
 
-    List<ApplyParams> getParams(RenderObject target) {
+    List<ApplyParams> resolveParams(RenderObject target) {
       final parentParams = parentResolver?.call(target) ?? const [];
       final applyParent = (context as Element)._parentRenderObjectElement?.renderObject;
 
@@ -333,7 +336,7 @@ class _InheritedDomComponent extends InheritedComponent {
       return [...parentParams, params];
     }
 
-    return _InheritedDomComponent(getParams: getParams, child: child);
+    return _InheritedDomComponent(resolveParams: resolveParams, child: child);
   }
 
   @override

--- a/packages/jaspr/lib/src/framework/framework.dart
+++ b/packages/jaspr/lib/src/framework/framework.dart
@@ -150,6 +150,7 @@ abstract class Component {
     Map<String, String>? attributes,
     Map<String, EventCallback>? events,
     required Component child,
+    Key? key,
   }) = _ApplyDomComponent;
 
   /// Creates a component which renders a list of child components without any wrapping element.

--- a/packages/jaspr/lib/src/framework/render_object.dart
+++ b/packages/jaspr/lib/src/framework/render_object.dart
@@ -60,6 +60,18 @@ mixin RenderObjectElement on Element {
 
   bool _dirtyRender = false;
 
+  @protected
+  void markNeedsRender() {
+    _dirtyRender = true;
+  }
+
+  @override
+  @mustCallSuper
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    markNeedsRender();
+  }
+
   bool shouldRerender(covariant Component newComponent) {
     return true;
   }
@@ -70,6 +82,10 @@ mixin RenderObjectElement on Element {
 
     if (!_attached) {
       attachRenderObject();
+    }
+    if (_dirtyRender) {
+      _dirtyRender = false;
+      updateRenderObject(renderObject);
     }
   }
 
@@ -83,11 +99,14 @@ mixin RenderObjectElement on Element {
 
   @override
   void didUpdate(Component oldComponent) {
+    super.didUpdate(oldComponent);
     if (_dirtyRender) {
       _dirtyRender = false;
+      if (!_attached) {
+        attachRenderObject();
+      }
       updateRenderObject(renderObject);
     }
-    super.didUpdate(oldComponent);
   }
 
   bool _attached = false;

--- a/packages/jaspr/test/client/hydration/hydration_browser_test.dart
+++ b/packages/jaspr/test/client/hydration/hydration_browser_test.dart
@@ -277,6 +277,49 @@ void main() {
       expect(strongElement.textContent, equals('Hello Nested Client'));
     });
 
+    testClient('should apply inherited dom params from outer client component to inner client component via server slot', (tester) async {
+      final marker = DomValidator.clientMarkerPrefix;
+      window.document.body!.innerHTML =
+          '<div>'
+                  '  <!--${marker}outer data={"child":"s${marker}1"}-->'
+                  '  <!--s${marker}1-->'
+                  '  <!--${marker}inner-->'
+                  '  <button class="highlighted" data-outer="true">Click me</button>'
+                  '  <!--/${marker}inner-->'
+                  '  <!--/s${marker}1-->'
+                  '  <!--/${marker}outer-->'
+                  '</div>'
+              .toJS;
+
+      final buttonElement = window.document.querySelector('button')!;
+      expect(buttonElement.classList.contains('highlighted'), isTrue);
+      expect(buttonElement.getAttribute('data-outer'), equals('true'));
+
+      Jaspr.initializeApp(
+        options: ClientOptions(
+          clients: {
+            'outer': ClientLoader((params) {
+              return Component.apply(
+                classes: 'highlighted',
+                attributes: const {'data-outer': 'true'},
+                child: params.mount(params.get<String>('child')),
+              );
+            }),
+            'inner': ClientLoader((_) {
+              return button([Component.text('Click me')]);
+            }),
+          },
+        ),
+      );
+
+      tester.pumpComponent(const ClientApp());
+      await pumpEventQueue();
+
+      final buttonHydrated = window.document.querySelector('button')!;
+      expect(buttonHydrated.classList.contains('highlighted'), isTrue);
+      expect(buttonHydrated.getAttribute('data-outer'), equals('true'));
+    });
+
     testClient('should reload client components and update parameters/sync state on performReload', (tester) async {
       final marker = DomValidator.clientMarkerPrefix;
       window.document.body!.innerHTML =

--- a/packages/jaspr/test/client/hydration/hydration_browser_test.dart
+++ b/packages/jaspr/test/client/hydration/hydration_browser_test.dart
@@ -277,48 +277,51 @@ void main() {
       expect(strongElement.textContent, equals('Hello Nested Client'));
     });
 
-    testClient('should apply inherited dom params from outer client component to inner client component via server slot', (tester) async {
-      final marker = DomValidator.clientMarkerPrefix;
-      window.document.body!.innerHTML =
-          '<div>'
-                  '  <!--${marker}outer data={"child":"s${marker}1"}-->'
-                  '  <!--s${marker}1-->'
-                  '  <!--${marker}inner-->'
-                  '  <button class="highlighted" data-outer="true">Click me</button>'
-                  '  <!--/${marker}inner-->'
-                  '  <!--/s${marker}1-->'
-                  '  <!--/${marker}outer-->'
-                  '</div>'
-              .toJS;
+    testClient(
+      'should apply inherited dom params from outer client component to inner client component via server slot',
+      (tester) async {
+        final marker = DomValidator.clientMarkerPrefix;
+        window.document.body!.innerHTML =
+            '<div>'
+                    '  <!--${marker}outer data={"child":"s${marker}1"}-->'
+                    '  <!--s${marker}1-->'
+                    '  <!--${marker}inner-->'
+                    '  <button class="highlighted" data-outer="true">Click me</button>'
+                    '  <!--/${marker}inner-->'
+                    '  <!--/s${marker}1-->'
+                    '  <!--/${marker}outer-->'
+                    '</div>'
+                .toJS;
 
-      final buttonElement = window.document.querySelector('button')!;
-      expect(buttonElement.classList.contains('highlighted'), isTrue);
-      expect(buttonElement.getAttribute('data-outer'), equals('true'));
+        final buttonElement = window.document.querySelector('button')!;
+        expect(buttonElement.classList.contains('highlighted'), isTrue);
+        expect(buttonElement.getAttribute('data-outer'), equals('true'));
 
-      Jaspr.initializeApp(
-        options: ClientOptions(
-          clients: {
-            'outer': ClientLoader((params) {
-              return Component.apply(
-                classes: 'highlighted',
-                attributes: const {'data-outer': 'true'},
-                child: params.mount(params.get<String>('child')),
-              );
-            }),
-            'inner': ClientLoader((_) {
-              return button([Component.text('Click me')]);
-            }),
-          },
-        ),
-      );
+        Jaspr.initializeApp(
+          options: ClientOptions(
+            clients: {
+              'outer': ClientLoader((params) {
+                return Component.apply(
+                  classes: 'highlighted',
+                  attributes: const {'data-outer': 'true'},
+                  child: params.mount(params.get<String>('child')),
+                );
+              }),
+              'inner': ClientLoader((_) {
+                return button([Component.text('Click me')]);
+              }),
+            },
+          ),
+        );
 
-      tester.pumpComponent(const ClientApp());
-      await pumpEventQueue();
+        tester.pumpComponent(const ClientApp());
+        await pumpEventQueue();
 
-      final buttonHydrated = window.document.querySelector('button')!;
-      expect(buttonHydrated.classList.contains('highlighted'), isTrue);
-      expect(buttonHydrated.getAttribute('data-outer'), equals('true'));
-    });
+        final buttonHydrated = window.document.querySelector('button')!;
+        expect(buttonHydrated.classList.contains('highlighted'), isTrue);
+        expect(buttonHydrated.getAttribute('data-outer'), equals('true'));
+      },
+    );
 
     testClient('should reload client components and update parameters/sync state on performReload', (tester) async {
       final marker = DomValidator.clientMarkerPrefix;

--- a/packages/jaspr/test/client/slotted_child_view_test.dart
+++ b/packages/jaspr/test/client/slotted_child_view_test.dart
@@ -130,5 +130,72 @@ void main() {
       pElement.click();
       expect(clicked, 1);
     });
+
+    testClient('applies direct child params to root range slot', (tester) async {
+      window.document.body!.innerHTML = '<!--start--><button>Click me</button><!--end-->'.toJS;
+      final start = window.document.body!.firstChild!;
+      final end = window.document.body!.lastChild!;
+
+      tester.pumpComponent(
+        Component.apply(
+          classes: 'highlighted',
+          attributes: const {'data-outer': 'true'},
+          child: SlottedChildView(
+            slots: [
+              ChildSlot.between(
+                start: start,
+                end: end,
+                child: button([Component.text('Click me')]),
+              ),
+            ],
+          ),
+        ),
+      );
+
+      final btn = window.document.querySelector('button')!;
+      expect(btn.classList.contains('highlighted'), isTrue);
+      expect(btn.getAttribute('data-outer'), 'true');
+    });
+
+    testClient('preserves selector isolation with multiple apply components', (tester) async {
+      window.document.body!.innerHTML =
+          '<!--start-btn--><button>Btn</button><!--end-btn--><!--start-a--><a href="#">Link</a><!--end-a-->'.toJS;
+      final startBtn = window.document.body!.childNodes.item(0)!;
+      final endBtn = window.document.body!.childNodes.item(2)!;
+      final startA = window.document.body!.childNodes.item(3)!;
+      final endA = window.document.body!.childNodes.item(5)!;
+
+      tester.pumpComponent(
+        Component.apply(
+          target: ApplyTarget.childWith(tag: 'button'),
+          classes: 'btn-class',
+          child: Component.apply(
+            target: ApplyTarget.childWith(tag: 'a'),
+            classes: 'link-class',
+            child: SlottedChildView(
+              slots: [
+                ChildSlot.between(
+                  start: startBtn,
+                  end: endBtn,
+                  child: button([Component.text('Btn')]),
+                ),
+                ChildSlot.between(
+                  start: startA,
+                  end: endA,
+                  child: a(href: '#', [Component.text('Link')]),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      final btn = window.document.querySelector('button')!;
+      final link = window.document.querySelector('a')!;
+      expect(btn.classList.contains('btn-class'), isTrue);
+      expect(btn.classList.contains('link-class'), isFalse);
+      expect(link.classList.contains('link-class'), isTrue);
+      expect(link.classList.contains('btn-class'), isFalse);
+    });
   });
 }

--- a/packages/jaspr/test/server/inherited_dom_wrapper_test.dart
+++ b/packages/jaspr/test/server/inherited_dom_wrapper_test.dart
@@ -5,7 +5,10 @@ import 'dart:convert';
 
 import 'package:jaspr/dom.dart';
 import 'package:jaspr/server.dart';
+import 'package:jaspr/src/framework/framework.dart';
 import 'package:jaspr_test/server_test.dart';
+
+import '../utils/test_component.dart';
 
 void main() {
   group('Component.apply', () {
@@ -340,7 +343,129 @@ void main() {
 
       expect(renderObject, isA<TestRenderElement>().having((e) => e.attributes, 'attributes', {'data': 'test-2'}));
     });
+
+    testComponents('preserves child state across reordering when wrapped with wrapWithInheritedDomComponent', (tester) async {
+      final keyA = UniqueKey();
+      final keyB = UniqueKey();
+
+      final component = FakeComponent(
+        child: _TestSlottedParent(
+          children: [
+            _TestStatefulChild(key: keyA, label: 'A'),
+            _TestStatefulChild(key: keyB, label: 'B'),
+          ],
+        ),
+      );
+
+      tester.pumpComponent(component);
+
+      final stateA1 = (find.byKey(keyA).evaluate().first as StatefulElement).state;
+      final stateB1 = (find.byKey(keyB).evaluate().first as StatefulElement).state;
+
+      component.updateChild(
+        _TestSlottedParent(
+          children: [
+            _TestStatefulChild(key: keyB, label: 'B'),
+            _TestStatefulChild(key: keyA, label: 'A'),
+          ],
+        ),
+      );
+      await tester.pump();
+
+      final stateA2 = (find.byKey(keyA).evaluate().first as StatefulElement).state;
+      final stateB2 = (find.byKey(keyB).evaluate().first as StatefulElement).state;
+
+      expect(identical(stateA1, stateA2), isTrue);
+      expect(identical(stateB1, stateB2), isTrue);
+    });
+
+    testComponents('applies inherited dom params to reparented dom element', (tester) async {
+      final key = GlobalKey();
+
+      final component = FakeComponent(
+        child: div([
+          Component.apply(
+            classes: 'applied-class',
+            child: div([]),
+          ),
+          span([
+            p(key: key, []),
+          ]),
+        ]),
+      );
+
+      tester.pumpComponent(component);
+
+      final pFinder = find.tag('p');
+      expect(pFinder, findsOneComponent);
+      final renderObject = (pFinder.evaluate().first as RenderObjectElement).renderObject as TestRenderElement;
+      expect(renderObject.classes, isNull);
+
+      // Reparent the p element directly under Component.apply
+      component.updateChild(
+        div([
+          Component.apply(
+            classes: 'applied-class',
+            child: p(key: key, []),
+          ),
+          span([]),
+        ]),
+      );
+      await tester.pump();
+
+      expect(renderObject.classes, equals('applied-class'));
+    });
   });
+}
+
+class _TestSlottedParent extends Component {
+  const _TestSlottedParent({required this.children});
+  final List<Component> children;
+
+  @override
+  Element createElement() => _TestSlottedParentElement(this);
+}
+
+class _TestSlottedParentElement extends DomRenderObjectElement {
+  _TestSlottedParentElement(super.component);
+
+  @override
+  _TestSlottedParent get component => super.component as _TestSlottedParent;
+
+  @override
+  List<Component> buildOwnChildren() => component.children;
+
+  @override
+  List<Component> buildChildren() {
+    return [
+      for (final child in buildOwnChildren())
+        wrapWithInheritedDomComponent(
+          getParams: (_) => const [],
+          child: child,
+        ),
+    ];
+  }
+
+  @override
+  RenderObject createRenderObject() => parentRenderObjectElement!.renderObject.createChildRenderElement('div');
+
+  @override
+  void updateRenderObject(RenderElement renderObject) {}
+}
+
+class _TestStatefulChild extends StatefulComponent {
+  const _TestStatefulChild({super.key, required this.label});
+  final String label;
+
+  @override
+  State<StatefulComponent> createState() => _TestStatefulChildState();
+}
+
+class _TestStatefulChildState extends State<_TestStatefulChild> {
+  @override
+  Component build(BuildContext context) {
+    return Component.text(component.label);
+  }
 }
 
 TypeMatcher<List<int>> decodedMatches(dynamic string) {

--- a/packages/jaspr/test/server/inherited_dom_wrapper_test.dart
+++ b/packages/jaspr/test/server/inherited_dom_wrapper_test.dart
@@ -344,7 +344,9 @@ void main() {
       expect(renderObject, isA<TestRenderElement>().having((e) => e.attributes, 'attributes', {'data': 'test-2'}));
     });
 
-    testComponents('preserves child state across reordering when wrapped with wrapWithInheritedDomComponent', (tester) async {
+    testComponents('preserves child state across reordering when wrapped with wrapWithInheritedDomComponent', (
+      tester,
+    ) async {
       final keyA = UniqueKey();
       final keyB = UniqueKey();
 


### PR DESCRIPTION
## Description

Refactors parts of how `Component.apply` is handled and works in combination with `SlottedChildView`.

The resolution of `.apply()` parameters is shifted to the render-object phase instead of the build phase by using a resolver callback in `_InheritedDomComponent` instead of storing the parameters directly. 

Fixes #859 

---


## Type of Change

<!-- Uncomment all that apply: -->

<!-- - ❌ Breaking change -->
<!-- - ✨ New feature or improvement -->
- 🛠️ Bug fix
<!-- - 🧹 Code refactor -->
<!-- - 📝 Documentation -->
<!-- - 🗑️ Chore -->

## Ready Checklist

- [ ] I've read the [Contribution Guide](https://github.com/schultek/jaspr/blob/main/CONTRIBUTING.md).
- [ ] In case this PR changes one of the core packages, I've modified the respective **CHANGELOG.md** file using
      the [semantic_changelog](https://github.com/rrousselGit/semantic_changelog) format.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added myself to the AUTHORS file (optional, if you want to).

<!-- 
  Feel free to expand this list if you have additional todos before your PR is ready. 
-->

<!--
  If you need help, consider asking for advice on the *#contribute* channel on [Discord](https://discord.gg/XGXrGEk4c6).
-->
