### PR TITLE
Add render adapter and child-list range nesting tests

### DIFF
--- a/packages/jaspr/test/server/child_list_mutation_test.dart
+++ b/packages/jaspr/test/server/child_list_mutation_test.dart
@@ -113,6 +113,34 @@ void main() {
       _expectList(target, [children[3]]);
     });
 
+    test('preserves nested range handles when an enclosing range is detached', () {
+      final source = MarkupRenderFragment().children;
+      final target = MarkupRenderFragment().children;
+      final children = List.generate(5, (i) => MarkupRenderText('$i', false));
+      for (final child in children) {
+        source.insertBefore(child);
+      }
+      final outer = source.range(startAfter: source.find(children[0]), endBefore: source.find(children[4]));
+      final inner = source.range(startAfter: source.find(children[1]), endBefore: source.find(children[3]));
+      target.insertNodeAfter(outer);
+      _expectList(source, [children[0], children[4]]);
+      _expectList(target, children.sublist(1, 4));
+
+      outer.remove();
+      _expectList(target, []);
+      final marker = ChildNodeData(MarkupRenderText('<!--detached-->', true));
+      inner.start.insertNext(marker);
+      expect(inner.toList(), [marker.node, children[2]]);
+      expect(outer.toList(), [children[1], marker.node, children[2], children[3]]);
+      expect(source.find(marker.node), isNull);
+      expect(target.find(marker.node), isNull);
+
+      target.insertNodeBefore(outer);
+      _expectList(source, [children[0], children[4]]);
+      _expectList(target, [children[1], marker.node, children[2], children[3]]);
+      expect(target.find(marker.node), same(marker));
+    });
+
     test('moves ranges within a list', () {
       final list = MarkupRenderFragment().children;
       final children = List.generate(4, (i) => MarkupRenderText('$i', false));
@@ -158,6 +186,28 @@ void main() {
       expect(target.find(b.node), same(b));
       _expectList(source, [a.node]);
       _expectList(target, [b.node]);
+    });
+
+    test('supports inserting into an empty range after transfer and detachment', () {
+      final source = MarkupRenderFragment().children;
+      final target = MarkupRenderFragment().children;
+      final range = source.range();
+      target.insertNodeAfter(range);
+      _expectList(source, []);
+      _expectList(target, []);
+
+      range.remove();
+      _expectList(target, []);
+      final child = ChildNodeData(MarkupRenderText('detached', false));
+      range.end.insertPrev(child);
+      expect(range.toList(), [child.node]);
+      expect(source.find(child.node), isNull);
+      expect(target.find(child.node), isNull);
+
+      source.insertNodeBefore(range);
+      _expectList(source, [child.node]);
+      _expectList(target, []);
+      expect(source.find(child.node), same(child));
     });
 
     test('find remains shallow while findWhere visits fragments', () {

--- a/packages/jaspr/test/server/child_list_test.dart
+++ b/packages/jaspr/test/server/child_list_test.dart
@@ -707,7 +707,82 @@ void main() {
       expect(node, equals(children.lastNode));
       expect(node, isA<ChildNode>().having((n) => n.next, 'next', isNull));
     });
+
+    // The ancestor boundary has the lowest priority,
+    // the high boundary wraps the descendant with a higher priority,
+    // and the low-a and low-b boundaries wrap the descendant with equal priorities.
+    for (final order in _permutations(['ancestor', 'low-a', 'high', 'low-b'])) {
+      test('nests boundaries by ancestry and priority for capture order ${order.join(', ')}', () async {
+        late Element ancestor;
+        late Element descendant;
+        final r = await renderServerApp(
+          Builder(
+            builder: (context) {
+              ancestor = context as Element;
+              return Builder(
+                builder: (context) {
+                  descendant = context as Element;
+                  return .element(tag: 'body', children: []);
+                },
+              );
+            },
+          ),
+        );
+
+        final root = r.renderObject as MarkupRenderObject;
+        final ranges = {
+          for (final name in order)
+            name: root.children.wrapElement(
+              name == 'ancestor' ? ancestor : descendant,
+              name == 'high' ? 10 : 0,
+            ),
+        };
+
+        // Like render adapters, markers are inserted after all boundaries are captured and in reverse order.
+        for (final name in order.reversed) {
+          final range = ranges[name]!;
+          range.start.insertNext(ChildNodeData(MarkupRenderText('<!--$name-->', true)));
+          range.end.insertPrev(ChildNodeData(MarkupRenderText('<!--/$name-->', true)));
+        }
+
+        // Ancestry takes precedence over priority,
+        // and the later of two equal-priority captures wraps the earlier one.
+        final nesting = order.indexOf('low-a') < order.indexOf('low-b')
+            ? ['ancestor', 'high', 'low-b', 'low-a']
+            : ['ancestor', 'high', 'low-a', 'low-b'];
+        final expected = [
+          for (final name in nesting) '<!--$name-->',
+          '<body></body>',
+          for (final name in nesting.reversed) '<!--/$name-->',
+        ];
+        expect(root.children.map((node) => node.renderToHtml()), expected);
+
+        final destination = MarkupRenderFragment();
+        destination.children.insertNodeBefore(ranges['ancestor']!);
+        expect(root.children, isEmpty);
+        expect(destination.children.map((node) => node.renderToHtml()), expected);
+        for (final (depth, name) in nesting.indexed) {
+          expect(
+            ranges[name]!.map((node) => node.renderToHtml()),
+            expected.sublist(depth, expected.length - depth),
+            reason: 'Boundary $name must retain exactly its own contents after the move.',
+          );
+        }
+      });
+    }
   });
 }
 
 Matcher hasTag(String tag) => isA<MarkupRenderElement>().having((e) => e.tag, 'tag', tag);
+
+Iterable<List<T>> _permutations<T>(List<T> values) sync* {
+  if (values.isEmpty) {
+    yield [];
+    return;
+  }
+  for (final value in values) {
+    for (final rest in _permutations(values.where((v) => v != value).toList())) {
+      yield [value, ...rest];
+    }
+  }
+}

--- a/packages/jaspr/test/server/render_adapter_test.dart
+++ b/packages/jaspr/test/server/render_adapter_test.dart
@@ -1,0 +1,234 @@
+@TestOn('vm')
+library;
+
+import 'dart:convert';
+
+import 'package:html/dom.dart' as dom;
+import 'package:html/parser.dart';
+import 'package:jaspr/server.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('render adapters', () {
+    test('marks a component whose output is an empty fragment', () async {
+      final output = parseFragment(await _render(_marked(.fragment([])), standalone: true));
+      expect(output.nodes.whereType<dom.Comment>().map((node) => node.data), ['boundary', '/boundary']);
+      expect(output.children, isEmpty);
+      expect(output.text!.trim(), isEmpty);
+    });
+
+    test('marks a component nested in fragments whose output has multiple children', () async {
+      final output = parseFragment(
+        await _render(
+          .element(
+            tag: 'div',
+            children: [
+              .fragment([
+                .text('before'),
+                .fragment([
+                  _marked(.fragment([.element(tag: 'span', children: []), .text('inside')])),
+                ]),
+                .text('after'),
+              ]),
+            ],
+          ),
+          standalone: true,
+        ),
+      );
+      expect(output.children.single.innerHtml, 'before<!--boundary--><span></span>inside<!--/boundary-->after');
+    });
+
+    test('awaits preparation, prepares newly registered adapters, and applies in reverse order', () async {
+      final events = <String>[];
+      final output = await _render(
+        Builder(
+          builder: (context) {
+            (context.binding as ServerAppBinding)
+              ..addRenderAdapter(_PreparingAdapter(events))
+              ..addRenderAdapter(_MarkingAdapter(context as Element, events: events));
+            return .element(tag: 'p', children: [.text('Some content')]);
+          },
+        ),
+        standalone: true,
+      );
+      expect(events, [
+        'preparing.prepare',
+        'preparing.ready',
+        'marking.prepare',
+        'extra.prepare',
+        'extra.apply',
+        'marking.apply',
+        'preparing.apply',
+      ]);
+      expect(output, '<!--boundary-->\n<p>Some content</p>\n<!--/boundary-->\n');
+    });
+  });
+
+  group('template document', () {
+    test('wraps component boundaries in a template and replaces target contents', () async {
+      final html = await _render(
+        Document.template(
+          attachTo: '#content',
+          child: _marked(.element(tag: 'p', children: [.text('Some content')])),
+        ),
+        files: {
+          'index.template.html':
+              '<!DOCTYPE html><html><head><title>Template title</title></head>'
+              '<body><main id="content" data-label="Main content"><p>placeholder</p></main>'
+              '<footer>Footer content</footer></body></html>',
+        },
+      );
+      // Reject malformed output instead of letting the parser silently repair it.
+      final output = HtmlParser(html, strict: true).parse();
+      expect(output.nodes.whereType<dom.DocumentType>().single.name, 'html');
+      expect(output.head!.children.map((node) => node.outerHtml), ['<title>Template title</title>']);
+      expect(output.body!.children.map((node) => node.localName), ['main', 'footer']);
+      final target = output.querySelector('main#content')!;
+      expect(target.attributes, {'id': 'content', 'data-label': 'Main content'});
+      expect(target.innerHtml, '<!--boundary--><p>Some content</p><!--/boundary-->');
+      expect(output.querySelector('footer')!.outerHtml, '<footer>Footer content</footer>');
+    });
+
+    test('reports the name of a missing template', () async {
+      await expectLater(
+        _render(Document.template(name: 'missing', child: .text('content'))),
+        throwsA(isA<TemplateNotFoundError>().having((error) => error.name, 'name', 'missing')),
+      );
+    });
+
+    test(
+      'reports the selector of a missing attach target',
+      () async {
+        await expectLater(
+          _render(
+            Document.template(attachTo: '#missing', child: .text('content')),
+            files: {'index.template.html': '<html><body></body></html>'},
+          ),
+          throwsA(
+            allOf(
+              isNot(isA<TypeError>()),
+              predicate<Object>((error) => '$error'.contains('#missing'), 'mentions the selector'),
+            ),
+          ),
+        );
+      },
+      // TODO: Enable when a missing attach target reports a descriptive error.
+      // Currently `TemplateDocumentAdapter` null-asserts the `querySelector` result,
+      // so rendering fails with "Null check operator used on a null value".
+      skip: true,
+    );
+
+    test(
+      'preserves significant whitespace in template text',
+      () async {
+        final output = parse(
+          await _render(
+            Document.template(attachTo: '#app', child: .text('content')),
+            files: {
+              'index.template.html':
+                  '<html><body><p id="inline">Hello <b>world</b></p>'
+                  '<p id="between"><a href="#">one</a> <a href="#">two</a></p>'
+                  '<pre>  keep\n  indentation</pre><div id="app"></div></body></html>',
+            },
+          ),
+        );
+        expect(output.querySelector('#inline')!.text, 'Hello world');
+        expect(output.querySelector('#between')!.text, 'one two');
+        expect(output.querySelector('pre')!.text, '  keep\n  indentation');
+      },
+      // TODO: Enable when template text keeps its significant whitespace.
+      // Currently `TemplateDocumentAdapter` trims every text node and drops whitespace-only ones,
+      // rendering "Hello<b>world</b>", "<a>one</a><a>two</a>", and "<pre>keep\n  indentation</pre>".
+      skip: true,
+    );
+
+    test(
+      'escapes template text instead of rendering it as markup',
+      () async {
+        final output = parse(
+          await _render(
+            Document.template(attachTo: '#app', child: .text('content')),
+            files: {
+              'index.template.html':
+                  '<html><head><script>if (a < b && c) {}</script></head>'
+                  '<body><p>a &lt;b&gt; c</p><div id="app"></div></body></html>',
+            },
+          ),
+        );
+        final paragraph = output.querySelector('p')!;
+        expect(paragraph.text, 'a <b> c');
+        expect(paragraph.children, isEmpty);
+        // Raw text elements must not be escaped.
+        expect(output.querySelector('script')!.text, 'if (a < b && c) {}');
+      },
+      // TODO: Enable when template text is escaped when rendered.
+      // Currently `TemplateDocumentAdapter` renders the parser's decoded text as raw HTML,
+      // so "a &lt;b&gt; c" is rendered as "a <b> c" and creates a `b` element.
+      skip: true,
+    );
+  });
+}
+
+Future<String> _render(Component component, {bool standalone = false, Map<String, String> files = const {}}) async {
+  final binding = ServerAppBinding((
+    url: '/',
+    basePath: '/',
+    headers: .empty(),
+  ), loadFile: (name) async => files[name]);
+  addTearDown(binding.detachRootComponent);
+  binding.initializeOptions(const ServerOptions());
+  binding.attachRootComponent(component);
+  return utf8.decode(await binding.render(standalone: standalone));
+}
+
+Component _marked(Component child) => Builder(
+  builder: (context) {
+    (context.binding as ServerAppBinding).addRenderAdapter(_MarkingAdapter(context as Element));
+    return child;
+  },
+);
+
+final class _MarkingAdapter extends ElementBoundaryAdapter {
+  _MarkingAdapter(super.element, {this.events});
+
+  final List<String>? events;
+
+  @override
+  void prepareBoundary(ChildListRange range) => events?.add('marking.prepare');
+
+  @override
+  void applyBoundary(ChildListRange range) {
+    events?.add('marking.apply');
+    range.start.insertNext(ChildNodeData(MarkupRenderText('<!--boundary-->', true)));
+    range.end.insertPrev(ChildNodeData(MarkupRenderText('<!--/boundary-->', true)));
+  }
+}
+
+final class _PreparingAdapter extends RenderAdapter {
+  _PreparingAdapter(this.events);
+
+  final List<String> events;
+
+  @override
+  Future<void> prepare() async {
+    events.add('preparing.prepare');
+    await Future<void>.value();
+    events.add('preparing.ready');
+    binding.addRenderAdapter(_ExtraAdapter(events));
+  }
+
+  @override
+  void apply(MarkupRenderObject root) => events.add('preparing.apply');
+}
+
+final class _ExtraAdapter extends RenderAdapter {
+  _ExtraAdapter(this.events);
+
+  final List<String> events;
+
+  @override
+  void prepare() => events.add('extra.prepare');
+
+  @override
+  void apply(MarkupRenderObject root) => events.add('extra.apply');
+}


### PR DESCRIPTION
Add additional tests, mostly around server handling of markup. Some are skipped with TODOs as they are failing due to framework issues.

These additional tests will help me validate some performance improvements I'm exploring.