### PR TITLE
Tighten framework class hierarchies

### DIFF
--- a/packages/jaspr/CHANGELOG.md
+++ b/packages/jaspr/CHANGELOG.md
@@ -1,17 +1,67 @@
 ## Unreleased breaking
 
-- Added **Server Components** to allow for more fine-grained control over the server-side rendered component trees.
-- **Breaking**: Renamed `Component.wrapElement()` to `Component.apply()` and added `ApplyTarget target` parameter used to target specific elements instead of only direct children.
-- **Breaking**: Removed support for `attachBetween` parameter in `ClientAppBinding.attachRootComponent()`, as it is no longer needed.
-- Added stateful server-side reload feature.
-- Require Dart 3.13 or later.
-- Update `package:analyzer` requirement to `>=13.3.0 <15.0.0`.
+### New features
 
+- Added **Server Components** to allow for more fine-grained control over
+  server-side rendered component trees.
+- Added support for stateful server-side reload.
 - Added hot-reloading of generated stylesheets in `standalone` mode.
-- Style generation in `standalone` mode now also works when importing web libraries like `package:web` or `dart:js_interop`.
-- Replaced Jaspr's implementation of `Listenable`, `ValueListenable`, `ChangeNotifier` and `ValueNotifier` with the [`listen`](https://pub.dev/packages/listen) package.
+- Added an `ApplyTarget target` parameter to `Component.apply` (previously `Component.wrapElement`)
+  to target specific elements instead of only direct children.
 
-- Added `@Target` meta annotation to `@client`, `@encoder`, `@decoder` and `@Import` annotations to indicate where they are allowed to be used. 
+### Breaking changes
+
+- Require Dart 3.13 or later.
+- Renamed `Component.wrapElement` to `Component.apply`.
+- Removed support for the `attachBetween` parameter of `ClientAppBinding.attachRootComponent`.
+- The following classes can no longer be extended,
+  but can still be implemented:
+
+  - `RenderObject`
+  - `RenderElement`
+  - `RenderText`
+  - `RenderFragment`,
+  - `RawableRenderObject`
+  - `RawableRenderText`
+
+- The following classes no longer be implemented,
+  but can still be extended:
+
+  - `RenderAdapter`
+  - `ElementBoundaryAdapter`
+  - `HeadScopeAdapter`
+
+  Their subclasses must be declared `base`, `final`, or `sealed`.
+- The following classes can no longer be extended or implemented:
+
+  - `MarkupRenderObject`
+  - `MarkupRenderElement`
+  - `MarkupRenderText`
+  - `MarkupRenderFragment`,
+  - `RootMarkupRenderObject`
+  - `ChildListRange`
+  - `ChildNodeData`
+
+  To customize server rendering, instead use render adapters.
+- The following classes are no longer public:
+
+  - `AttachAdapter`, previously exported by `package:jaspr/server.dart`.
+  - `TemplateDocumentAdapter`, previously exported by `package:jaspr/server.dart`.
+
+### Behavior changes
+
+- Replaced Jaspr's implementation of
+  `Listenable`, `ValueListenable`, `ChangeNotifier` and `ValueNotifier` with
+  types from the [`listen`](https://pub.dev/packages/listen) package.
+- Added `@Target` meta annotation to
+  `@client`, `@encoder`, `@decoder`, and `@Import` annotations to
+  indicate where they are allowed to be used.
+- Updated `package:analyzer` requirement to `>=13.3.0 <15.0.0`.
+
+### Bug fixes
+
+- Fixed style generation in `standalone` mode when
+  importing web libraries like `package:web` or `dart:js_interop`.
 
 ## 0.23.4
 

--- a/packages/jaspr/lib/src/components/document/document_client.dart
+++ b/packages/jaspr/lib/src/components/document/document_client.dart
@@ -142,13 +142,13 @@ class _AttachElement extends MultiChildRenderObjectElement {
   void detachRenderObject() {
     super.detachRenderObject();
     final renderObject = this.renderObject as AttachRenderObject;
-    AttachAdapter.instanceFor(renderObject._target).unregister(renderObject);
+    _AttachAdapter.instanceFor(renderObject._target).unregister(renderObject);
   }
 }
 
 class AttachRenderObject extends DomRenderText {
   AttachRenderObject(this._target, this._depth) : super('', null) {
-    AttachAdapter.instanceFor(_target).register(this);
+    _AttachAdapter.instanceFor(_target).register(this);
   }
 
   final List<web.Node> children = [];
@@ -156,17 +156,17 @@ class AttachRenderObject extends DomRenderText {
   AttachTarget _target;
   set target(AttachTarget target) {
     if (_target == target) return;
-    AttachAdapter.instanceFor(_target).unregister(this);
+    _AttachAdapter.instanceFor(_target).unregister(this);
     _target = target;
-    AttachAdapter.instanceFor(_target).register(this);
-    AttachAdapter.instanceFor(_target).update();
+    _AttachAdapter.instanceFor(_target).register(this);
+    _AttachAdapter.instanceFor(_target).update();
   }
 
   Map<String, String>? _attributes;
   set attributes(Map<String, String>? attrs) {
     if (_attributes == attrs) return;
     _attributes = attrs;
-    AttachAdapter.instanceFor(_target).update();
+    _AttachAdapter.instanceFor(_target).update();
   }
 
   int _depth;
@@ -174,7 +174,7 @@ class AttachRenderObject extends DomRenderText {
   set depth(int depth) {
     if (_depth == depth) return;
     _depth = depth;
-    AttachAdapter.instanceFor(_target).update(needsResorting: true);
+    _AttachAdapter.instanceFor(_target).update(needsResorting: true);
   }
 
   @override
@@ -197,7 +197,7 @@ class AttachRenderObject extends DomRenderText {
       children.remove(childNode);
       children.insert(afterNode != null ? children.indexOf(afterNode) + 1 : 0, childNode);
 
-      AttachAdapter.instanceFor(_target).update();
+      _AttachAdapter.instanceFor(_target).update();
     } finally {
       child.finalize();
     }
@@ -208,18 +208,18 @@ class AttachRenderObject extends DomRenderText {
     children.remove(child.node);
     child.parent = null;
 
-    AttachAdapter.instanceFor(_target).update();
+    _AttachAdapter.instanceFor(_target).update();
   }
 }
 
-class AttachAdapter {
-  AttachAdapter(this.target);
+final class _AttachAdapter {
+  _AttachAdapter(this.target);
 
-  static AttachAdapter instanceFor(AttachTarget target) {
-    return _instances[target] ??= AttachAdapter(target);
+  static _AttachAdapter instanceFor(AttachTarget target) {
+    return _instances[target] ??= _AttachAdapter(target);
   }
 
-  static final Map<AttachTarget, AttachAdapter> _instances = {};
+  static final Map<AttachTarget, _AttachAdapter> _instances = {};
 
   final AttachTarget target;
 

--- a/packages/jaspr/lib/src/components/document/document_server.dart
+++ b/packages/jaspr/lib/src/components/document/document_server.dart
@@ -190,14 +190,14 @@ class _TemplateDocumentElement extends StatelessElement {
 
   @override
   Component build() {
-    (binding as ServerAppBinding).addRenderAdapter(TemplateDocumentAdapter(this));
+    (binding as ServerAppBinding).addRenderAdapter(_TemplateDocumentAdapter(this));
     _templateFuture ??= (binding as ServerAppBinding).loadFile('${(component as TemplateDocument).name}.template.html');
     return super.build();
   }
 }
 
-class TemplateDocumentAdapter extends ElementBoundaryAdapter {
-  TemplateDocumentAdapter(super.element);
+final class _TemplateDocumentAdapter extends ElementBoundaryAdapter {
+  _TemplateDocumentAdapter(super.element);
 
   late String template;
 
@@ -316,14 +316,14 @@ class AttachDocument extends StatelessComponent implements Document {
 
   @override
   Component build(BuildContext context) {
-    AttachAdapter.register(context, this);
+    _AttachAdapter.register(context, this);
     return Component.fragment(children ?? []);
   }
 }
 
-final Expando<AttachAdapter> _attach = Expando();
+final Expando<_AttachAdapter> _attach = Expando();
 
-class AttachAdapter extends RenderAdapter {
+final class _AttachAdapter extends RenderAdapter {
   static void register(BuildContext context, AttachDocument item) {
     final binding = context.binding;
     if (binding is! ServerAppBinding) {
@@ -331,7 +331,7 @@ class AttachAdapter extends RenderAdapter {
       return;
     }
 
-    final adapter = _attach[binding] ??= AttachAdapter();
+    final adapter = _attach[binding] ??= _AttachAdapter();
     binding.addRenderAdapter(adapter);
 
     final entry = adapter.targetElements[item.target] ??= (attributes: {}, children: []);
@@ -417,10 +417,10 @@ class AttachAdapter extends RenderAdapter {
   }
 }
 
-class _AttachChildrenAdapter extends ElementBoundaryAdapter {
+final class _AttachChildrenAdapter extends ElementBoundaryAdapter {
   _AttachChildrenAdapter(this.adapter, this.target, super.element);
 
-  final AttachAdapter adapter;
+  final _AttachAdapter adapter;
   final String target;
 
   @override

--- a/packages/jaspr/lib/src/foundation/sync/sync_vm.dart
+++ b/packages/jaspr/lib/src/foundation/sync/sync_vm.dart
@@ -5,12 +5,12 @@ import '../../dom/validator.dart';
 
 void initSyncState(SyncStateMixin<StatefulComponent, Object?> element) {
   if (element.context.binding case final ServerAppBinding b) {
-    b.addRenderAdapter(SyncAdapter(element, element.context as Element));
+    b.addRenderAdapter(_SyncAdapter(element, element.context as Element));
   }
 }
 
-class SyncAdapter extends ElementBoundaryAdapter {
-  SyncAdapter(this.sync, super.element);
+final class _SyncAdapter extends ElementBoundaryAdapter {
+  _SyncAdapter(this.sync, super.element);
 
   final SyncStateMixin<StatefulComponent, Object?> sync;
 

--- a/packages/jaspr/lib/src/framework/render_object.dart
+++ b/packages/jaspr/lib/src/framework/render_object.dart
@@ -1,6 +1,6 @@
 part of 'framework.dart';
 
-abstract class RenderObject {
+abstract interface class RenderObject {
   RenderObject? get parent;
   web.Node? get node;
 
@@ -13,7 +13,7 @@ abstract class RenderObject {
   void remove(covariant RenderObject child);
 }
 
-abstract class RenderElement implements RenderObject {
+abstract interface class RenderElement implements RenderObject {
   void update(
     String? id,
     String? classes,
@@ -23,21 +23,21 @@ abstract class RenderElement implements RenderObject {
   );
 }
 
-abstract class RenderText implements RenderObject {
+abstract interface class RenderText implements RenderObject {
   void update(String text);
 }
 
-abstract class RawableRenderObject implements RenderObject {
+abstract interface class RawableRenderObject implements RenderObject {
   @override
   RenderText createChildRenderText(String text, [bool rawHtml = false]);
 }
 
-abstract class RawableRenderText implements RenderText {
+abstract interface class RawableRenderText implements RenderText {
   @override
   void update(String text, [bool rawHtml = false]);
 }
 
-abstract class RenderFragment implements RenderObject {}
+abstract interface class RenderFragment implements RenderObject {}
 
 abstract class MultiChildRenderObjectElement = MultiChildElement with RenderObjectElement;
 abstract class LeafRenderObjectElement = LeafElement with RenderObjectElement;

--- a/packages/jaspr/lib/src/server/adapters/client_component_adapter.dart
+++ b/packages/jaspr/lib/src/server/adapters/client_component_adapter.dart
@@ -6,7 +6,7 @@ import '../options.dart';
 import 'element_boundary_adapter.dart';
 import 'server_component_adapter.dart';
 
-class ClientComponentAdapter extends ElementBoundaryAdapter {
+final class ClientComponentAdapter extends ElementBoundaryAdapter {
   ClientComponentAdapter(this.registry, this.target, super.element)
     : super(priority: ElementBoundaryAdapter.clientComponentBoundaryPriority);
 

--- a/packages/jaspr/lib/src/server/adapters/client_script_adapter.dart
+++ b/packages/jaspr/lib/src/server/adapters/client_script_adapter.dart
@@ -3,7 +3,7 @@ import 'dart:io';
 import '../markup_render_object.dart';
 import 'head_scope_adapter.dart';
 
-class ClientScriptAdapter extends HeadScopeAdapter {
+final class ClientScriptAdapter extends HeadScopeAdapter {
   ClientScriptAdapter(this.clientId);
 
   final String clientId;
@@ -26,7 +26,7 @@ class ClientScriptAdapter extends HeadScopeAdapter {
   }
 }
 
-class NoClientScriptAdapter extends HeadScopeAdapter {
+final class NoClientScriptAdapter extends HeadScopeAdapter {
   static bool _didOutputWarning = false;
 
   @override

--- a/packages/jaspr/lib/src/server/adapters/element_boundary_adapter.dart
+++ b/packages/jaspr/lib/src/server/adapters/element_boundary_adapter.dart
@@ -7,7 +7,7 @@ import '../server_binding.dart';
 
 export '../child_nodes.dart' show ChildListRange, ChildNodeData;
 
-abstract class ElementBoundaryAdapter extends RenderAdapter {
+abstract base class ElementBoundaryAdapter extends RenderAdapter {
   /// Priority for client component boundaries.
   ///
   /// This is set to an arbitrary high value so that the client component markers

--- a/packages/jaspr/lib/src/server/adapters/global_styles_adapter.dart
+++ b/packages/jaspr/lib/src/server/adapters/global_styles_adapter.dart
@@ -1,7 +1,7 @@
 import '../../../server.dart';
 import '../../dom/styles/rules.dart' show StyleRulesRender;
 
-class GlobalStylesAdapter extends HeadScopeAdapter {
+final class GlobalStylesAdapter extends HeadScopeAdapter {
   @override
   bool applyHead(MarkupRenderObject head) {
     var stylesId = binding.options.stylesId;

--- a/packages/jaspr/lib/src/server/adapters/head_scope_adapter.dart
+++ b/packages/jaspr/lib/src/server/adapters/head_scope_adapter.dart
@@ -1,7 +1,7 @@
 import '../markup_render_object.dart';
 import '../server_binding.dart';
 
-abstract class HeadScopeAdapter extends RenderAdapter {
+abstract base class HeadScopeAdapter extends RenderAdapter {
   @override
   void prepare() {}
 

--- a/packages/jaspr/lib/src/server/adapters/server_component_adapter.dart
+++ b/packages/jaspr/lib/src/server/adapters/server_component_adapter.dart
@@ -2,7 +2,7 @@ import '../../dom/validator.dart';
 import '../markup_render_object.dart';
 import 'element_boundary_adapter.dart';
 
-class ServerComponentAdapter extends ElementBoundaryAdapter {
+final class ServerComponentAdapter extends ElementBoundaryAdapter {
   ServerComponentAdapter(this.id, super.element)
     : super(priority: ElementBoundaryAdapter.serverComponentBoundaryPriority);
 

--- a/packages/jaspr/lib/src/server/child_nodes.dart
+++ b/packages/jaspr/lib/src/server/child_nodes.dart
@@ -3,13 +3,13 @@ import 'package:meta/meta.dart';
 import '../framework/framework.dart';
 import 'markup_render_object.dart';
 
-class ChildNodeData extends BaseChildNode {
+final class ChildNodeData extends BaseChildNode {
   ChildNodeData(this.node);
 
   final MarkupRenderObject node;
 }
 
-class ChildNodeBoundary extends BaseChildNode {
+final class ChildNodeBoundary extends BaseChildNode {
   ChildNodeBoundary(this.element, [this.priority = 0]);
 
   final Element element;
@@ -17,7 +17,7 @@ class ChildNodeBoundary extends BaseChildNode {
   late final ChildListRange range;
 }
 
-class BaseChildNode extends ChildNode {
+final class BaseChildNode extends ChildNode {
   @override
   ChildNode? _prev;
   @override
@@ -58,7 +58,7 @@ sealed class ChildNode {
   }
 }
 
-class ChildListRange extends ChildNode with Iterable<MarkupRenderObject> {
+final class ChildListRange extends ChildNode with Iterable<MarkupRenderObject> {
   ChildListRange(this.start, this.end) {
     if (start case final ChildNodeBoundary s) s.range = this;
     if (end case final ChildNodeBoundary e) e.range = this;
@@ -83,7 +83,7 @@ class ChildListRange extends ChildNode with Iterable<MarkupRenderObject> {
   ChildNode get _end => end;
 
   @override
-  Iterator<MarkupRenderObject> get iterator => ChildListIterator(start, end.next);
+  Iterator<MarkupRenderObject> get iterator => _ChildListIterator(start, end.next);
 
   Iterable<ChildNode> get nodes sync* {
     ChildNode? curr = start;
@@ -97,7 +97,7 @@ class ChildListRange extends ChildNode with Iterable<MarkupRenderObject> {
   }
 }
 
-class ChildList with Iterable<MarkupRenderObject> {
+final class ChildList with Iterable<MarkupRenderObject> {
   ChildList(this.parent) {
     _first.insertNext(_last);
   }
@@ -152,7 +152,7 @@ class ChildList with Iterable<MarkupRenderObject> {
   }
 
   @override
-  Iterator<MarkupRenderObject> get iterator => ChildListIterator(_first);
+  Iterator<MarkupRenderObject> get iterator => _ChildListIterator(_first);
 
   ChildListRange range({ChildNode? startAfter, ChildNode? endBefore}) {
     final start = BaseChildNode();
@@ -249,8 +249,8 @@ class ChildList with Iterable<MarkupRenderObject> {
   }
 }
 
-class ChildListIterator implements Iterator<MarkupRenderObject> {
-  ChildListIterator(ChildNode? first, [this._end]) : _current = first;
+final class _ChildListIterator implements Iterator<MarkupRenderObject> {
+  _ChildListIterator(ChildNode? first, [this._end]) : _current = first;
 
   ChildNode? _current;
   final ChildNode? _end;

--- a/packages/jaspr/lib/src/server/markup_render_object.dart
+++ b/packages/jaspr/lib/src/server/markup_render_object.dart
@@ -6,7 +6,7 @@ import '../../server.dart';
 import '../dom/validator.dart';
 import 'child_nodes.dart';
 
-abstract class MarkupRenderObject extends RenderObject implements RawableRenderObject {
+abstract final class MarkupRenderObject implements RawableRenderObject {
   @override
   MarkupRenderObject? parent;
   @override
@@ -155,7 +155,7 @@ abstract class MarkupRenderObject extends RenderObject implements RawableRenderO
   }
 }
 
-class MarkupRenderElement extends MarkupRenderObject implements RenderElement {
+final class MarkupRenderElement extends MarkupRenderObject implements RenderElement {
   MarkupRenderElement(this.tag);
 
   final String tag;
@@ -234,7 +234,7 @@ class MarkupRenderElement extends MarkupRenderObject implements RenderElement {
   }
 }
 
-class MarkupRenderText extends MarkupRenderObject implements RawableRenderText {
+final class MarkupRenderText extends MarkupRenderObject implements RawableRenderText {
   MarkupRenderText(this.text, this.rawHtml);
 
   String text;
@@ -270,7 +270,7 @@ class MarkupRenderText extends MarkupRenderObject implements RawableRenderText {
   }
 }
 
-class MarkupRenderFragment extends MarkupRenderObject implements RenderFragment {
+final class MarkupRenderFragment extends MarkupRenderObject implements RenderFragment {
   @override
   (String, bool, bool) _renderAndFormat([
     bool strictFormatting = false,
@@ -282,7 +282,7 @@ class MarkupRenderFragment extends MarkupRenderObject implements RenderFragment 
   }
 }
 
-class RootMarkupRenderObject extends MarkupRenderObject {
+final class RootMarkupRenderObject extends MarkupRenderObject {
   @override
   (String, bool, bool) _renderAndFormat([
     bool strictFormatting = false,

--- a/packages/jaspr/lib/src/server/server_binding.dart
+++ b/packages/jaspr/lib/src/server/server_binding.dart
@@ -156,7 +156,7 @@ class ServerAppBinding extends AppBinding with ComponentsBinding {
   static final Uint8List _emptyResponse = Uint8List(0);
 }
 
-abstract class RenderAdapter {
+abstract base class RenderAdapter {
   late ServerAppBinding binding;
   FutureOr<void> prepare() {}
   void apply(MarkupRenderObject root) {}

--- a/packages/jaspr/test/client/head/head_browser_test.dart
+++ b/packages/jaspr/test/client/head/head_browser_test.dart
@@ -1,17 +1,18 @@
 @TestOn('browser')
 library;
 
-import 'package:jaspr/src/components/document/document_client.dart';
 import 'package:jaspr_test/client_test.dart';
+import 'package:universal_web/web.dart' as web;
 
 import 'head_app.dart';
 
 void main() {
   group('head browser test', () {
     testClient('should serve component', (tester) async {
+      final initialNodes = _headElements().toSet();
       tester.pumpComponent(App());
 
-      var nodes = AttachAdapter.instanceFor(AttachTarget.head).liveNodes.toList();
+      var nodes = _headElements().where((node) => !initialNodes.contains(node)).toList();
 
       expect(nodes, [
         hasOuterHtml('<title>c</title>'),
@@ -21,7 +22,7 @@ void main() {
 
       await tester.click(find.tag('button'));
 
-      nodes = AttachAdapter.instanceFor(AttachTarget.head).liveNodes.toList();
+      nodes = _headElements().where((node) => !initialNodes.contains(node)).toList();
 
       expect(nodes, [
         hasOuterHtml('<title>d</title>'),
@@ -30,4 +31,9 @@ void main() {
       ]);
     });
   });
+}
+
+List<web.Element> _headElements() {
+  final children = web.document.head!.children;
+  return [for (var i = 0; i < children.length; i++) children.item(i)!];
 }

--- a/packages/jaspr_test/lib/src/testers/component_tester.dart
+++ b/packages/jaspr_test/lib/src/testers/component_tester.dart
@@ -142,7 +142,7 @@ class TestComponentsBinding extends AppBinding with ComponentsBinding {
   }
 }
 
-class TestRenderObject extends RenderObject implements RawableRenderObject {
+class TestRenderObject implements RawableRenderObject {
   List<TestRenderObject> children = [];
 
   @override


### PR DESCRIPTION
To avoid exposing implementation or behavior that isn't useful or necessary, supporting future evolution of the framework.

If the hierarchies that were closed here need to be opened back up in the future, we can do so explicitly, documenting the constraints and expectations around them.

This is a step towards my work implementing some performance improvements to child node handling.